### PR TITLE
[Setup] Docker Compose（ローカル環境）のセットアップ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # =====================
 # Database (PostgreSQL)
 # =====================
+# make dev-native（ネイティブ起動）の場合は localhost を使用
+# make dev（Docker Compose）の場合は docker-compose.yml 側で db に上書き済み
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/decision_loop"
 
 # =====================
@@ -14,5 +16,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/decision_loop"
 # PORT=8001
 
 # Azure Service Bus（ローカル: Service Bus Emulator を使用）
+# make dev-native（ネイティブ起動）の場合は localhost を使用
+# make dev（Docker Compose）の場合は docker-compose.yml 側で servicebus に上書き済み
 AZURE_SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
 AZURE_SERVICE_BUS_QUEUE_NAME="decision-loop"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# =====================
+# Database (PostgreSQL)
+# =====================
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/decision_loop"
+
+# =====================
+# API Server
+# =====================
+# PORT=3001
+
+# =====================
+# AI Service
+# =====================
+# PORT=8001
+
+# Azure Service Bus（ローカル: Service Bus Emulator を使用）
+AZURE_SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
+AZURE_SERVICE_BUS_QUEUE_NAME="decision-loop"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
-.PHONY: install dev lint test format migrate
+.PHONY: install dev dev-native lint test format migrate
 
 install:
 	pnpm install
 	cd services/ai && uv sync
 
+# 全サービスを Docker Compose で起動する
 dev:
-	docker compose up -d
+	docker compose up
+
+# インフラ（db / servicebus）のみ Docker で起動し、アプリは overmind（Procfile）で起動する
+dev-native:
+	docker compose up -d db servicebus-db servicebus
 	overmind start
 
 lint:

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ flowchart LR
 | Python | 3.12+ | https://www.python.org |
 | uv | 最新 | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | Docker / Docker Compose | 最新 | https://www.docker.com |
-| overmind | 最新 | `brew install overmind` |
-
-> **overmind** は複数プロセスを一括管理するツールです。`make dev` で Backend・Frontend・AI Service・WebSocket を同時起動するために使用します。
+| overmind | 最新（`make dev-native` のみ） | `brew install overmind` |
 
 ## Getting Started
 
 ```bash
-make install   # 依存関係のインストール（pnpm install + uv sync）
-make dev       # 全サービス起動（Docker + overmind）
+cp .env.example .env.local  # 環境変数を設定
+make install                # 依存関係のインストール（pnpm install + uv sync）
+make dev                    # 全サービスを Docker Compose で起動
 ```
+
+> アプリサービスをネイティブ起動したい場合は `docker-compose.yml` の web / api / ai をコメントアウトして `make dev-native` を使用してください（overmind が必要）。
 
 ### 起動されるサービス
 

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,0 @@
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/decision_loop"
-PORT=3001

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/api/package.json ./apps/api/
+RUN pnpm install --frozen-lockfile
+WORKDIR /app/apps/api
+EXPOSE 3001
+CMD ["pnpm", "dev"]

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+.vite

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json ./apps/web/
+RUN pnpm install --frozen-lockfile
+WORKDIR /app/apps/web
+EXPOSE 5173
+CMD ["pnpm", "dev", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,12 +40,8 @@ services:
     depends_on:
       servicebus-db:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/5672' 2>/dev/null && echo ok || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 60s
+    # distroless .NET イメージのためシェルが存在せず healthcheck 不可。
+    # ai サービスは restart: on-failure で接続失敗を再試行する。
 
   # アプリサービス（コメントアウトするとネイティブ起動 / overmind に切り替え可能）
   web:
@@ -55,14 +51,17 @@ services:
     ports:
       - "5173:5173"
     volumes:
-      - ./apps/web/src:/app/apps/web/src
-      - ./apps/web/index.html:/app/apps/web/index.html
-      - ./apps/web/vite.config.ts:/app/apps/web/vite.config.ts
+      - ./apps/web:/app/apps/web
+      # コンテナ内の node_modules をホストの空ディレクトリで上書きしないよう保護
+      - /app/apps/web/node_modules
     environment:
       CHOKIDAR_USEPOLLING: "true"
     env_file:
       - path: .env.local
         required: false
+    depends_on:
+      api:
+        condition: service_started
 
   api:
     build:
@@ -79,6 +78,8 @@ services:
     env_file:
       - path: .env.local
         required: false
+    # db 起動タイミング依存の接続失敗に備えたフォールバック
+    restart: on-failure
     depends_on:
       db:
         condition: service_healthy
@@ -99,10 +100,11 @@ services:
     env_file:
       - path: .env.local
         required: false
+    # servicebus は healthcheck 不可のため service_started + restart: on-failure で再試行
     restart: on-failure
     depends_on:
       servicebus:
-        condition: service_healthy
+        condition: service_started
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
     depends_on:
       servicebus-db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/5672' 2>/dev/null && echo ok || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
 
   # アプリサービス（コメントアウトするとネイティブ起動 / overmind に切り替え可能）
   web:
@@ -67,6 +73,9 @@ services:
     volumes:
       - ./apps/api/src:/app/apps/api/src
       - ./apps/api/prisma:/app/apps/api/prisma
+    environment:
+      # Docker 内では db コンテナ名で解決する（.env.local の localhost 指定を上書き）
+      DATABASE_URL: "postgresql://postgres:postgres@db:5432/decision_loop"
     env_file:
       - path: .env.local
         required: false
@@ -81,13 +90,19 @@ services:
     ports:
       - "8001:8001"
     volumes:
-      - ./services/ai:/app
+      - ./services/ai/main.py:/app/main.py
+      - ./services/ai/consumers:/app/consumers
+      - ./services/ai/routers:/app/routers
+    environment:
+      # Docker 内では servicebus コンテナ名で解決する（.env.local の localhost 指定を上書き）
+      AZURE_SERVICE_BUS_CONNECTION_STRING: "Endpoint=sb://servicebus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
     env_file:
       - path: .env.local
         required: false
+    restart: on-failure
     depends_on:
       servicebus:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,79 @@ services:
       timeout: 5s
       retries: 5
 
+  servicebus-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Emulator@P@ssw0rd"
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "SELECT 1" -C || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  servicebus:
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    environment:
+      SQL_SERVER: servicebus-db
+      MSSQL_SA_PASSWORD: "Emulator@P@ssw0rd"
+      ACCEPT_EULA: "Y"
+    ports:
+      - "5672:5672"
+    volumes:
+      - ./servicebus-config.json:/ServiceBus_Emulator/ConfigFiles/Config.json
+    depends_on:
+      servicebus-db:
+        condition: service_healthy
+
+  # アプリサービス（コメントアウトするとネイティブ起動 / overmind に切り替え可能）
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./apps/web/src:/app/apps/web/src
+      - ./apps/web/index.html:/app/apps/web/index.html
+      - ./apps/web/vite.config.ts:/app/apps/web/vite.config.ts
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+    env_file:
+      - path: .env.local
+        required: false
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./apps/api/src:/app/apps/api/src
+      - ./apps/api/prisma:/app/apps/api/prisma
+    env_file:
+      - path: .env.local
+        required: false
+    depends_on:
+      db:
+        condition: service_healthy
+
+  ai:
+    build:
+      context: .
+      dockerfile: services/ai/Dockerfile
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./services/ai:/app
+    env_file:
+      - path: .env.local
+        required: false
+    depends_on:
+      servicebus:
+        condition: service_started
+
 volumes:
   postgres_data:

--- a/servicebus-config.json
+++ b/servicebus-config.json
@@ -1,0 +1,28 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulator",
+        "Queues": [
+          {
+            "Name": "decision-loop",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "ForwardDeadLetteredMessagesTo": "",
+              "ForwardTo": "",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          }
+        ]
+      }
+    ],
+    "LoggingConfig": {
+      "Type": "File"
+    }
+  }
+}

--- a/services/ai/.dockerignore
+++ b/services/ai/.dockerignore
@@ -1,0 +1,5 @@
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache

--- a/services/ai/.env.example
+++ b/services/ai/.env.example
@@ -1,3 +1,0 @@
-PORT=8001
-AZURE_SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>"
-AZURE_SERVICE_BUS_QUEUE_NAME="<queue-name>"

--- a/services/ai/Dockerfile
+++ b/services/ai/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.12-slim
-RUN pip install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 COPY services/ai/pyproject.toml services/ai/uv.lock ./
 RUN uv sync
+COPY services/ai/main.py ./
+COPY services/ai/consumers ./consumers
+COPY services/ai/routers ./routers
 EXPOSE 8001
 CMD ["uv", "run", "uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/ai/Dockerfile
+++ b/services/ai/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+RUN pip install uv
+WORKDIR /app
+COPY services/ai/pyproject.toml services/ai/uv.lock ./
+RUN uv sync
+EXPOSE 8001
+CMD ["uv", "run", "uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/ai/consumers/service_bus.py
+++ b/services/ai/consumers/service_bus.py
@@ -26,4 +26,6 @@ class ServiceBusConsumer:
                         await receiver.complete_message(message)
                     except Exception:
                         # 1件の処理失敗でループを止めない
-                        logger.exception("メッセージ処理中にエラーが発生しました: %s", message)
+                        logger.exception(
+                            "メッセージ処理中にエラーが発生しました: %s", message
+                        )


### PR DESCRIPTION
## 関連Issue
Closes #7

## 概要・目的
* ローカル開発環境を `make dev` 一発で全サービス起動できるよう Docker Compose を整備した。PostgreSQL・Azure Service Bus Emulator・web/api/ai の各サービスをコンテナ化し、`.env.local` を用意するだけで動作する構成にした。

## 背景
* ローカル開発環境を Docker Compose で統一することが決定済みだったが、既存の `docker-compose.yml` には PostgreSQL のみ設定されていた。各サービスの Dockerfile が未作成で、開発環境のセットアップ手順がなかった。

## 変更内容
* `docker-compose.yml` に servicebus-db（SQL Server 2022）・servicebus（Azure Service Bus Emulator）・web・api・ai の各サービスを追加
* `servicebus-config.json` を追加（キュー名: `decision-loop`）
* `apps/web/Dockerfile`・`apps/api/Dockerfile`・`services/ai/Dockerfile` を新規作成（開発用・ホットリロード対応）
* 各サービスに `.dockerignore` を追加（node_modules, dist, .venv 等を除外）
* ルートに `.env.example` を作成し、`apps/api/.env.example` と `services/ai/.env.example` を削除して一本化
* `make dev` を `docker compose up` に変更、インフラのみ Docker 起動して overmind でアプリを動かす `make dev-native` を追加
* `services/ai/consumers/service_bus.py` の行長超過 lint エラーを修正
* `servicebus` の healthcheck を削除（distroless .NET イメージのためシェルが存在せず動作しないことを確認済み）
* `ai` の `depends_on.servicebus` を `service_healthy` → `service_started` に変更し、`restart: on-failure` で接続失敗を再試行する構成に変更
* `web` のボリュームをディレクトリごとのマウントに変更し設定ファイルの変更もホットリロードに反映されるよう対応（`node_modules` は anonymous volume で保護）
* `web` に `depends_on: api`（`service_started`）を追加して起動順序を保証
* `api` に `restart: on-failure` を追加

## 動作確認手順
1. `.env.example` を `.env.local` としてコピーし、必要に応じて値を編集
2. `make dev` を実行して全サービスが起動することを確認
3. 各サービスが起動していることを確認（db: port 5432、api: port 3001、ai: port 8001、web: port 5173）
4. アプリサービスをネイティブ起動したい場合は `docker-compose.yml` の web/api/ai をコメントアウトして `make dev-native` を実行