### PR TITLE
fix(ci): dependabot.yml の package-ecosystem を正しく設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/services/ai"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## 関連Issue
Closes #15

## 概要・目的
* `dependabot.yml` の `package-ecosystem` が空文字（`""`）のままで、GitHub が無効な設定としてエラーを検知していた。
* `npm`・`pip`・`github-actions` の3エコシステムを設定し、依存パッケージの自動更新を有効にした。

## 背景
* Issue #8（CI/CDセットアップ）でスケルトンとして作成されたが、エコシステムの指定が未設定のままになっていた。

## 変更内容
* `package-ecosystem: ""` を削除し、3エントリに分割
  * `npm`（`/`）: `apps/web`・`apps/api` の依存関係を週次更新
  * `pip`（`/services/ai`）: AI サービスの依存関係を週次更新
  * `github-actions`（`/`）: ワークフローのアクションバージョンを週次更新
* スケルトンのコメント行を削除

## 動作確認手順
1. このブランチを checkout
2. `.github/dependabot.yml` の内容を確認
3. マージ後、GitHub リポジトリの Settings > Security > Dependabot で3エコシステムが表示されることを確認

## スクリーンショット
*