### PR TITLE
fix(ci): test-py から不要な exit code 5 回避処理を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,5 +136,4 @@ jobs:
         run: uv sync --frozen
 
       - name: テスト (pytest)
-        # exit code 5 = テストファイルが存在しない場合（エラーではない）
-        run: uv run pytest || [ $? -eq 5 ]
+        run: uv run pytest


### PR DESCRIPTION
## 関連Issue
Closes #16

## 概要・目的
* `ci.yml` の `test-py` ジョブに残っていた `|| [ $? -eq 5 ]` の回避処理を削除した。
* exit code 5 は「テストファイルが存在しない」場合の pytest の終了コードで、`services/ai/tests/` にテストが揃った現在は不要になっている。

## 背景
* Issue #8（CI/CDセットアップ）当初はテストファイルが存在しなかったため、`pytest` が exit code 5 で終了しても CI が通過するよう回避処理を設けていた。
* 現在は `test_health.py`・`test_ws.py`・`test_service_bus.py` が存在するため、この条件は不要になった。
* 残したままだと pytest が別の理由で終了コード 5 を返した場合でも CI が通過してしまう。

## 変更内容
* `uv run pytest || [ $? -eq 5 ]` を `uv run pytest` に変更
* 不要になったコメント行を削除

## 動作確認手順
1. このブランチを checkout
2. `.github/workflows/ci.yml` の140行目付近を確認
3. マージ後、PR を出して CI が `uv run pytest` の結果をそのまま返すことを確認

## スクリーンショット
*