### PR TITLE
feat(web): Vite proxy と hono/client セットアップ

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,8 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "api": "workspace:*",
+    "hono": "^4.7.7",
     "@tailwindcss/vite": "^4.1.6",
     "@tanstack/router-plugin": "^1.114.23",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,4 @@
+import { hc } from "hono/client";
+import type { AppType } from "api/types";
+
+export const api = hc<AppType>("/api");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { hc } from "hono/client";
 import type { AppType } from "api/types";
+import { hc } from "hono/client";
 
 export const api = hc<AppType>("/api");

--- a/apps/web/src/test/api.test.ts
+++ b/apps/web/src/test/api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { api } from "../lib/api";
+
+describe("api クライアント", () => {
+  it("api がエクスポートされている", () => {
+    expect(api).toBeDefined();
+  });
+
+  it("meetings ルートクライアントが存在する", () => {
+    expect(api.meetings).toBeDefined();
+  });
+
+  it("health ルートクライアントが存在する", () => {
+    expect(api.health).toBeDefined();
+  });
+});

--- a/apps/web/src/test/api.test.ts
+++ b/apps/web/src/test/api.test.ts
@@ -1,16 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { api } from "../lib/api";
 
+// hono/client は Proxy オブジェクトを返すため、存在しないプロパティも toBeDefined() を通過する。
+// ルートの存在保証はコンパイル時の型チェック（expectTypeOf）に委ねる。
 describe("api クライアント", () => {
   it("api がエクスポートされている", () => {
     expect(api).toBeDefined();
   });
 
-  it("meetings ルートクライアントが存在する", () => {
-    expect(api.meetings).toBeDefined();
-  });
-
-  it("health ルートクライアントが存在する", () => {
-    expect(api.health).toBeDefined();
+  it("meetings・health ルートが AppType に型付けされている", () => {
+    expectTypeOf(api.meetings).not.toBeNever();
+    expectTypeOf(api.health).not.toBeNever();
   });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,11 +13,13 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:3001",
+        // Docker 内では API_URL 環境変数でサービス名に切り替える
+        target: process.env.API_URL ?? "http://localhost:3001",
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
       "/ws": {
-        target: "ws://localhost:8000",
+        // Docker 内では AI_WS_URL 環境変数でサービス名に切り替える
+        target: process.env.AI_WS_URL ?? "ws://localhost:8001",
         ws: true,
       },
     },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,11 +15,13 @@ export default defineConfig({
       "/api": {
         // Docker 内では API_URL 環境変数でサービス名に切り替える
         target: process.env.API_URL ?? "http://localhost:3001",
+        changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
       "/ws": {
         // Docker 内では AI_WS_URL 環境変数でサービス名に切り替える
         target: process.env.AI_WS_URL ?? "ws://localhost:8001",
+        changeOrigin: true,
         ws: true,
       },
     },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+      "/ws": {
+        target: "ws://localhost:8000",
+        ws: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,9 @@ services:
       - /app/apps/web/node_modules
     environment:
       CHOKIDAR_USEPOLLING: "true"
+      # Docker 内では api/ai コンテナのサービス名で解決する
+      API_URL: "http://api:3001"
+      AI_WS_URL: "ws://ai:8001"
     env_file:
       - path: .env.local
         required: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.3
         version: 3.2.4(vitest@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0))
+      api:
+        specifier: workspace:*
+        version: link:../api
+      hono:
+        specifier: ^4.7.7
+        version: 4.12.14
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0


### PR DESCRIPTION
## 関連Issue
Closes #36

## 概要・目的
* Web から API を型安全に呼ぶための HTTP クライアント基盤を整備した。
* hono/client で `AppType` を使った型付きクライアントを生成し、Vite の proxy 設定で `/api` と `/ws` のルーティングを追加した。

## 背景
* `apps/web` に hono/client が未導入で、API への型安全な呼び出し手段がなかった。
* `vite.config.ts` に proxy 設定がなく、開発時に Web → API・WebSocket への通信ができない状態だった。
* Docker Compose 環境ではプロキシターゲットに `localhost` が使えないため、サービス名を参照する必要があった。

## 変更内容
* `apps/web/package.json`: `hono@^4.7.7` と `"api": "workspace:*"` を devDependency に追加
* `apps/web/src/lib/api.ts`: `hc<AppType>("/api")` クライアントを新規作成・エクスポート
* `apps/web/vite.config.ts`: `server.proxy` を追加（`/api` → `API_URL` 環境変数 or `http://localhost:3001`、`/ws` → `AI_WS_URL` 環境変数 or `ws://localhost:8001`）
* `docker-compose.yml`: `web` サービスに `API_URL=http://api:3001` と `AI_WS_URL=ws://ai:8001` を追加
* `apps/web/src/test/api.test.ts`: api クライアントのエクスポートとルートプロパティ（meetings・health）を検証するテストを追加

## 動作確認手順
1. `git checkout feature/issue-36-vite-proxy-hono-client`
2. `make install`
3. `make test` でテストが全て通ることを確認
4. `make dev` で全サービスを起動し、ブラウザで `http://localhost:5173/api/health` にアクセスして `{"status":"ok"}` が返ることを確認

## スクリーンショット
* API・設定変更のみのため不要