### PR TITLE
feat(web): index ページに meetings 一覧・作成フォーム・WS チャットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev dev-build dev-fresh dev-native docker-clean lint test format migrate migrate-status db-shell
+.PHONY: install dev dev-build dev-fresh dev-reset dev-native docker-clean lint test format migrate migrate-status db-shell
 
 install:
 	pnpm install
@@ -12,12 +12,16 @@ dev:
 dev-build:
 	docker compose up --build
 
-# anonymous volume を削除してイメージを再ビルドし起動する（node_modules が壊れたとき）
+# node_modules の anonymous volume のみリセットして起動する（DB データは維持）
 dev-fresh:
+	docker compose up --build --renew-anon-volumes
+
+# 全 volume（DB 含む）をリセットして起動する（起動後に make migrate が必要）
+dev-reset:
 	docker compose down -v
 	docker compose up --build
 
-# コンテナと anonymous volume を削除する
+# コンテナと全 volume を削除する
 docker-clean:
 	docker compose down -v --remove-orphans
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
-.PHONY: install dev dev-native lint test format migrate migrate-status db-shell
+.PHONY: install dev dev-build dev-fresh dev-native docker-clean lint test format migrate migrate-status db-shell
 
 install:
 	pnpm install
 	cd services/ai && uv sync
 
-# 全サービスを Docker Compose で起動する
+# 全サービスを Docker Compose で起動する（イメージ再ビルドなし）
 dev:
 	docker compose up
+
+# イメージを再ビルドしてから起動する（package.json / Dockerfile 変更後）
+dev-build:
+	docker compose up --build
+
+# anonymous volume を削除してイメージを再ビルドし起動する（node_modules が壊れたとき）
+dev-fresh:
+	docker compose down -v
+	docker compose up --build
+
+# コンテナと anonymous volume を削除する
+docker-clean:
+	docker compose down -v --remove-orphans
 
 # インフラ（db / servicebus）のみ Docker で起動し、アプリは overmind（Procfile）で起動する
 dev-native:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ flowchart LR
 cp .env.example .env.local  # 環境変数を設定
 make install                # 依存関係のインストール（pnpm install + uv sync）
 make dev                    # 全サービスを Docker Compose で起動
+make migrate                # DB マイグレーションを適用（初回起動時）
 ```
 
 > アプリサービスをネイティブ起動したい場合は `docker-compose.yml` の web / api / ai をコメントアウトして `make dev-native` を使用してください（overmind が必要）。
@@ -56,11 +57,24 @@ make dev                    # 全サービスを Docker Compose で起動
 | AI Service (FastAPI + WebSocket) | http://localhost:8001 |
 | AI Service docs | http://localhost:8001/docs |
 
+### Docker 起動コマンドの使い分け
+
+| コマンド | 用途 | DB データ |
+|---------|------|---------|
+| `make dev` | 通常起動（イメージ再ビルドなし） | 維持 |
+| `make dev-build` | `package.json` / `Dockerfile` 変更後の再ビルド起動 | 維持 |
+| `make dev-fresh` | `node_modules` が壊れたときのリセット起動 | **維持** |
+| `make dev-reset` | DB 含む全 volume をリセットして起動 | **消える** |
+| `make docker-clean` | コンテナと全 volume を削除（起動しない） | **消える** |
+
+> `make dev-reset` / `make docker-clean` 後は `make migrate` で DB を再構築してください。
+
 ## Development
 
 ```bash
 make lint             # Biome (TS) + Ruff (Python)
 make test             # Vitest + pytest
+make format           # Biome (TS) + Ruff (Python) の自動修正
 make migrate          # prisma migrate dev（NAME=xxx でマイグレーション名を指定可）
 make migrate-status   # マイグレーションの適用状況を確認
 make db-shell         # psql で decision_loop DB に直接接続

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,9 @@
 import { api } from "@/lib/api";
-import { useQuery } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 export const Route = createFileRoute("/")({
   component: Index,
@@ -45,6 +48,85 @@ function MeetingsList() {
   );
 }
 
+// ===== 作成フォーム =====
+
+const createSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  heldAt: z.string().min(1, "開催日時は必須です"),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+
+function CreateMeetingForm() {
+  const queryClient = useQueryClient();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateFormValues>({ resolver: zodResolver(createSchema) });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateFormValues) => {
+      const res = await api.meetings.$post({
+        json: {
+          title: data.title,
+          // datetime-local 値を ISO 8601 UTC に変換
+          heldAt: new Date(data.heldAt).toISOString(),
+        },
+      });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["meetings"] });
+      reset();
+    },
+  });
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold mb-2">会議を作成</h2>
+      <form
+        onSubmit={handleSubmit((data) => mutation.mutate(data))}
+        className="flex flex-col gap-2 max-w-sm"
+      >
+        <input
+          {...register("title")}
+          placeholder="タイトル"
+          className="border rounded px-2 py-1"
+        />
+        {errors.title && (
+          <p role="alert" className="text-red-500 text-sm">
+            {errors.title.message}
+          </p>
+        )}
+        <input
+          {...register("heldAt")}
+          id="heldAt"
+          aria-label="開催日時"
+          type="datetime-local"
+          className="border rounded px-2 py-1"
+        />
+        {errors.heldAt && (
+          <p role="alert" className="text-red-500 text-sm">
+            {errors.heldAt.message}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="bg-primary text-primary-foreground rounded px-4 py-1"
+        >
+          作成
+        </button>
+        {mutation.isError && (
+          <p className="text-red-500 text-sm">作成に失敗しました</p>
+        )}
+      </form>
+    </section>
+  );
+}
+
 // ===== メインページ =====
 
 export function Index() {
@@ -52,6 +134,7 @@ export function Index() {
     <main className="container mx-auto p-8 space-y-8">
       <h1 className="text-2xl font-bold">Decision Loop</h1>
       <MeetingsList />
+      <CreateMeetingForm />
     </main>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,7 +3,7 @@ import type { Meeting } from "@/types/meeting";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -166,16 +166,19 @@ function WsChat() {
     };
   }, []);
 
-  function sendMessage() {
+  const sendMessage = useCallback(() => {
     if (!input.trim() || wsRef.current?.readyState !== WebSocket.OPEN) return;
     wsRef.current.send(JSON.stringify({ message: input }));
     setInput("");
-  }
+  }, [input]);
 
   return (
     <section>
       <h2 className="text-xl font-semibold mb-2">WebSocket チャット</h2>
-      <ul className="border rounded p-2 h-32 overflow-y-auto mb-2 space-y-1">
+      <ul
+        aria-label="チャットメッセージ"
+        className="border rounded p-2 h-32 overflow-y-auto mb-2 space-y-1"
+      >
         {messages.map((msg) => (
           <li key={msg.id} className="text-sm">
             {msg.text}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import type { Meeting } from "@/types/meeting";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -10,19 +11,14 @@ export const Route = createFileRoute("/")({
   component: Index,
 });
 
-// ===== 型定義 =====
-
-type Meeting = {
-  id: string;
-  title: string;
-  heldAt: string;
-  createdAt: string;
-};
-
 // ===== meetings 一覧 =====
 
 function MeetingsList() {
-  const { data: meetings = [], isLoading } = useQuery<Meeting[]>({
+  const {
+    data: meetings = [],
+    isLoading,
+    isError,
+  } = useQuery<Meeting[]>({
     queryKey: ["meetings"],
     queryFn: async () => {
       const res = await api.meetings.$get();
@@ -31,11 +27,12 @@ function MeetingsList() {
   });
 
   if (isLoading) return <p>読み込み中...</p>;
+  if (isError) return <p>取得に失敗しました</p>;
 
   return (
     <section>
       <h2 className="text-xl font-semibold mb-2">会議一覧</h2>
-      <ul className="space-y-1">
+      <ul aria-label="会議一覧" className="space-y-1">
         {meetings.map((m) => (
           <li key={m.id} className="border rounded p-2">
             <span className="font-medium">{m.title}</span>
@@ -93,6 +90,7 @@ function CreateMeetingForm() {
       >
         <input
           {...register("title")}
+          aria-label="タイトル"
           placeholder="タイトル"
           className="border rounded px-2 py-1"
         />
@@ -143,17 +141,22 @@ function WsChat() {
     const proto = window.location.protocol === "https:" ? "wss" : "ws";
     const ws = new WebSocket(`${proto}://${window.location.host}/ws`);
 
+    const pushMessage = (text: string) =>
+      setMessages((prev) =>
+        [...prev, { id: crypto.randomUUID(), text }].slice(-100),
+      );
+
     ws.onmessage = (event: MessageEvent) => {
       try {
         const data: WsMessage = JSON.parse(event.data as string);
-        const text = data.echo ?? data.type ?? JSON.stringify(data);
-        setMessages((prev) => [...prev, { id: crypto.randomUUID(), text }]);
+        pushMessage(data.echo ?? data.type ?? JSON.stringify(data));
       } catch {
-        setMessages((prev) => [
-          ...prev,
-          { id: crypto.randomUUID(), text: String(event.data) },
-        ]);
+        pushMessage(String(event.data));
       }
+    };
+
+    ws.onerror = () => {
+      pushMessage("接続エラーが発生しました");
     };
 
     wsRef.current = ws;
@@ -164,7 +167,7 @@ function WsChat() {
   }, []);
 
   function sendMessage() {
-    if (!input.trim() || !wsRef.current) return;
+    if (!input.trim() || wsRef.current?.readyState !== WebSocket.OPEN) return;
     wsRef.current.send(JSON.stringify({ message: input }));
     setInput("");
   }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { api } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -127,6 +128,77 @@ function CreateMeetingForm() {
   );
 }
 
+// ===== WebSocket チャット =====
+
+type WsMessage = { echo?: string; type?: string; [key: string]: unknown };
+
+type WsChatMessage = { id: string; text: string };
+
+function WsChat() {
+  const wsRef = useRef<WebSocket | null>(null);
+  const [messages, setMessages] = useState<WsChatMessage[]>([]);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    const proto = window.location.protocol === "https:" ? "wss" : "ws";
+    const ws = new WebSocket(`${proto}://${window.location.host}/ws`);
+
+    ws.onmessage = (event: MessageEvent) => {
+      try {
+        const data: WsMessage = JSON.parse(event.data as string);
+        const text = data.echo ?? data.type ?? JSON.stringify(data);
+        setMessages((prev) => [...prev, { id: crypto.randomUUID(), text }]);
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          { id: crypto.randomUUID(), text: String(event.data) },
+        ]);
+      }
+    };
+
+    wsRef.current = ws;
+
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  function sendMessage() {
+    if (!input.trim() || !wsRef.current) return;
+    wsRef.current.send(JSON.stringify({ message: input }));
+    setInput("");
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold mb-2">WebSocket チャット</h2>
+      <ul className="border rounded p-2 h-32 overflow-y-auto mb-2 space-y-1">
+        {messages.map((msg) => (
+          <li key={msg.id} className="text-sm">
+            {msg.text}
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="メッセージ"
+          className="border rounded px-2 py-1 flex-1"
+          onKeyDown={(e) => e.key === "Enter" && sendMessage()}
+        />
+        <button
+          type="button"
+          onClick={sendMessage}
+          className="bg-primary text-primary-foreground rounded px-4 py-1"
+        >
+          送信
+        </button>
+      </div>
+    </section>
+  );
+}
+
 // ===== メインページ =====
 
 export function Index() {
@@ -135,6 +207,7 @@ export function Index() {
       <h1 className="text-2xl font-bold">Decision Loop</h1>
       <MeetingsList />
       <CreateMeetingForm />
+      <WsChat />
     </main>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,16 +1,57 @@
+import { api } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
   component: Index,
 });
 
-function Index() {
+// ===== 型定義 =====
+
+type Meeting = {
+  id: string;
+  title: string;
+  heldAt: string;
+  createdAt: string;
+};
+
+// ===== meetings 一覧 =====
+
+function MeetingsList() {
+  const { data: meetings = [], isLoading } = useQuery<Meeting[]>({
+    queryKey: ["meetings"],
+    queryFn: async () => {
+      const res = await api.meetings.$get();
+      return res.json();
+    },
+  });
+
+  if (isLoading) return <p>読み込み中...</p>;
+
   return (
-    <main className="container mx-auto p-8">
+    <section>
+      <h2 className="text-xl font-semibold mb-2">会議一覧</h2>
+      <ul className="space-y-1">
+        {meetings.map((m) => (
+          <li key={m.id} className="border rounded p-2">
+            <span className="font-medium">{m.title}</span>
+            <span className="ml-2 text-sm text-muted-foreground">
+              {new Date(m.heldAt).toLocaleString("ja-JP")}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// ===== メインページ =====
+
+export function Index() {
+  return (
+    <main className="container mx-auto p-8 space-y-8">
       <h1 className="text-2xl font-bold">Decision Loop</h1>
-      <p className="text-muted-foreground mt-2">
-        定例会議の意思決定サイクルを支援するAIエージェント
-      </p>
+      <MeetingsList />
     </main>
   );
 }

--- a/apps/web/src/test/App.test.tsx
+++ b/apps/web/src/test/App.test.tsx
@@ -1,10 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
+
+// index ページが依存する api モジュールをモック
+vi.mock("@/lib/api", () => ({
+  api: {
+    meetings: {
+      $get: vi.fn().mockResolvedValue({ json: async () => [] }),
+      $post: vi.fn(),
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "WebSocket",
+    vi.fn(() => ({
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+      onmessage: null,
+      onopen: null,
+      onclose: null,
+      onerror: null,
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
 
 describe("App", () => {
   it("描画エラーなくルートページが表示される", async () => {
-    render(<App />);
+    renderWithQuery(<App />);
     expect(await screen.findByText("Decision Loop")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/test/App.test.tsx
+++ b/apps/web/src/test/App.test.tsx
@@ -1,7 +1,7 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
+import { renderWithQuery } from "./test-utils";
 
 // index ページが依存する api モジュールをモック
 vi.mock("@/lib/api", () => ({
@@ -16,15 +16,18 @@ vi.mock("@/lib/api", () => ({
 beforeEach(() => {
   vi.stubGlobal(
     "WebSocket",
-    vi.fn(() => ({
-      send: vi.fn(),
-      close: vi.fn(),
-      readyState: 1,
-      onmessage: null,
-      onopen: null,
-      onclose: null,
-      onerror: null,
-    })),
+    Object.assign(
+      vi.fn(() => ({
+        send: vi.fn(),
+        close: vi.fn(),
+        readyState: 1,
+        onmessage: null,
+        onopen: null,
+        onclose: null,
+        onerror: null,
+      })),
+      { OPEN: 1 },
+    ),
   );
 });
 
@@ -32,15 +35,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
-
-function renderWithQuery(ui: React.ReactElement) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
-  );
-}
 
 describe("App", () => {
   it("描画エラーなくルートページが表示される", async () => {

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Index } from "../routes/index";
+
+// hono/client api モジュールをモック
+vi.mock("@/lib/api", () => ({
+	api: {
+		meetings: {
+			$get: vi.fn(),
+			$post: vi.fn(),
+		},
+	},
+}));
+
+import { api } from "@/lib/api";
+
+type Meeting = {
+	id: string;
+	title: string;
+	heldAt: string;
+	createdAt: string;
+};
+
+const mockMeetings: Meeting[] = [
+	{
+		id: "1",
+		title: "週次定例",
+		heldAt: "2026-04-21T10:00:00.000Z",
+		createdAt: "2026-04-20T00:00:00.000Z",
+	},
+	{
+		id: "2",
+		title: "月次レビュー",
+		heldAt: "2026-04-14T14:00:00.000Z",
+		createdAt: "2026-04-13T00:00:00.000Z",
+	},
+];
+
+function renderWithQuery(ui: React.ReactElement) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return {
+		client,
+		...render(
+			<QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+		),
+	};
+}
+
+beforeEach(() => {
+	vi.stubGlobal(
+		"WebSocket",
+		vi.fn(() => ({
+			send: vi.fn(),
+			close: vi.fn(),
+			readyState: 1,
+			onmessage: null,
+			onopen: null,
+			onclose: null,
+			onerror: null,
+		})),
+	);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+// ===== meetings 一覧表示 =====
+
+describe("meetings 一覧表示", () => {
+	it("meetings の一覧が表示される", async () => {
+		vi.mocked(api.meetings.$get).mockResolvedValue({
+			json: async () => mockMeetings,
+		} as never);
+
+		renderWithQuery(<Index />);
+
+		expect(await screen.findByText("週次定例")).toBeInTheDocument();
+		expect(await screen.findByText("月次レビュー")).toBeInTheDocument();
+	});
+
+	it("meetings が空のとき空リストを表示する", async () => {
+		vi.mocked(api.meetings.$get).mockResolvedValue({
+			json: async () => [],
+		} as never);
+
+		renderWithQuery(<Index />);
+
+		await waitFor(() => {
+			expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+		});
+	});
+});

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -18,6 +18,11 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
+// hono/client のレスポンス型が複雑なため、モックの戻り値はヘルパー経由でキャスト
+function mockJson<T>(data: T) {
+  return { json: async () => data } as never;
+}
+
 const mockMeetings: Meeting[] = [
   {
     id: "1",
@@ -57,7 +62,10 @@ beforeEach(() => {
     onclose: null,
     onerror: null,
   };
-  MockWebSocket = Object.assign(vi.fn(() => mockWs), { OPEN: 1 });
+  MockWebSocket = Object.assign(
+    vi.fn(() => mockWs),
+    { OPEN: 1 },
+  );
   vi.stubGlobal("WebSocket", MockWebSocket);
 });
 
@@ -70,9 +78,7 @@ afterEach(() => {
 
 describe("meetings 一覧表示", () => {
   it("meetings の一覧が表示される", async () => {
-    vi.mocked(api.meetings.$get).mockResolvedValue({
-      json: async () => mockMeetings,
-    } as never);
+    vi.mocked(api.meetings.$get).mockResolvedValue(mockJson(mockMeetings));
 
     renderWithQuery(<Index />);
 
@@ -81,9 +87,7 @@ describe("meetings 一覧表示", () => {
   });
 
   it("meetings が空のとき会議一覧に項目がない", async () => {
-    vi.mocked(api.meetings.$get).mockResolvedValue({
-      json: async () => [],
-    } as never);
+    vi.mocked(api.meetings.$get).mockResolvedValue(mockJson([]));
 
     renderWithQuery(<Index />);
 
@@ -96,9 +100,7 @@ describe("meetings 一覧表示", () => {
 
 describe("meeting 作成フォーム", () => {
   beforeEach(() => {
-    vi.mocked(api.meetings.$get).mockResolvedValue({
-      json: async () => [],
-    } as never);
+    vi.mocked(api.meetings.$get).mockResolvedValue(mockJson([]));
   });
 
   it("title が空のとき送信できない", async () => {
@@ -130,12 +132,10 @@ describe("meeting 作成フォーム", () => {
       heldAt: "2026-04-23T10:00:00.000Z",
       createdAt: "2026-04-23T00:00:00.000Z",
     };
-    vi.mocked(api.meetings.$post).mockResolvedValue({
-      json: async () => newMeeting,
-    } as never);
+    vi.mocked(api.meetings.$post).mockResolvedValue(mockJson(newMeeting));
     vi.mocked(api.meetings.$get)
-      .mockResolvedValueOnce({ json: async () => [] } as never)
-      .mockResolvedValueOnce({ json: async () => [newMeeting] } as never);
+      .mockResolvedValueOnce(mockJson([]))
+      .mockResolvedValueOnce(mockJson([newMeeting]));
 
     renderWithQuery(<Index />);
 
@@ -154,9 +154,7 @@ describe("meeting 作成フォーム", () => {
 
 describe("WebSocket チャット", () => {
   beforeEach(() => {
-    vi.mocked(api.meetings.$get).mockResolvedValue({
-      json: async () => [],
-    } as never);
+    vi.mocked(api.meetings.$get).mockResolvedValue(mockJson([]));
   });
 
   it("マウント時に /ws へ接続する", async () => {

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Index } from "../routes/index";
 
@@ -93,5 +94,63 @@ describe("meetings 一覧表示", () => {
 		await waitFor(() => {
 			expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
 		});
+	});
+});
+
+// ===== meeting 作成フォーム =====
+
+describe("meeting 作成フォーム", () => {
+	beforeEach(() => {
+		vi.mocked(api.meetings.$get).mockResolvedValue({
+			json: async () => [],
+		} as never);
+	});
+
+	it("title が空のとき送信できない", async () => {
+		const user = userEvent.setup();
+		renderWithQuery(<Index />);
+
+		await user.click(screen.getByRole("button", { name: "作成" }));
+
+		expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
+		expect(api.meetings.$post).not.toHaveBeenCalled();
+	});
+
+	it("heldAt が空のとき送信できない", async () => {
+		const user = userEvent.setup();
+		renderWithQuery(<Index />);
+
+		await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
+		await user.click(screen.getByRole("button", { name: "作成" }));
+
+		expect(await screen.findByText("開催日時は必須です")).toBeInTheDocument();
+		expect(api.meetings.$post).not.toHaveBeenCalled();
+	});
+
+	it("正常送信で api.$post が呼ばれ一覧が再取得される", async () => {
+		const user = userEvent.setup();
+		const newMeeting: Meeting = {
+			id: "3",
+			title: "テスト会議",
+			heldAt: "2026-04-23T10:00:00.000Z",
+			createdAt: "2026-04-23T00:00:00.000Z",
+		};
+		vi.mocked(api.meetings.$post).mockResolvedValue({
+			json: async () => newMeeting,
+		} as never);
+		vi.mocked(api.meetings.$get)
+			.mockResolvedValueOnce({ json: async () => [] } as never)
+			.mockResolvedValueOnce({ json: async () => [newMeeting] } as never);
+
+		renderWithQuery(<Index />);
+
+		await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
+		await user.type(screen.getByLabelText("開催日時"), "2026-04-23T10:00");
+		await user.click(screen.getByRole("button", { name: "作成" }));
+
+		await waitFor(() => {
+			expect(api.meetings.$post).toHaveBeenCalled();
+		});
+		expect(await screen.findByText("テスト会議")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -1,156 +1,217 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Index } from "../routes/index";
 
 // hono/client api モジュールをモック
 vi.mock("@/lib/api", () => ({
-	api: {
-		meetings: {
-			$get: vi.fn(),
-			$post: vi.fn(),
-		},
-	},
+  api: {
+    meetings: {
+      $get: vi.fn(),
+      $post: vi.fn(),
+    },
+  },
 }));
 
 import { api } from "@/lib/api";
 
 type Meeting = {
-	id: string;
-	title: string;
-	heldAt: string;
-	createdAt: string;
+  id: string;
+  title: string;
+  heldAt: string;
+  createdAt: string;
 };
 
 const mockMeetings: Meeting[] = [
-	{
-		id: "1",
-		title: "週次定例",
-		heldAt: "2026-04-21T10:00:00.000Z",
-		createdAt: "2026-04-20T00:00:00.000Z",
-	},
-	{
-		id: "2",
-		title: "月次レビュー",
-		heldAt: "2026-04-14T14:00:00.000Z",
-		createdAt: "2026-04-13T00:00:00.000Z",
-	},
+  {
+    id: "1",
+    title: "週次定例",
+    heldAt: "2026-04-21T10:00:00.000Z",
+    createdAt: "2026-04-20T00:00:00.000Z",
+  },
+  {
+    id: "2",
+    title: "月次レビュー",
+    heldAt: "2026-04-14T14:00:00.000Z",
+    createdAt: "2026-04-13T00:00:00.000Z",
+  },
 ];
 
 function renderWithQuery(ui: React.ReactElement) {
-	const client = new QueryClient({
-		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-	});
-	return {
-		client,
-		...render(
-			<QueryClientProvider client={client}>{ui}</QueryClientProvider>,
-		),
-	};
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    client,
+    ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>),
+  };
 }
 
+// WebSocket モック（WsChat テストで send/onmessage を検証するため外部参照可能にする）
+type MockWs = {
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  onclose: ((event: CloseEvent) => void) | null;
+  onerror: ((event: Event) => void) | null;
+};
+
+let mockWs: MockWs;
+let MockWebSocket: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
-	vi.stubGlobal(
-		"WebSocket",
-		vi.fn(() => ({
-			send: vi.fn(),
-			close: vi.fn(),
-			readyState: 1,
-			onmessage: null,
-			onopen: null,
-			onclose: null,
-			onerror: null,
-		})),
-	);
+  mockWs = {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    onmessage: null,
+    onopen: null,
+    onclose: null,
+    onerror: null,
+  };
+  MockWebSocket = vi.fn(() => mockWs);
+  vi.stubGlobal("WebSocket", MockWebSocket);
 });
 
 afterEach(() => {
-	vi.restoreAllMocks();
-	vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 // ===== meetings 一覧表示 =====
 
 describe("meetings 一覧表示", () => {
-	it("meetings の一覧が表示される", async () => {
-		vi.mocked(api.meetings.$get).mockResolvedValue({
-			json: async () => mockMeetings,
-		} as never);
+  it("meetings の一覧が表示される", async () => {
+    vi.mocked(api.meetings.$get).mockResolvedValue({
+      json: async () => mockMeetings,
+    } as never);
 
-		renderWithQuery(<Index />);
+    renderWithQuery(<Index />);
 
-		expect(await screen.findByText("週次定例")).toBeInTheDocument();
-		expect(await screen.findByText("月次レビュー")).toBeInTheDocument();
-	});
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(await screen.findByText("月次レビュー")).toBeInTheDocument();
+  });
 
-	it("meetings が空のとき空リストを表示する", async () => {
-		vi.mocked(api.meetings.$get).mockResolvedValue({
-			json: async () => [],
-		} as never);
+  it("meetings が空のとき空リストを表示する", async () => {
+    vi.mocked(api.meetings.$get).mockResolvedValue({
+      json: async () => [],
+    } as never);
 
-		renderWithQuery(<Index />);
+    renderWithQuery(<Index />);
 
-		await waitFor(() => {
-			expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
-		});
-	});
+    await waitFor(() => {
+      expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+    });
+  });
 });
 
 // ===== meeting 作成フォーム =====
 
 describe("meeting 作成フォーム", () => {
-	beforeEach(() => {
-		vi.mocked(api.meetings.$get).mockResolvedValue({
-			json: async () => [],
-		} as never);
-	});
+  beforeEach(() => {
+    vi.mocked(api.meetings.$get).mockResolvedValue({
+      json: async () => [],
+    } as never);
+  });
 
-	it("title が空のとき送信できない", async () => {
-		const user = userEvent.setup();
-		renderWithQuery(<Index />);
+  it("title が空のとき送信できない", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<Index />);
 
-		await user.click(screen.getByRole("button", { name: "作成" }));
+    await user.click(screen.getByRole("button", { name: "作成" }));
 
-		expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
-		expect(api.meetings.$post).not.toHaveBeenCalled();
-	});
+    expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
+    expect(api.meetings.$post).not.toHaveBeenCalled();
+  });
 
-	it("heldAt が空のとき送信できない", async () => {
-		const user = userEvent.setup();
-		renderWithQuery(<Index />);
+  it("heldAt が空のとき送信できない", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<Index />);
 
-		await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
-		await user.click(screen.getByRole("button", { name: "作成" }));
+    await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
+    await user.click(screen.getByRole("button", { name: "作成" }));
 
-		expect(await screen.findByText("開催日時は必須です")).toBeInTheDocument();
-		expect(api.meetings.$post).not.toHaveBeenCalled();
-	});
+    expect(await screen.findByText("開催日時は必須です")).toBeInTheDocument();
+    expect(api.meetings.$post).not.toHaveBeenCalled();
+  });
 
-	it("正常送信で api.$post が呼ばれ一覧が再取得される", async () => {
-		const user = userEvent.setup();
-		const newMeeting: Meeting = {
-			id: "3",
-			title: "テスト会議",
-			heldAt: "2026-04-23T10:00:00.000Z",
-			createdAt: "2026-04-23T00:00:00.000Z",
-		};
-		vi.mocked(api.meetings.$post).mockResolvedValue({
-			json: async () => newMeeting,
-		} as never);
-		vi.mocked(api.meetings.$get)
-			.mockResolvedValueOnce({ json: async () => [] } as never)
-			.mockResolvedValueOnce({ json: async () => [newMeeting] } as never);
+  it("正常送信で api.$post が呼ばれ一覧が再取得される", async () => {
+    const user = userEvent.setup();
+    const newMeeting: Meeting = {
+      id: "3",
+      title: "テスト会議",
+      heldAt: "2026-04-23T10:00:00.000Z",
+      createdAt: "2026-04-23T00:00:00.000Z",
+    };
+    vi.mocked(api.meetings.$post).mockResolvedValue({
+      json: async () => newMeeting,
+    } as never);
+    vi.mocked(api.meetings.$get)
+      .mockResolvedValueOnce({ json: async () => [] } as never)
+      .mockResolvedValueOnce({ json: async () => [newMeeting] } as never);
 
-		renderWithQuery(<Index />);
+    renderWithQuery(<Index />);
 
-		await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
-		await user.type(screen.getByLabelText("開催日時"), "2026-04-23T10:00");
-		await user.click(screen.getByRole("button", { name: "作成" }));
+    await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
+    await user.type(screen.getByLabelText("開催日時"), "2026-04-23T10:00");
+    await user.click(screen.getByRole("button", { name: "作成" }));
 
-		await waitFor(() => {
-			expect(api.meetings.$post).toHaveBeenCalled();
-		});
-		expect(await screen.findByText("テスト会議")).toBeInTheDocument();
-	});
+    await waitFor(() => {
+      expect(api.meetings.$post).toHaveBeenCalled();
+    });
+    expect(await screen.findByText("テスト会議")).toBeInTheDocument();
+  });
+});
+
+// ===== WebSocket チャット =====
+
+describe("WebSocket チャット", () => {
+  beforeEach(() => {
+    vi.mocked(api.meetings.$get).mockResolvedValue({
+      json: async () => [],
+    } as never);
+  });
+
+  it("マウント時に /ws へ接続する", async () => {
+    renderWithQuery(<Index />);
+
+    await waitFor(() => {
+      expect(MockWebSocket).toHaveBeenCalledWith(
+        expect.stringContaining("/ws"),
+      );
+    });
+  });
+
+  it("メッセージを入力して送信ボタンを押すと ws.send が呼ばれる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<Index />);
+
+    await waitFor(() => expect(MockWebSocket).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText("メッセージ"), "こんにちは");
+    await user.click(screen.getByRole("button", { name: "送信" }));
+
+    expect(mockWs.send).toHaveBeenCalledWith(
+      expect.stringContaining("こんにちは"),
+    );
+  });
+
+  it("WebSocket からメッセージを受信すると画面に表示される", async () => {
+    renderWithQuery(<Index />);
+
+    await waitFor(() => expect(MockWebSocket).toHaveBeenCalled());
+
+    const event = new MessageEvent("message", {
+      data: JSON.stringify({ echo: "サーバーからの応答" }),
+    });
+    act(() => {
+      mockWs.onmessage?.(event);
+    });
+
+    expect(await screen.findByText("サーバーからの応答")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -1,9 +1,10 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import type { Meeting } from "@/types/meeting";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Index } from "../routes/index";
+import { renderWithQuery } from "./test-utils";
 
 // hono/client api モジュールをモック
 vi.mock("@/lib/api", () => ({
@@ -16,13 +17,6 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { api } from "@/lib/api";
-
-type Meeting = {
-  id: string;
-  title: string;
-  heldAt: string;
-  createdAt: string;
-};
 
 const mockMeetings: Meeting[] = [
   {
@@ -38,16 +32,6 @@ const mockMeetings: Meeting[] = [
     createdAt: "2026-04-13T00:00:00.000Z",
   },
 ];
-
-function renderWithQuery(ui: React.ReactElement) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
-  return {
-    client,
-    ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>),
-  };
-}
 
 // WebSocket モック（WsChat テストで send/onmessage を検証するため外部参照可能にする）
 type MockWs = {
@@ -73,7 +57,7 @@ beforeEach(() => {
     onclose: null,
     onerror: null,
   };
-  MockWebSocket = vi.fn(() => mockWs);
+  MockWebSocket = Object.assign(vi.fn(() => mockWs), { OPEN: 1 });
   vi.stubGlobal("WebSocket", MockWebSocket);
 });
 
@@ -96,16 +80,15 @@ describe("meetings 一覧表示", () => {
     expect(await screen.findByText("月次レビュー")).toBeInTheDocument();
   });
 
-  it("meetings が空のとき空リストを表示する", async () => {
+  it("meetings が空のとき会議一覧に項目がない", async () => {
     vi.mocked(api.meetings.$get).mockResolvedValue({
       json: async () => [],
     } as never);
 
     renderWithQuery(<Index />);
 
-    await waitFor(() => {
-      expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
-    });
+    const list = await screen.findByRole("list", { name: "会議一覧" });
+    expect(within(list).queryAllByRole("listitem")).toHaveLength(0);
   });
 });
 
@@ -156,7 +139,7 @@ describe("meeting 作成フォーム", () => {
 
     renderWithQuery(<Index />);
 
-    await user.type(screen.getByPlaceholderText("タイトル"), "テスト会議");
+    await user.type(screen.getByLabelText("タイトル"), "テスト会議");
     await user.type(screen.getByLabelText("開催日時"), "2026-04-23T10:00");
     await user.click(screen.getByRole("button", { name: "作成" }));
 

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -1,0 +1,12 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+
+export function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    client,
+    ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>),
+  };
+}

--- a/apps/web/src/types/meeting.ts
+++ b/apps/web/src/types/meeting.ts
@@ -1,0 +1,6 @@
+export type Meeting = {
+  id: string;
+  title: string;
+  heldAt: string;
+  createdAt: string;
+};


### PR DESCRIPTION
## 関連Issue
Closes #37

## 概要・目的
4レイヤー（UI/API/DB/WebSocket）の疎通確認用に `apps/web/src/routes/index.tsx` を更新した。meetings 一覧取得・作成フォーム・WebSocket チャットを1ページに実装し、各レイヤーが繋がっていることをローカルで確認できるようにする。

## 背景
Issue #36 で Vite proxy（`/api` → Hono、`/ws` → FastAPI）と hono/client が整備されたため、フロントエンドから実際に各サービスを呼び出す画面が必要だった。

## 変更内容
* `MeetingsList`: TanStack Query + hono/client で `GET /meetings` を呼び、取得結果を一覧表示
* `CreateMeetingForm`: React Hook Form + Zod で title・heldAt を入力し `POST /meetings` を送信。成功後に `invalidateQueries` で一覧を再取得。`datetime-local` の値は `.toISOString()` で UTC 変換してから送信
* `WsChat`: `useRef` + `useEffect` で `/ws` に接続。受信した `echo` フィールドをメッセージ一覧に追加。メッセージキーは `crypto.randomUUID()`（配列 index 使用を避けるため）
* `index.test.tsx`（新規）: 上記3コンポーネントのテストを追加（計8件）
* `App.test.tsx`: `MeetingsList` 追加で `useQuery` が必要になったため `QueryClientProvider` と api/WS モックを追加

## 動作確認手順
1. `git checkout feature/issue-37-index-meetings-ws`
2. `make dev`（または `docker compose up`）でサービスを起動
3. ブラウザで `http://localhost:5173` を開く
4. 会議タイトルと開催日時を入力して「作成」→ 一覧に追加されることを確認
5. WebSocket チャットエリアにメッセージを入力して「送信」→ echo が返ってくることを確認
6. `pnpm exec vitest run`（apps/web 内）で全テストが通ることを確認

## スクリーンショット
* 
<img width="837" height="513" alt="image" src="https://github.com/user-attachments/assets/3ac8c5d9-e715-4ea2-9f69-03592e932188" />