### PR TITLE
feat(ai): lifespan パターンで Service Bus コンシューマーを起動

### DIFF
--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -1,10 +1,48 @@
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from consumers.service_bus import ServiceBusConsumer
 from routers.health import router as health_router
 from routers.ws import router as ws_router
 
-app = FastAPI(title="AI Service")
+logger = logging.getLogger(__name__)
+
+
+async def _handle_message(message) -> None:
+    logger.info("受信メッセージ: %s", message)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    connection_string = os.getenv("AZURE_SERVICE_BUS_CONNECTION_STRING")
+    task = None
+
+    if connection_string:
+        queue_name = os.getenv("AZURE_SERVICE_BUS_QUEUE_NAME", "decision-loop")
+        consumer = ServiceBusConsumer(connection_string, queue_name)
+        task = asyncio.create_task(consumer.start(_handle_message))
+    else:
+        logger.warning(
+            "AZURE_SERVICE_BUS_CONNECTION_STRING が未設定のため、"
+            "Service Bus コンシューマーをスキップします"
+        )
+
+    yield
+
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+app = FastAPI(title="AI Service", lifespan=lifespan)
 
 # 開発環境用: フロントエンド開発サーバーからのリクエストを許可する
 app.add_middleware(

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
+from azure.servicebus import ServiceBusReceivedMessage
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -12,9 +13,17 @@ from routers.ws import router as ws_router
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_QUEUE_NAME = "decision-loop"
 
-async def _handle_message(message) -> None:
+
+async def _handle_message(message: ServiceBusReceivedMessage) -> None:
     logger.info("受信メッセージ: %s", message)
+
+
+def _on_consumer_done(task: asyncio.Task) -> None:
+    # cancel 以外で終了した場合はエラーをログに残す
+    if not task.cancelled() and (exc := task.exception()):
+        logger.error("Service Bus コンシューマーが予期せず終了しました: %s", exc)
 
 
 @asynccontextmanager
@@ -23,9 +32,10 @@ async def lifespan(app: FastAPI):
     task = None
 
     if connection_string:
-        queue_name = os.getenv("AZURE_SERVICE_BUS_QUEUE_NAME", "decision-loop")
+        queue_name = os.getenv("AZURE_SERVICE_BUS_QUEUE_NAME", _DEFAULT_QUEUE_NAME)
         consumer = ServiceBusConsumer(connection_string, queue_name)
         task = asyncio.create_task(consumer.start(_handle_message))
+        task.add_done_callback(_on_consumer_done)
     else:
         logger.warning(
             "AZURE_SERVICE_BUS_CONNECTION_STRING が未設定のため、"
@@ -38,7 +48,7 @@ async def lifespan(app: FastAPI):
         task.cancel()
         try:
             await task
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, Exception):
             pass
 
 

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -5,6 +5,7 @@ from httpx import ASGITransport, AsyncClient
 @pytest.fixture
 def app():
     from main import app
+
     return app
 
 

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -65,3 +65,28 @@ async def test_lifespan_cancels_task_on_shutdown():
                 await asyncio.sleep(0)
 
     assert cancelled.is_set()
+
+
+async def test_lifespan_logs_error_on_consumer_failure(caplog):
+    """コンシューマーが予期せず例外で終了した場合に ERROR をログに残す"""
+    import main
+
+    async def fake_start(handler):
+        raise RuntimeError("接続失敗")
+
+    mock_consumer = MagicMock()
+    mock_consumer.start = fake_start
+
+    env = {_SB_CONN_KEY: "fake://conn"}
+    with patch.dict(os.environ, env):
+        with patch("main.ServiceBusConsumer", return_value=mock_consumer):
+            with caplog.at_level(logging.ERROR, logger="main"):
+                async with main.lifespan(main.app):
+                    await asyncio.sleep(0)  # タスクを実行させる
+                    # done callback は call_soon で遅延するため 2 ティック必要
+                    await asyncio.sleep(0)
+
+    assert any(
+        r.levelno == logging.ERROR and "予期せず終了" in r.message
+        for r in caplog.records
+    )

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -1,0 +1,78 @@
+import asyncio
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_SB_CONN_KEY = "AZURE_SERVICE_BUS_CONNECTION_STRING"
+
+
+@pytest.fixture
+def app():
+    from main import app
+
+    return app
+
+
+async def test_lifespan_warns_when_env_not_set(app, caplog):
+    """接続文字列未設定時に WARNING を出してコンシューマーをスキップする"""
+    env = {k: v for k, v in os.environ.items() if k != _SB_CONN_KEY}
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level(logging.WARNING, logger="main"):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ):
+                pass
+
+    assert any(_SB_CONN_KEY in r.message for r in caplog.records)
+
+
+async def test_lifespan_starts_consumer_when_env_set(app):
+    """接続文字列設定済み時に ServiceBusConsumer がバックグラウンド起動される"""
+    # start() が永続的に動き続けるよう asyncio.Event で制御
+    started = asyncio.Event()
+
+    async def fake_start(handler):
+        started.set()
+        await asyncio.Event().wait()  # キャンセルされるまでブロック
+
+    mock_consumer = MagicMock()
+    mock_consumer.start = fake_start
+
+    env = {_SB_CONN_KEY: "fake://conn", "AZURE_SERVICE_BUS_QUEUE_NAME": "test-queue"}
+    with patch.dict(os.environ, env):
+        with patch("main.ServiceBusConsumer", return_value=mock_consumer) as mock_cls:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ):
+                await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    mock_cls.assert_called_once_with("fake://conn", "test-queue")
+
+
+async def test_lifespan_cancels_task_on_shutdown(app):
+    """シャットダウン時にバックグラウンドタスクがキャンセルされ例外が伝播しない"""
+    cancelled = asyncio.Event()
+
+    async def fake_start(handler):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    mock_consumer = MagicMock()
+    mock_consumer.start = fake_start
+
+    env = {"AZURE_SERVICE_BUS_CONNECTION_STRING": "fake://conn"}
+    with patch.dict(os.environ, env):
+        with patch("main.ServiceBusConsumer", return_value=mock_consumer):
+            # AsyncClient コンテキストを抜けると lifespan の shutdown が実行される
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ):
+                pass
+
+    assert cancelled.is_set()

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -3,35 +3,26 @@ import logging
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-from httpx import ASGITransport, AsyncClient
-
 _SB_CONN_KEY = "AZURE_SERVICE_BUS_CONNECTION_STRING"
 
 
-@pytest.fixture
-def app():
-    from main import app
-
-    return app
-
-
-async def test_lifespan_warns_when_env_not_set(app, caplog):
+async def test_lifespan_warns_when_env_not_set(caplog):
     """接続文字列未設定時に WARNING を出してコンシューマーをスキップする"""
+    import main
+
     env = {k: v for k, v in os.environ.items() if k != _SB_CONN_KEY}
     with patch.dict(os.environ, env, clear=True):
         with caplog.at_level(logging.WARNING, logger="main"):
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ):
+            async with main.lifespan(main.app):
                 pass
 
     assert any(_SB_CONN_KEY in r.message for r in caplog.records)
 
 
-async def test_lifespan_starts_consumer_when_env_set(app):
+async def test_lifespan_starts_consumer_when_env_set():
     """接続文字列設定済み時に ServiceBusConsumer がバックグラウンド起動される"""
-    # start() が永続的に動き続けるよう asyncio.Event で制御
+    import main
+
     started = asyncio.Event()
 
     async def fake_start(handler):
@@ -44,16 +35,16 @@ async def test_lifespan_starts_consumer_when_env_set(app):
     env = {_SB_CONN_KEY: "fake://conn", "AZURE_SERVICE_BUS_QUEUE_NAME": "test-queue"}
     with patch.dict(os.environ, env):
         with patch("main.ServiceBusConsumer", return_value=mock_consumer) as mock_cls:
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ):
+            async with main.lifespan(main.app):
                 await asyncio.wait_for(started.wait(), timeout=1.0)
 
     mock_cls.assert_called_once_with("fake://conn", "test-queue")
 
 
-async def test_lifespan_cancels_task_on_shutdown(app):
+async def test_lifespan_cancels_task_on_shutdown():
     """シャットダウン時にバックグラウンドタスクがキャンセルされ例外が伝播しない"""
+    import main
+
     cancelled = asyncio.Event()
 
     async def fake_start(handler):
@@ -66,13 +57,11 @@ async def test_lifespan_cancels_task_on_shutdown(app):
     mock_consumer = MagicMock()
     mock_consumer.start = fake_start
 
-    env = {"AZURE_SERVICE_BUS_CONNECTION_STRING": "fake://conn"}
+    env = {_SB_CONN_KEY: "fake://conn"}
     with patch.dict(os.environ, env):
         with patch("main.ServiceBusConsumer", return_value=mock_consumer):
-            # AsyncClient コンテキストを抜けると lifespan の shutdown が実行される
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ):
-                pass
+            async with main.lifespan(main.app):
+                # タスクが起動するまでイベントループを1周させる
+                await asyncio.sleep(0)
 
     assert cancelled.is_set()

--- a/services/ai/uv.lock
+++ b/services/ai/uv.lock
@@ -29,16 +29,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-servicebus", specifier = ">=7.14.3" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.136.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mypy", specifier = ">=1.13.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.25.0" },
-    { name = "ruff", specifier = ">=0.9.0" },
+    { name = "mypy", specifier = ">=1.20.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 関連Issue
Closes #38

## 概要・目的
FastAPI 起動時に `ServiceBusConsumer` を lifespan パターンでバックグラウンド起動する。
`AZURE_SERVICE_BUS_CONNECTION_STRING` 未設定時はグレースフルスキップし、シャットダウン時はタスクをキャンセルしてクリーン終了する。

## 背景
* `main.py` に lifespan ハンドラーがなく、既存の `ServiceBusConsumer` が起動されていなかった
* API → Service Bus → AI の接続経路が機能しない状態だった

## 変更内容
* `services/ai/main.py`
  * `@asynccontextmanager` で `lifespan` ハンドラーを追加し `FastAPI(lifespan=lifespan)` に接続
  * 接続文字列設定済み時: `ServiceBusConsumer` を `asyncio.create_task` でバックグラウンド起動
  * 未設定時: `logger.warning` を出力してスキップ（サービス自体は起動）
  * シャットダウン時: タスクをキャンセルし `asyncio.CancelledError` をキャッチして終了
  * `_handle_message`: 受信メッセージを `logger.info` に出力
* `services/ai/tests/test_main_lifespan.py`
  * lifespan 直接呼び出しによる 3 ケースのテストを追加
  * `ASGITransport` がライフスパンイベントをトリガーしないため、`main.lifespan` を直接 `async with` で呼び出す方式に変更

## 動作確認手順
1. テストを実行して全ケースが GREEN であることを確認する
   ```
   make test
   ```
2. `AZURE_SERVICE_BUS_CONNECTION_STRING` を未設定のまま AI サービスを起動し、warning ログが出ることを確認する
   ```
   make dev
   # ログに「AZURE_SERVICE_BUS_CONNECTION_STRING が未設定のため、Service Bus コンシューマーをスキップします」が出ること
   ```
3. `.env` に `AZURE_SERVICE_BUS_CONNECTION_STRING` を設定してサービスを起動し、コンシューマーがバックグラウンドで起動することを確認する
   ```
   make dev
   # AI サービスのログにエラーなく起動完了が出ること
   ```

## スクリーンショット
*