### PR TITLE
fix(deps): @hono/node-server の serveStatic ミドルウェア bypass 脆弱性を修正

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^1.19.13",
     "@prisma/client": "^6.6.0",
     "hono": "^4.7.7",
     "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -12,5 +12,10 @@
     "@biomejs/biome": "^1.9.4",
     "turbo": "^2.3.3"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "pnpm": {
+    "overrides": {
+      "@hono/node-server": ">=1.19.13"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@hono/node-server': '>=1.19.13'
+
 importers:
 
   .:
@@ -18,7 +21,7 @@ importers:
   apps/api:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
+        specifier: '>=1.19.13'
         version: 1.19.14(hono@4.12.14)
       '@prisma/client':
         specifier: ^6.6.0
@@ -496,12 +499,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -2656,10 +2653,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@hono/node-server@1.19.11(hono@4.12.14)':
-    dependencies:
-      hono: 4.12.14
-
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
@@ -2736,7 +2729,7 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.14)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2


### PR DESCRIPTION
## 関連Issue
Closes #42

## 概要・目的
Dependabot が検出した `@hono/node-server` の serveStatic ミドルウェア bypass 脆弱性（CVE: 1.19.11 以下）を解消した。`apps/api` が直接使うバージョンは既に 1.19.14 だったが、`@prisma/dev` の transitive 依存として 1.19.11 が lockfile に残存していたため、pnpm overrides で全パッケージを 1.19.13 以上に固定した。

## 背景
`@hono/node-server` 1.19.11 以下に URL の連続スラッシュ（`//foo` など）で `serveStatic` ミドルウェアがスキップされるバグが存在する。`apps/api/package.json` の specifier `^1.13.7` は lockfile 上で 1.19.14 に解決済みだったが、`@prisma/dev@0.24.3` が transitive 依存として 1.19.11 を引き込んでいた。

## 変更内容
* `apps/api/package.json`: `@hono/node-server` の specifier を `^1.13.7` → `^1.19.13` に変更（意図の明確化）
* `package.json` (root): `pnpm.overrides` に `@hono/node-server: ">=1.19.13"` を追加し、全ワークスペースで脆弱バージョンを強制排除
* `pnpm-lock.yaml`: 再生成により `@hono/node-server@1.19.11` のエントリを除去（`1.19.14` のみ残存）

## 動作確認手順
1. `git checkout issue-42-fix-hono-node-server-servestatic-middleware-bypass`
2. `pnpm install --frozen-lockfile`
3. `grep "1.19.11" pnpm-lock.yaml` — 出力なしであることを確認
4. `pnpm turbo run test` — 全テスト GREEN を確認

## スクリーンショット
*（依存バージョン更新のため省略）*