### PR TITLE
feat: DB設計ファイルを追加

### DIFF
--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -1,0 +1,188 @@
+Table users {
+  id          uuid [pk]
+  external_id varchar [unique, note: 'Entra IDのユーザーID']
+  provider    varchar [note: 'microsoft など']
+  name        varchar
+  email       varchar [unique]
+  created_at  timestamp
+  updated_at  timestamp
+  deleted_at  timestamp
+}
+
+Table user_roles {
+  id         uuid [pk]
+  user_id    uuid [ref: > users.id]
+  role       varchar [note: 'admin / member / guest など']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table recurring_meetings {
+  id            uuid [pk]
+  title         varchar
+  description   text
+  schedule_cron varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}
+
+Table recurring_meeting_members {
+  id                   uuid [pk]
+  recurring_meeting_id uuid [ref: > recurring_meetings.id]
+  user_id              uuid [ref: > users.id]
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table meetings {
+  id                   uuid [pk]
+  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は単発の会議']
+  title                varchar
+  scheduled_at         timestamp
+  status               varchar [note: 'scheduled / done / canceled']
+  transcription        text [note: '文字起こし本文']
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table meeting_attendees {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  user_id    uuid [ref: > users.id]
+  status     varchar [note: 'proposed / invited / accepted / declined / attended / absent']
+  is_default boolean [note: 'true = 定例メンバー / false = 今回だけの参加']
+  invited_by uuid [ref: > users.id, note: 'NULLの場合はAIによる提案']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table topic_requests {
+  id           uuid [pk]
+  meeting_id   uuid [ref: > meetings.id]
+  requested_by uuid [ref: > users.id]
+  title        varchar
+  body         text
+  created_at   timestamp
+  updated_at   timestamp
+  deleted_at   timestamp
+}
+
+Table agenda_items {
+  id                uuid [pk]
+  title             varchar
+  body              text
+  source_type       varchar [note: 'ai / human / carried_over']
+  status            varchar [note: 'pending / approved / rejected']
+  origin_meeting_id uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
+  created_by        uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
+  modified_by       uuid [ref: > users.id, note: 'NULLの場合は修正なし']
+  created_at        timestamp
+  updated_at        timestamp
+  deleted_at        timestamp
+}
+
+Table meeting_agenda_items {
+  id             uuid [pk]
+  meeting_id     uuid [ref: > meetings.id]
+  agenda_item_id uuid [ref: > agenda_items.id]
+  order_index    int
+  created_at     timestamp
+  updated_at     timestamp
+  deleted_at     timestamp
+}
+
+Table meeting_materials {
+  id          uuid [pk]
+  meeting_id  uuid [ref: > meetings.id]
+  uploaded_by uuid [ref: > users.id]
+  file_name   varchar
+  file_url    varchar
+  uploaded_at timestamp
+  created_at  timestamp
+  updated_at  timestamp
+  deleted_at  timestamp
+}
+
+Table issues {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  title      varchar
+  body       text
+  status     varchar [note: 'draft / reviewing / open / rejected / resolved / cancelled']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table issue_assignees {
+  id         uuid [pk]
+  issue_id   uuid [ref: > issues.id]
+  user_id    uuid [ref: > users.id]
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table tasks {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  issue_id   uuid [ref: > issues.id, note: 'NULLの場合は課題に紐づかない独立したタスク']
+  title      varchar
+  body       text
+  status     varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
+  due_date   timestamp
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table task_assignees {
+  id         uuid [pk]
+  task_id    uuid [ref: > tasks.id]
+  user_id    uuid [ref: > users.id]
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table ambiguous_info {
+  id                   uuid [pk]
+  meeting_id           uuid [ref: > meetings.id]
+  body                 text
+  status               varchar [note: 'draft / reviewing / resolved / rejected']
+  resolution_type      varchar [note: 'null = 未解決 / task / issue / discarded']
+  resolved_to_task_id  uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
+  resolved_to_issue_id uuid [ref: > issues.id, note: 'resolution_type = issue のときのみ値が入る']
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table audit_logs {
+  id            uuid [pk]
+  actor_id      uuid [ref: > users.id]
+  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_id   uuid
+  action        varchar [note: 'create / update / delete']
+  before_value  json
+  after_value   json
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}
+
+Table read_logs {
+  id            uuid [pk]
+  user_id       uuid [ref: > users.id]
+  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_id   uuid
+  read_at       timestamp
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}

--- a/tmp/db-business-process-flow.md
+++ b/tmp/db-business-process-flow.md
@@ -1,0 +1,75 @@
+# ビジネスプロセスフロー図
+
+```mermaid
+flowchart TD
+    subgraph PRE["会議前"]
+        direction TB
+        P1["TopicRequest 入力\n（人間）"]
+        P2["未完了 Task・OpenIssue 参照\n（システム）"]
+        P3["AgendaItem 生成\n（AI）"]
+        P4["参加者候補提案\n（AI）"]
+        P5["参加者確定\n（人間）"]
+
+        P1 --> P3
+        P2 --> P3
+        P3 --> P4
+        P4 --> P5
+    end
+
+    subgraph MTG["会議"]
+        direction TB
+        M1["会議開催"]
+    end
+
+    subgraph POST["会議後"]
+        direction TB
+        Q1["文字起こし・議事録入力\n（人間）"]
+        Q2["内容構造化\n（AI）"]
+
+        subgraph EXTRACT["抽出"]
+            direction LR
+            Q3["Decision"]
+            Q4["OpenIssue"]
+            Q5["Task"]
+            Q6["Ambiguity"]
+        end
+
+        Q7["レビュー・解消先確定\n（人間）"]
+
+        Q1 --> Q2
+        Q2 --> EXTRACT
+        Q6 --> Q7
+        Q7 -->|"Decision として確定"| Q3
+        Q7 -->|"OpenIssue として持ち越し"| Q4
+        Q7 -->|"Task として確定"| Q5
+    end
+
+    subgraph TASK["タスク管理"]
+        direction TB
+        T1["担当者・期限確定\n（人間）"]
+        T2["着手 → 完了\n（担当者）"]
+        T3["期限超過リマインド\n（システム）"]
+
+        T1 --> T2
+        T3 -->|"未完了の場合通知"| T1
+    end
+
+    subgraph NEXT["次回会議へ"]
+        direction TB
+        N1["未完了 Task を持ち越し"]
+        N2["scheduled な OpenIssue を議題へ"]
+        N3["次回 AgendaItem 生成\n（AI）"]
+
+        N1 --> N3
+        N2 --> N3
+    end
+
+    P5 --> M1
+    M1 --> Q1
+    Q3 -->|"AuditLog 記録"| TASK
+    Q5 --> T1
+    Q4 -->|"open"| NEXT
+    T2 -->|"未完了"| N1
+    T2 -->|"完了"| NEXT
+    N3 -->|"次の会議サイクルへ"| PRE
+```

--- a/tmp/db-columns.md
+++ b/tmp/db-columns.md
@@ -1,0 +1,208 @@
+# カラム候補一覧
+
+## User
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| external_id | varchar | NOT NULL, UNIQUE（Entra ID のオブジェクトID） |
+| provider | varchar | NOT NULL, DEFAULT 'entra' |
+| name | varchar | NOT NULL |
+| email | varchar | NOT NULL, UNIQUE |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+| deleted_at | timestamp | |
+
+---
+
+## MeetingSeries
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| name | varchar | NOT NULL |
+| description | text | |
+| created_by | uuid | FK → User |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+| deleted_at | timestamp | |
+
+---
+
+## MeetingSeriesMember
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| series_id | uuid | PK, FK → MeetingSeries |
+| user_id | uuid | PK, FK → User |
+
+---
+
+## Meeting
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| series_id | uuid | NOT NULL, FK → MeetingSeries |
+| status | enum | NOT NULL, DEFAULT 'scheduled' |
+| held_at | timestamp | NOT NULL |
+| transcript_text | text | |
+| ai_summary_text | text | |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+
+status: `scheduled` / `done` / `cancelled`
+
+---
+
+## MeetingAttendee
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| meeting_id | uuid | PK, FK → Meeting |
+| user_id | uuid | PK, FK → User |
+| status | enum | NOT NULL, DEFAULT 'suggested' |
+| suggested_reason | text | |
+
+status: `suggested` / `confirmed` / `declined`
+
+---
+
+## MeetingDocument
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| meeting_id | uuid | NOT NULL, FK → Meeting |
+| type | varchar | NOT NULL |
+| content | text | NOT NULL |
+| created_by | enum | NOT NULL |
+| created_at | timestamp | NOT NULL |
+
+type: `minutes` / `material` / ...
+created_by: `human` / `ai`
+
+---
+
+## TopicRequest
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| series_id | uuid | NOT NULL, FK → MeetingSeries |
+| requested_by | uuid | NOT NULL, FK → User |
+| content | text | NOT NULL |
+| created_at | timestamp | NOT NULL |
+
+---
+
+## AgendaItem
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| title | varchar | NOT NULL |
+| description | text | |
+| priority | int | NOT NULL, DEFAULT 0 |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+
+---
+
+## AgendaItemSource
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| agenda_item_id | uuid | PK, FK → AgendaItem |
+| source_type | enum | PK |
+| source_id | uuid | PK |
+
+source_type: `open_issue` / `topic_request`
+
+---
+
+## MeetingAgendaItem
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| meeting_id | uuid | PK, FK → Meeting |
+| agenda_item_id | uuid | PK, FK → AgendaItem |
+| order | int | NOT NULL |
+
+---
+
+## Issue（決定事項・未決事項を統合）
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| meeting_id | uuid | NOT NULL, FK → Meeting（発生元） |
+| content | text | NOT NULL |
+| status | enum | NOT NULL, DEFAULT 'draft' |
+| decision_deadline | date | （open 時のみ使用） |
+| scheduled_meeting_id | uuid | FK → Meeting（open 時のみ使用） |
+| resolved_at | timestamp | （resolved 時のみ使用） |
+| resolved_by | uuid | FK → User（resolved 時のみ使用） |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+
+status: `draft` / `reviewing` / `open` / `resolved` / `rejected` / `cancelled`
+
+---
+
+## Task
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| meeting_id | uuid | FK → Meeting（発生元、人間作成時は nullable） |
+| content | text | NOT NULL |
+| status | enum | NOT NULL, DEFAULT 'draft' |
+| due_date | date | |
+| created_by | uuid | FK → User |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+
+status: `draft` / `reviewing` / `todo` / `in_progress` / `done` / `rejected`
+
+---
+
+## TaskAssignee
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| task_id | uuid | PK, FK → Task |
+| user_id | uuid | PK, FK → User |
+| assigned_at | timestamp | NOT NULL |
+
+---
+
+## Ambiguity
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| meeting_id | uuid | NOT NULL, FK → Meeting |
+| content | text | NOT NULL |
+| status | enum | NOT NULL, DEFAULT 'draft' |
+| resolution_type | enum | （resolved 時のみ使用） |
+| resolved_issue_id | uuid | FK → Issue（nullable） |
+| resolved_task_id | uuid | FK → Task（nullable） |
+| created_at | timestamp | NOT NULL |
+| updated_at | timestamp | NOT NULL |
+
+status: `draft` / `reviewing` / `resolved` / `rejected`
+resolution_type: `issue` / `task` / `discarded`
+
+---
+
+## AuditLog
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| id | uuid | PK |
+| target_type | varchar | NOT NULL |
+| target_id | uuid | NOT NULL |
+| field_name | varchar | NOT NULL |
+| before_value | text | |
+| after_value | text | |
+| change_source | enum | NOT NULL |
+| changed_by | uuid | FK → User |
+| changed_at | timestamp | NOT NULL |
+
+target_type: `task` / `decision` / `open_issue` / `ambiguity` / ...
+change_source: `ai` / `human`
+
+---
+
+## ReadLog
+| カラム | 型 | 制約 |
+|--------|-----|------|
+| task_id | uuid | PK, FK → Task |
+| user_id | uuid | PK, FK → User |
+| read_at | timestamp | NOT NULL |

--- a/tmp/db-design-discussion.md
+++ b/tmp/db-design-discussion.md
@@ -1,0 +1,442 @@
+# DBテーブル設計 議論ログ
+
+## Step 1: エンティティの洗い出し
+
+### 候補
+- Meeting（会議）
+- Agenda（議題）
+- Decision（決定事項）
+- OpenIssue（未決事項）
+- Task（タスク）
+- Ambiguity（曖昧箇所）
+- Member（メンバー）
+- MeetingLog（会議ログ）
+
+---
+
+## Step 2: MeetingSeries と Meeting を分けるか？
+
+**Q: 「毎週の定例」と「1回の会議」は別テーブルにすべきか？**
+
+- 案A: Meeting 1テーブルのみ
+- 案B: MeetingSeries（定例そのもの）と Meeting（1回の開催）に分ける
+
+**結論: 案B（2テーブルに分ける）**
+
+理由: それぞれが扱いたい情報が異なるため。
+- `MeetingSeries` → 定例の名前・参加メンバー・開催曜日・会議室など「シリーズとして変わらない情報」
+- `Meeting` → 開催日・実際の参加者・会議ログなど「その回ごとに変わる情報」
+
+---
+
+## Step 3: Meeting のステータス
+
+**Q: Meeting はどんな状態を持つか？**
+
+**議論:**
+- `done` と `closed` を分けるか検討したが、タスク化やレビューはすぐに完了しない。会議の中で全てが完了したかどうかは Meeting で追うより Task や Ambiguity の状態で追えばよい。
+- 次回アジェンダ生成は「状態」ではなく「アクション（手動または特定タイミングのトリガー）」として扱う。
+- このシステムは会議中にリアルタイムで使うものではなく（§14.3 より MTGツール・文字起こし機能は除外）、会議後にテキストを貼り付けて使うため `in_progress` は不要。
+
+**結論:**
+```
+scheduled  → 予定されている
+done       → 会議が終わった（ログを投入できる状態）
+cancelled  → キャンセルされた
+```
+
+---
+
+## Step 4: Task のステータス
+
+**Q: タスクが生まれる瞬間はどこか？**
+
+- AIが抽出（会議ログ投入後）→ 人間が確認・確定
+- 人間が直接作成（最初から確定済み）
+
+**Q: `draft` → `confirmed` の間に「レビュー中」は必要か？**
+
+オーナー以外も確認するケースがあるため、「確認中（reviewing）」があると良い。
+
+**Q: `overdue`（期限超過）ステータスは必要か？**
+
+不要。タスクの着手状況と期限は別の概念であり、`due_date` と現在日時の比較で動的に判断できる。客観的事実を重複して持つ必要はない。
+
+**結論:**
+```
+draft       → AIが抽出した、未確認
+reviewing   → 誰かが確認中
+confirmed   → 確定した（直接作成はここからスタート）
+in_progress → 着手中
+done        → 完了
+rejected    → 却下された
+```
+
+遷移:
+```
+[draft] → [reviewing] → [confirmed] → [in_progress] → [done]
+                              ↓
+                          [rejected]
+```
+
+---
+
+---
+
+## Step 5: Ambiguity のステータス
+
+**Q: Ambiguity はどんな状態を持つか？**
+
+**議論:**
+- 当初 `dismissed`（対応不要）を候補に挙げたが、曖昧箇所は必ず Decision / OpenIssue / Task のいずれかに解消されるべきであり、dismissed は不要と判断。
+- `resolved` の細分化も検討したが、解消先との紐付きはリレーション（外部キー）で別途追うため、ステータスはシンプルで良い。
+- ステータスは「この曖昧箇所が今どの段階にあるか」のみを表す。「どの Decision/OpenIssue/Task に解消されたか」はリレーションで管理する。
+
+**結論:**
+```
+extracted   → AIが抽出した、未確認
+reviewing   → 誰かが確認中
+resolved    → いずれかに解消された（Decision / OpenIssue / Task）
+```
+
+---
+
+---
+
+## Step 6: Decision のステータス
+
+**Q: 曖昧でない抽出結果も全件レビューを挟むべきか？**
+
+- 案A: 全部レビューを挟む（draft → reviewing → confirmed）
+- 案B: とりあえず確定、後から修正可能
+
+**議論:**
+- 要件 §10.1「曖昧箇所のみ人が確認する」という設計思想と合わせると、全件レビュー強制は運用が重くなる。
+- 案Bが適切。ただし「誰がいつ何を修正したか」の差分ログ（AuditLog）は必須。
+- **設計方針として確立:** レビューフローが必要かどうかは曖昧さの有無で決まる。
+
+**結論:**
+```
+confirmed   → AI抽出時点で確定（デフォルト）
+overturned  → 後の会議で覆された
+```
+
+`draft` は不要。修正履歴は AuditLog で追う。
+
+---
+
+---
+
+## Step 7: OpenIssue のステータス
+
+**Q: `scheduled` は必要か？予定会議のFKがあれば動的に判断できるのでは？**
+
+**議論:**
+- 未決で何も決まっていない状態と、いつ話すかが決まっている状態は、UI上でパッと区別できる必要がある。
+- それはOpenIssueそのものの状態なので、ステータスで持つべき。
+
+**結論:**
+```
+open        → 未決のまま（AI抽出時点でデフォルト）
+scheduled   → 次回会議の議題に設定済み
+resolved    → Decision または Task に変換された
+cancelled   → 対応不要と判断された
+```
+
+---
+
+---
+
+## Step 8: リレーション設計
+
+### 基本リレーション
+
+```
+MeetingSeries 1 ──< Meeting
+Meeting       1 ──< Agenda
+Meeting       1 ──< Decision
+Meeting       1 ──< Task
+Meeting       1 ──< Ambiguity
+Meeting       1 ──< OpenIssue（発生元会議）
+OpenIssue     N ──> Meeting（予定会議）
+Task          N ── N Member（担当者）
+```
+
+### Ambiguity の解消先リレーション
+
+**Q: 解消先（Decision / OpenIssue / Task）とどう紐づけるか？**
+
+- 案A: 3つの外部キーを持つ（nullable）
+- 案B: ポリモーフィック（resolved_type + resolved_id）
+- 第3案: 中間テーブル（AmbiguityResolution）
+
+**議論:**
+- 件数より「変更コスト」で判断するのがベストプラクティス。
+- A → 3 の移行はテーブル追加から段階的にできるため比較的容易。
+- 3 → A の移行は type に応じた振り分けが必要で面倒。
+- MVP フェーズでデータ量が少ない今は案Aで始め、必要になったら3に移行するのが合理的。
+- 解消先は現時点で3種類固定の見込み。
+
+**結論: 案A**
+```
+Ambiguity
+- resolved_decision_id   (nullable FK)
+- resolved_open_issue_id (nullable FK)
+- resolved_task_id       (nullable FK)
+```
+
+---
+
+### Task と Member の多対多
+
+担当者は複数人つけるケースが必ずあるため中間テーブルで管理。
+
+```
+TaskAssignee
+- task_id   (FK)
+- member_id (FK)
+```
+
+### Agenda のリレーション設計
+
+**Q: Agenda をどう設計するか？**
+
+**議論:**
+- 追跡したいのは「どのMTGで話したか」「どんな未決事項を通ってきたか」の2軸。
+- 1つの議題トピックが複数の会議にまたがって追跡されるため、AgendaItem と Meeting は多対多。
+- AgendaItem は AI Agent が OpenIssue と人間入力（TopicRequest）をもとに生成する。
+- 人間入力は別テーブル（TopicRequest）で管理し、AI がそれを読んで AgendaItem を生成。
+- 重複・関連する OpenIssue や TopicRequest をまとめて1つの AgendaItem にするケースがあるため、ソースとの紐付きは中間テーブルで管理。
+- ソースの種類は OpenIssue と TopicRequest の2種類で固定見込みのため、ポリモーフィックで対応。
+
+**結論:**
+```
+TopicRequest（人間が入力した「次回話したいこと」）
+- requested_by
+- content
+- meeting_series_id
+
+AgendaItem（AIが生成した議題項目）
+
+AgendaItemSource（ソースとの紐付き・中間テーブル）
+- agenda_item_id
+- source_type: "open_issue" | "topic_request"
+- source_id
+
+MeetingAgendaItem（AgendaItem と Meeting の中間テーブル）
+- meeting_id
+- agenda_item_id
+```
+
+---
+
+## Step 9: テキスト系データの設計
+
+**Q: 文字起こし・議事録・AI要約などをどこに持つか？**
+
+**論点1: DBのTEXT型 vs Blob Storage**
+
+- MVP段階では文字起こし1件あたり数万字、1,000件でも約10MBとDBとして問題ない規模。
+- Blob Storageへの移行タイミングは「DBサイズがコスト圧迫になったとき」「ファイルとして扱いたいニーズが出たとき」「Azure AI SearchのインデクサーをBlob Storageから直接つなぎたいとき」。
+- **結論: MVPはDB TEXT型で持ち、スケール時にストレージへ移行する。**
+
+**論点2: Meeting のカラムに持つ（案A）vs MeetingDocument テーブル（案B）**
+
+- ドキュメントの種類は今後増える可能性が大いにある（入力系・AI出力系）ため、案Aの固定カラムでは対応しきれない。
+- ただし文字起こしとAI要約は1:1、議事録・関連資料は1:Nと性質が異なる。
+- 1:1 のものを MeetingDocument に入れると毎回JOINが必要になりクエリが複雑になる。
+
+**結論: 案B-2（1:1はMeetingカラム、1:NはMeetingDocumentテーブル）**
+
+```
+Meeting
+- transcript_text   (1:1)
+- ai_summary_text   (1:1)
+
+MeetingDocument（議事録・関連資料など 1:N）
+- meeting_id
+- type: "minutes" | "material" | ...
+- content (TEXT)
+- created_by: "human" | "ai"
+- created_at
+```
+
+---
+
+---
+
+## Step 10: 抜け漏れ確認
+
+### 1. Member / MeetingAttendee
+
+**議論:**
+- User をベースエンティティとして持つ。
+- 定例のデフォルトメンバーは MeetingSeriesMember で管理。変動はあるが履歴は不要（削除で対応）。
+- その回の参加者・参加候補は MeetingAttendee で管理。AIが提案するケースもある。
+
+**結論:**
+```
+User（ユーザーアカウント）
+
+MeetingSeriesMember（定例のデフォルトメンバー）
+- series_id
+- user_id
+
+MeetingAttendee（その回の実際の参加者・参加候補）
+- meeting_id
+- user_id
+- status: "suggested" | "confirmed" | "declined"
+- suggested_reason
+```
+
+---
+
+### 2. ReadLog の設計
+
+一旦 Task のみ対象。今後増える可能性は0ではないが、MVPはシンプルに直接FKで持つ。
+
+```
+ReadLog
+- task_id (FK)
+- user_id (FK)
+- read_at
+```
+
+### 3. AuditLog のスコープ・設計方針
+
+**Q: ログテーブルとして持つか、イベントとして持つか？**
+
+**議論:**
+- イベントソーシングは現在の状態の取得が複雑（replay・スナップショット）、クエリが難しい、スキーマ変更が困難。
+- ドメインイベントは中間的な選択肢だが、Service Bus などの追加インフラが必要。
+- インフラコスト: CRUD+AuditLog $50〜150/月 vs イベントソーシング $150〜400/月。
+- エンジニアリングコストの差が最も大きく、イベントソーシングは4〜6倍の工数。
+- 通知・リマインドはバッチ処理で対応できる。
+
+**結論: CRUD + AuditLog**
+
+対象テーブル: Task / Decision / OpenIssue / Ambiguity 全て。
+
+```
+AuditLog
+- target_type: "task" | "decision" | "open_issue" | "ambiguity" | ...
+- target_id
+- field_name
+- before_value
+- after_value
+- change_source: "ai" | "human"
+- changed_by (user_id FK)
+- changed_at
+```
+
+---
+
+### 4. Briefing
+
+要件書 §16.4 に記載があったが、Agenda（AgendaItem）が会議前の事前共有資料の役割を担うため不要。テーブルとして持たない。
+
+---
+
+## 全テーブル一覧（確定版）
+
+**リソース系:**
+```
+User
+MeetingSeries
+MeetingSeriesMember（series_id, user_id）
+Meeting（transcript_text, ai_summary_text を持つ）
+MeetingAttendee（meeting_id, user_id, status, suggested_reason）
+MeetingDocument（議事録・関連資料など 1:N）
+TopicRequest（人間が入力した「次回話したいこと」）
+AgendaItem（AIが生成した議題項目）
+AgendaItemSource（AgendaItem とソースの中間テーブル）
+MeetingAgendaItem（AgendaItem と Meeting の中間テーブル）
+Decision
+OpenIssue
+Task
+TaskAssignee（task_id, user_id）
+Ambiguity
+```
+
+**イベント系:**
+```
+AuditLog（AI提案→人間確定の差分記録）
+ReadLog（タスク既読状況）
+```
+
+---
+
+### 5. 認証方式
+
+**Q: ログインはどう扱うか？**
+
+- 案A: 自前実装（email + password）
+- 案B: Microsoft Entra ID（Azure AD）
+- 案C: Auth0 / Clerk などの外部サービス
+
+**結論: 案B（Microsoft Entra ID）**
+
+チーム向けB2Bツールでありazureスタックを使う前提のため自然な選択。パスワードはDBに持たず認証はEntra IDに委託。
+
+```
+User
+- external_id  varchar NOT NULL UNIQUE（Entra ID のオブジェクトID）
+- provider     varchar NOT NULL DEFAULT 'entra'
+```
+
+---
+
+---
+
+## Step 11: Decision / OpenIssue の統合
+
+**Q: Decision と OpenIssue は別テーブルか、Issue として1テーブルか？**
+
+**議論:**
+- パフォーマンス観点では規模的に誤差。
+- open → resolved への遷移が自然で、同じ議題の経緯をトレースできる。
+- フィールドの差異（decision_deadline / resolved_at）は nullable で許容範囲。
+- Ambiguity の解消先も Issue 1本になりシンプルになる。
+
+**結論: Issue として統合**
+
+```
+status: draft / reviewing / open / resolved / rejected / cancelled
+```
+
+- open    = 未決事項
+- resolved = 決定事項
+
+あわせて以下も確定:
+- Task の `confirmed` → `todo` に変更
+- Ambiguity の解消先: resolved_issue_id / resolved_task_id / resolution_type（discarded）
+
+---
+
+## Step 12: 残課題の確認
+
+### Issue の scheduled ステータス
+`scheduled_meeting_id` が設定されているかどうかで動的に判断する。別ステータスは不要。
+
+### Ambiguity の変更履歴
+案A（CRUD + AuditLog）で対応。Ambiguity テーブルを UPDATE し、変更は AuditLog で追う。
+
+### AgendaItemSource の source_type
+`"open_issue"` → `"issue"` に変更（Decision/OpenIssue の統合に伴う）。
+
+### 論理削除（soft delete）
+削除後も参照されるテーブルのみ `deleted_at` を追加。
+
+| テーブル | 判断 | 理由 |
+|----------|------|------|
+| User | 必要 | AuditLog 等から参照される。退職者の履歴保持。 |
+| MeetingSeries | 必要 | 廃止後も過去の会議履歴を残す。 |
+| Task / Issue / Ambiguity | 不要 | rejected / cancelled ステータスで表現できる。 |
+| Meeting | 不要 | cancelled ステータスで表現できる。 |
+| 中間テーブル・ログ系 | 不要 | 物理削除または追記のみ。 |
+
+---
+
+## カラム設計
+
+`tmp/db-columns.md` 参照。

--- a/tmp/db-design-guide.md
+++ b/tmp/db-design-guide.md
@@ -1,0 +1,119 @@
+# データテーブル設計の手順
+
+## Step 1: 登場人物（エンティティ）を洗い出す
+
+要件書の「扱う情報」「出力情報」からリソース名を列挙します。
+
+> 例: Meeting, Task, Decision, OpenIssue, Ambiguity, Agenda, Member...
+
+**コツ:** 名詞を拾う。「会議ログ」「タスク一覧」「曖昧箇所」など。
+
+---
+
+## Step 2: リソース系 vs イベント系を分ける
+
+| 種類 | 説明 | 例 |
+|------|------|-----|
+| **リソース系** | 「今の状態」を持つもの。更新される | Meeting, Task, Decision |
+| **イベント系** | 「起きたこと」の記録。追記のみ、削除しない | AuditLog, ReviewLog, ReadLog |
+
+**なぜ分けるか:** リソースは上書き更新、イベントは追記だけ。混ぜると「なぜこうなったか」が追えなくなります。
+
+Decision Loop では要件 §15.1 に「差分とログを保持する」とあるので、イベント系が重要です。
+
+---
+
+## Step 3: 状態遷移を書く
+
+状態を持つリソース（主に Task と Ambiguity）は、取りうる状態とその遷移を図にします。
+
+**Task の例:**
+```
+[pending] → [in_progress] → [done]
+               ↓
+           [overdue]
+```
+
+**Ambiguity（曖昧箇所）の例:**
+```
+[extracted] → [under_review] → [confirmed]
+                                    ↓
+                               [rejected]
+```
+
+**コツ:** 状態遷移を先に書くと、カラムに何が必要かが自然に決まります。例えば `confirmed_at` `confirmed_by` `rejected_reason` など。
+
+---
+
+## Step 4: 関係性（リレーション）を整理する
+
+「誰が誰を持つか」を整理します。
+
+```
+Meeting 1 ──< Agenda
+Meeting 1 ──< Decision
+Meeting 1 ──< OpenIssue
+Meeting 1 ──< Ambiguity
+Meeting 1 ──< Task
+Task 1 ──< ReviewLog  (誰がどう修正したか)
+Task N ──< Member N   (担当者)
+```
+
+**コツ:** `1対多` か `多対多` かを区別する。多対多は中間テーブルが必要です（例: `task_assignees`）。
+
+---
+
+## Step 5: 時間軸を意識する
+
+定例会議は「前回→今回→次回」の継続性が命です。
+
+- `Meeting` に `series_id`（同じ定例シリーズの識別子）を持たせる
+- `Task` に `created_at_meeting_id` と `closed_at_meeting_id` を持たせる
+- `Agenda` が「前回の持ち越しか、今回の新規か」を区別できるようにする
+
+---
+
+## Step 6: AI提案と人間確定の差分を保持する
+
+要件 §10.3 「AI提案と最終確定の差分を残す」は設計に直結します。
+
+```
+Ambiguity テーブル
+- ai_proposed_owner    (AIが提案した担当者)
+- confirmed_owner      (人間が確定した担当者)
+- ai_proposed_deadline
+- confirmed_deadline
+- reviewed_by
+- reviewed_at
+```
+
+これを Review テーブルとして独立させるか、Ambiguity に埋め込むかは規模次第です。
+
+---
+
+## この要件のテーブル候補まとめ
+
+```
+リソース系:
+  MeetingSeries  (定例の「シリーズ」単位)
+  Meeting        (1回の会議)
+  Agenda         (議題)
+  Decision       (決定事項)
+  OpenIssue      (未決事項)
+  Task           (タスク)
+  Ambiguity      (曖昧箇所)
+  Member         (メンバー)
+
+イベント系:
+  AuditLog       (AI提案→人間確定の差分記録)
+  ReadLog        (タスク既読状況)
+```
+
+---
+
+## 初心者が陥りやすいポイント
+
+1. **状態を boolean で持つ** → `is_done: bool` より `status: enum` の方が拡張しやすい
+2. **削除する** → 論理削除（`deleted_at`）にして履歴を残す
+3. **AI提案を上書きする** → 元の提案を消さず、確定値を別カラムに持つ
+4. **Meeting に全部詰め込む** → 1テーブルが肥大化するので、概念ごとに分ける

--- a/tmp/db-er-diagram.md
+++ b/tmp/db-er-diagram.md
@@ -1,0 +1,137 @@
+# DB設計 ER図
+
+```mermaid
+erDiagram
+    User {
+        uuid id
+        string name
+        string email
+    }
+    MeetingSeries {
+        uuid id
+        string name
+        string schedule
+    }
+    MeetingSeriesMember {
+        uuid series_id
+        uuid user_id
+    }
+    Meeting {
+        uuid id
+        uuid series_id
+        string status
+        text transcript_text
+        text ai_summary_text
+        datetime held_at
+    }
+    MeetingAttendee {
+        uuid meeting_id
+        uuid user_id
+        string status
+        text suggested_reason
+    }
+    MeetingDocument {
+        uuid id
+        uuid meeting_id
+        string type
+        string created_by
+        text content
+        datetime created_at
+    }
+    TopicRequest {
+        uuid id
+        uuid series_id
+        uuid requested_by
+        text content
+        datetime created_at
+    }
+    AgendaItem {
+        uuid id
+        string title
+        int priority
+    }
+    AgendaItemSource {
+        uuid agenda_item_id
+        string source_type
+        uuid source_id
+    }
+    MeetingAgendaItem {
+        uuid meeting_id
+        uuid agenda_item_id
+    }
+    Decision {
+        uuid id
+        uuid meeting_id
+        text content
+        string status
+        datetime confirmed_at
+    }
+    OpenIssue {
+        uuid id
+        uuid meeting_id
+        text content
+        string status
+        datetime decision_deadline
+        uuid scheduled_meeting_id
+    }
+    Task {
+        uuid id
+        uuid meeting_id
+        text content
+        string status
+        datetime due_date
+    }
+    TaskAssignee {
+        uuid task_id
+        uuid user_id
+    }
+    Ambiguity {
+        uuid id
+        uuid meeting_id
+        text content
+        string status
+        uuid resolved_decision_id
+        uuid resolved_open_issue_id
+        uuid resolved_task_id
+    }
+    AuditLog {
+        uuid id
+        string target_type
+        uuid target_id
+        string field_name
+        text before_value
+        text after_value
+        string change_source
+        uuid changed_by
+        datetime changed_at
+    }
+    ReadLog {
+        uuid task_id
+        uuid user_id
+        datetime read_at
+    }
+
+    User ||--o{ MeetingSeriesMember : "所属"
+    MeetingSeries ||--o{ MeetingSeriesMember : "メンバー"
+    MeetingSeries ||--o{ Meeting : "開催"
+    MeetingSeries ||--o{ TopicRequest : "次回議題"
+    Meeting ||--o{ MeetingAttendee : "参加者"
+    User ||--o{ MeetingAttendee : "参加"
+    Meeting ||--o{ MeetingDocument : "資料"
+    Meeting ||--o{ MeetingAgendaItem : ""
+    AgendaItem ||--o{ MeetingAgendaItem : ""
+    AgendaItem ||--o{ AgendaItemSource : "ソース"
+    Meeting ||--o{ Decision : "決定事項"
+    Meeting ||--o{ OpenIssue : "発生元"
+    Meeting ||--o{ Task : "タスク"
+    Meeting ||--o{ Ambiguity : "曖昧箇所"
+    Task ||--o{ TaskAssignee : "担当者"
+    User ||--o{ TaskAssignee : "担当"
+    Decision ||--o{ Ambiguity : "解消先"
+    OpenIssue ||--o{ Ambiguity : "解消先"
+    Task ||--o{ Ambiguity : "解消先"
+    Meeting ||--o{ OpenIssue : "予定会議"
+    User ||--o{ AuditLog : "変更者"
+    User ||--o{ ReadLog : "既読"
+    Task ||--o{ ReadLog : "対象"
+```

--- a/tmp/db-state-diagrams.md
+++ b/tmp/db-state-diagrams.md
@@ -1,0 +1,68 @@
+# 状態遷移図
+
+## Meeting
+
+```mermaid
+stateDiagram-v2
+    [*] --> scheduled : 会議を登録
+    scheduled --> done : 会議終了・ログ投入
+    scheduled --> cancelled : キャンセル
+    done --> [*]
+    cancelled --> [*]
+```
+
+---
+
+## Task
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft : AI抽出
+    [*] --> confirmed : 人間が直接作成
+    draft --> reviewing : 確認開始
+    reviewing --> confirmed : 確定
+    reviewing --> rejected : 却下
+    confirmed --> in_progress : 着手
+    in_progress --> done : 完了
+    done --> [*]
+    rejected --> [*]
+```
+
+---
+
+## Ambiguity
+
+```mermaid
+stateDiagram-v2
+    [*] --> extracted : AI抽出
+    extracted --> reviewing : 確認開始
+    reviewing --> resolved : 解消（Decision / OpenIssue / Task へ）
+    resolved --> [*]
+```
+
+---
+
+## Decision
+
+```mermaid
+stateDiagram-v2
+    [*] --> confirmed : AI抽出（デフォルト確定）
+    confirmed --> overturned : 後の会議で覆された
+    overturned --> [*]
+    confirmed --> [*]
+```
+
+---
+
+## OpenIssue
+
+```mermaid
+stateDiagram-v2
+    [*] --> open : AI抽出（デフォルト）
+    open --> scheduled : 次回会議の議題に設定
+    open --> cancelled : 対応不要と判断
+    scheduled --> resolved : Decision または Task に変換
+    scheduled --> cancelled : 対応不要と判断
+    resolved --> [*]
+    cancelled --> [*]
+```

--- a/tmp/dev-environment-discussion.md
+++ b/tmp/dev-environment-discussion.md
@@ -1,0 +1,157 @@
+# 開発環境・周辺ツール 議論ログ
+
+## Step 1: リポジトリ構成
+
+**Q: monorepo か 複数リポジトリか？**
+
+**議論:**
+
+- 5人チームでサービス間通信がある以上、PR の見通しや Docker Compose の一元管理の方が価値が高い。
+- TS + Python 混在の monorepo は若干ぎこちないが、Python 側を独立ディレクトリとして置くだけで JS ツールチェーンと干渉しない。
+- 分けるメリットが「TS チームと Python チームが独立して動ける」程度で、通信を考えると薄い。
+
+**結論: monorepo（Turborepo + pnpm workspaces）**
+
+```
+/
+├── apps/
+│   ├── web/        ← Vite + React (TypeScript)
+│   └── api/        ← Hono (TypeScript)
+├── services/
+│   └── ai/         ← FastAPI (Python)
+├── docker-compose.yml
+└── turbo.json
+```
+
+---
+
+## Step 2: パッケージマネージャー（TypeScript）
+
+**Q: pnpm / bun / npm どれか？**
+
+**議論:**
+
+- monorepo との相性が最も良いのは pnpm（workspaces が標準機能・node_modules の重複排除）。
+- Turborepo との組み合わせが定番。
+- bun は monorepo サポートが発展途上。npm は workspaces 管理がやや貧弱。
+
+**結論: pnpm**
+
+---
+
+## Step 3: ローカル DB 環境
+
+**Q: PostgreSQL をどう立てるか？**
+
+**結論: Docker Compose**
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: decision_loop
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+    ports:
+      - "5432:5432"
+```
+
+全員が `docker-compose up -d` で同じ環境を立ち上げられる。Prisma の `DATABASE_URL` を `.env` に書けばすぐ繋がる。
+
+---
+
+## Step 4: Python 環境管理
+
+**Q: uv / Poetry / venv+pip どれか？**
+
+**議論:**
+
+- uv は 2024年以降急速に普及。pip・venv・lock ファイル管理を一括で担い、インストールが爆速。
+- `uv sync` 一発で環境が再現できる。Poetry より速く、最近は乗り換えが増えている。
+
+**結論: uv**
+
+`services/ai/` 配下に `pyproject.toml` + `uv.lock` を置く構成。
+
+---
+
+## Step 5: Linter / Formatter
+
+**Q: TS 側・Python 側それぞれ何を使うか？**
+
+**議論:**
+
+- TypeScript: Biome は ESLint + Prettier を1ツールで代替。`biome.json` 1ファイルで完結・高速。初見チームに向いている。
+- Python: Ruff は Flake8 + Black + isort を1ツールで代替。uv との相性が良く `pyproject.toml` に数行で済む。
+
+**結論:**
+
+| | ツール |
+|---|---|
+| TS Lint + Format | Biome |
+| Python Lint + Format | Ruff |
+
+---
+
+## Step 6: テスト方針
+
+**Q: どのレイヤーをどこまでテストするか？**
+
+**議論:**
+
+- ハッカソンでも実プロダクトのような品質を目指す方針。
+- 社会人 + 大学生の混成チームでテストの重要性・TDD・CI/CD を整えたい。
+- AI ツールがあるのでテスト実装コストは下がる。
+
+**結論: C（全レイヤーカバー）**
+
+| レイヤー | ツール | 用途 |
+|---|---|---|
+| Frontend | Vitest + Testing Library | コンポーネント・ロジック |
+| App Server | Vitest | API エンドポイント |
+| AI Service | pytest + pytest-asyncio | 構造化ロジック・エンドポイント |
+
+---
+
+## Step 7: CI/CD
+
+**結論: GitHub Actions**
+
+```
+PR 作成時:
+  lint（Biome / Ruff）
+  型チェック（tsc / mypy）
+  テスト（Vitest / pytest）
+
+main マージ時:
+  上記 + build + Azure へデプロイ
+```
+
+**ブランチ戦略:**
+
+- `main`: 常にデプロイ可能
+- `feature/*`: 作業ブランチ → PR → レビュー必須 → main マージ
+
+---
+
+## 開発環境・ツールまとめ
+
+| 項目 | 技術 |
+|---|---|
+| リポジトリ構成 | monorepo（Turborepo + pnpm workspaces） |
+| パッケージマネージャー | pnpm |
+| ローカル起動 | 全部 Docker Compose（必要に応じてアプリだけネイティブ切り替え） |
+| ローカル DB | Docker Compose（PostgreSQL 16） |
+| ローカル Service Bus | Docker Compose（Azure Service Bus Emulator） |
+| ローカル WebSocket | FastAPI WebSocket サーバー（本番は Azure Web PubSub に切り替え） |
+| Python 環境管理 | uv |
+| TS Linter/Formatter | Biome |
+| Python Linter/Formatter | Ruff |
+| ホットリロード | Turborepo `turbo dev`（Vite HMR / tsx watch / uvicorn --reload） |
+| 環境変数 | `.env.example`（Git管理）+ `.env.local`（Git管理外） |
+| TS テスト | Vitest + Testing Library |
+| Python テスト | pytest + pytest-asyncio |
+| CI/CD | GitHub Actions |
+| ブランチ戦略 | feature/* → PR レビュー → main |
+| タスクランナー | Makefile（随時追加） |

--- a/tmp/frontend-stack-discussion.md
+++ b/tmp/frontend-stack-discussion.md
@@ -1,0 +1,83 @@
+# フロントエンド技術選定 議論ログ
+
+## Step 1: フレームワーク選定
+
+**Q: Next.js か Vite + React (SPA) か？**
+
+- **Next.js**: SSR・SSG・App Router・Server Actions が使える。ただし覚えることが多い。
+- **Vite + React (SPA)**: シンプルで軽量。
+
+**議論:**
+
+- このプロダクトは社内向け管理ツールであり SEO 不要。SSR・SSG の恩恵がほぼない。
+- 参考: AI Shift 社の事例（Zenn）でも toBツールは Next.js を採用せず Vite + React SPA を選択。サーバーコスト負担とコンテキストスイッチ削減が理由。
+- 参考: levtech 記事でも toBツールにはフレームワークなし SPA が合う場面があると言及。
+- チームの学習コストを下げる方針と一致する。
+
+**結論: Vite + React (SPA)**
+
+---
+
+## Step 2: ルーティング
+
+**Q: React Router v7 か TanStack Router か？**
+
+- **React Router v7**: 最も普及・情報量が多い。
+- **TanStack Router**: 型安全が強力。ファイルベースルーティングも可能。
+
+**議論:**
+
+- AI Shift 社の事例で TanStack Router が採用されており、ルーティングが深くなった場合も追いやすいと評価されている。
+- 型安全の恩恵が hono/client との組み合わせで活きる。
+
+**結論: TanStack Router**
+
+---
+
+## Step 3: スタイリング・UI コンポーネント
+
+**Q: MUI（フルコンポーネントライブラリ）か shadcn/ui + Tailwind CSS か plain CSS か？**
+
+**議論:**
+
+- 管理画面寄りのUIのため MUI の DataGrid・フォーム部品の恩恵は受けやすい。
+- ただし AI コーディングツール（Cursor・Claude Code）との相性は MUI が低く、shadcn/ui + Tailwind が高い。
+- 「AI があるのでコンポーネント実装は苦ではない」→ plain CSS でもよいのでは？という案が出たが、Tailwind は AI が最も得意なスタイリング記法であり、plain CSS より生成精度が高い。shadcn/ui はコードがリポジトリに直接入るため AI が拡張しやすい。
+- 「AI で実装する」前提に最も合っているのが shadcn/ui + Tailwind であり、MUI に戻る理由も plain CSS に戻る理由もない。
+
+**結論: shadcn/ui + Tailwind CSS**
+
+---
+
+## Step 4: データフェッチ・状態管理・フォーム
+
+**Q: サーバー状態・クライアント状態・フォームをどう管理するか？**
+
+**結論:**
+
+| 用途 | 技術 | 補足 |
+|------|------|------|
+| サーバー状態（APIキャッシュ・再取得） | TanStack Query | hono/client と組み合わせて型安全なフェッチ |
+| クライアント状態（UI状態など） | Jotai | Zustand より軽量・管理画面規模に十分 |
+| フォーム + バリデーション | React Hook Form + Zod | Zod スキーマを App Server と共有できる |
+
+---
+
+## フロントエンド技術スタックまとめ
+
+| レイヤー | 技術 |
+|----------|------|
+| フレームワーク | Vite + React (TypeScript) |
+| ルーティング | TanStack Router |
+| UI コンポーネント | shadcn/ui |
+| スタイリング | Tailwind CSS |
+| サーバー状態管理 | TanStack Query |
+| クライアント状態管理 | Jotai |
+| フォーム | React Hook Form + Zod |
+
+---
+
+## 次の議論
+
+- テスト方針（Vitest / Testing Library）
+- App Server と AI Service の通信方式

--- a/tmp/tech-stack-discussion.md
+++ b/tmp/tech-stack-discussion.md
@@ -1,0 +1,141 @@
+# 技術選定 議論ログ
+
+## Step 1: フロントエンド
+
+**結論: Vite + React (TypeScript)**
+
+詳細は `frontend-stack-discussion.md` を参照。
+
+---
+
+## Step 2: バックエンド言語の選定
+
+**Q: TypeScript か Python か？**
+
+- 候補A: TypeScript（フルスタック統一）
+- 候補B: Python（AI処理に強い）
+
+**議論:**
+
+- このプロダクトの中心は AI処理（構造化・曖昧性抽出・アジェンダ生成）なので、LangChain / Semantic Kernel / Azure AI SDK のエコシステムが成熟している Python に優位性がある。
+- ただしバックエンドを「App Server（CRUD・DB接続）」と「AI Service（AI処理）」に分離する場合、App Server 側は普通の Web バックエンドになるため Python の優位性が薄れる。
+
+---
+
+## Step 3: サービス分割の判断
+
+**Q: App Server と AI Service を分けるか？**
+
+**分けた場合の構成:**
+
+```
+Frontend (Next.js / TypeScript)
+     ↓
+App Server (TypeScript / Hono or Fastify)
+  - Meeting / Task / Decision / OpenIssue の CRUD
+  - DB接続 (Prisma + Cosmos DB or PostgreSQL)
+  - フロントと型定義・Zodスキーマを共有できる
+
+AI Service (Python / FastAPI)
+  - 構造化・曖昧性抽出・アジェンダ生成
+  - Azure OpenAI / AI Search / RAG
+```
+
+**分けない場合の構成:**
+
+```
+Frontend (Next.js / TypeScript)
+     ↓
+Backend (Python / FastAPI)
+  - CRUD + AI処理を同一プロセスで管理
+  - LangChain / Semantic Kernel 直接利用
+  - Azure SDK for Python
+```
+
+**議論:**
+
+- 分ける場合: App Server は TypeScript が自然（Prisma の型安全 ORM・Zod の型共有が活きる）。AI Service は Python 一択。ただし 2 サービスの運用・デプロイ・サービス間通信のコストが増える。
+- 分けない場合: Python 1 本で完結。AI 処理と CRUD を同一プロセスで扱えるためシンプル。MVP フェーズには現実的。
+
+**結論: 分ける（TypeScript + Python の 2 サービス構成）**
+
+理由:
+- App Server 側の型安全性（Prisma・Zod）と、フロントとの型共有の恩恵が大きい。
+- AI Service は Python でないと中長期で辛くなる（RAG パイプライン・エコシステムの成熟度）。
+- ハッカソンスコープでも 2 サービス構成は許容範囲と判断。
+
+---
+
+## Step 4: DB の選定
+
+**Q: RDB（PostgreSQL）か NoSQL（Cosmos DB）か？**
+
+**議論:**
+
+- 設計見直し前提なら NoSQL でも成立する。ただし横断クエリ（全シリーズのタスク一覧・未解消 OpenIssue 一覧）が多いこのプロダクトの性質上、NoSQL では cross-partition query が重くなりやすい。
+- コスト面は $200 の予算があれば DB の差額は誤差レベル。Azure OpenAI の呼び出し回数の方が支配的。
+- スキーマがまだ流動的なため、`prisma migrate dev` 一発で変更を追える Prisma + PostgreSQL の開発速度が決め手。
+
+**結論: PostgreSQL + Prisma**
+
+理由:
+- 横断クエリが多いアクセスパターンに自然に対応できる。
+- スキーマ変更が多い今の段階で Prisma のマイグレーション管理が効く。
+- Cosmos DB のパーティションキー設計を後から直すコストをハッカソン中に払いたくない。
+
+---
+
+## Step 5: App Server ↔ AI Service 通信方式
+
+**Q: REST（同期）か メッセージキュー（非同期）か？**
+
+**議論:**
+
+- 当初 REST + ポーリングを提案したが、LLM 呼び出しは秒数が読めないため REST 同期は実プロダクトとして設計が弱い。
+- ポーリングは「REST の限界を誤魔化す」設計であり、本質的な解決にならない。
+- AI 処理が絡む実プロダクトでは非同期キューが標準的。
+- Azure のサービスを上手く活用できるかも選定の軸。
+
+**結論: Azure Service Bus + Azure Web PubSub（非同期）**
+
+```
+App Server ──→ Azure Service Bus ──→ AI Service（Consumer）
+                                           ↓
+                                       DB に結果保存
+                                           ↓
+                              Azure Web PubSub でフロントに通知
+```
+
+| サービス | 役割 |
+|---|---|
+| Azure Service Bus | ジョブキュー。リトライ・デッドレターキューが標準装備 |
+| Azure Container Apps + KEDA | Service Bus のキュー深度に応じて AI Service を自動スケール |
+| Azure Web PubSub | AI 処理完了をフロントにリアルタイム通知 |
+
+理由:
+- AI Service が落ちてもジョブはキューに残り、復帰後に処理される
+- 負荷に応じて AI Service だけスケールアウトできる
+- Azure の強みをそのまま活かせる構成
+
+---
+
+## 技術スタックまとめ
+
+| レイヤー | 技術 | 補足 |
+|----------|------|------|
+| Frontend | Vite + React (TypeScript) | TanStack Router / shadcn/ui / Tailwind / TanStack Query / Jotai / RHF+Zod |
+| App Server | Hono (TypeScript) | Prisma ORM・Zod スキーマ共有・hono/client で型共有 |
+| AI Service | FastAPI (Python) | LangChain or Semantic Kernel |
+| 通信 | Azure Service Bus | App Server → AI Service のジョブキュー |
+| 通知 | Azure Web PubSub | AI 処理完了のリアルタイム通知 |
+| スケーリング | Azure Container Apps + KEDA | Service Bus キュー深度に応じた自動スケール |
+| AI 基盤 | Azure OpenAI / Microsoft Foundry | §16.2 |
+| 検索 | Azure AI Search | RAG による文脈補完 §16.3 |
+| DB | PostgreSQL + Prisma | Azure Database for PostgreSQL |
+| 実行基盤 | Azure Container Apps | §16.1 |
+
+---
+
+## 次の議論
+
+- Semantic Kernel vs LangChain の選定


### PR DESCRIPTION
## 概要
DB設計ファイル（DBML）を追加し、レビュー指摘に基づいた設計変更を反映しました。

## 主な変更点

### 1. 認証まわり（usersテーブル）
- パスワードハッシュを削除し、Microsoft Entra IDなどの外部IdPに認証を移譲
-  と  カラムを追加
-  カラムを削除し、 中間テーブルに切り出し（1ユーザー複数ロール対応）

### 2. 定例会議（recurring_meetingsテーブル）
-  カラムを追加（cron形式でデフォルトスケジュールを保持）

### 3. 参加者ステータス（meeting_attendeesテーブル）
- （boolean）を  に変更（proposed/invited/accepted/declined/attended/absent）
-  と  を追加

### 4. アジェンダ分割
-  テーブルを3つのテーブルに分割：
  - : 人間が入力する議題リクエスト
  - : AIまたは人間が作成するアジェンダ本体
  - : アジェンダと会議の紐付け

### 5. タスク・課題の担当者
-  および  テーブルの  を削除
-  および  中間テーブルを追加（複数担当者対応）

### 6. 曖昧情報の解消先（ambiguous_infoテーブル）
-  カラムを追加（null/task/issue/discarded）
- 未解決と対応不要を区別可能に

### 7. 履歴管理
-  テーブルを削除し、 に統合

### 8. 文字起こし（meetingsテーブル）
-  を削除し、 カラムに本文を直接格納（Azure SQL前提）

### 9. 共通変更
- 全テーブルに  と  を追加（論理削除対応）
-  テーブルの汎用化を維持