### PR TITLE
feat: DB設計ファイルを追加

### DIFF
--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -85,17 +85,18 @@ Table topic_requests {
 }
 
 Table agenda_items {
-  id                uuid [pk]
-  title             varchar
-  body              text
-  source_type       varchar [note: 'ai / human / carried_over']
-  status            varchar [note: 'pending / approved / rejected']
-  origin_meeting_id uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
-  created_by        uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
-  modified_by       uuid [ref: > users.id, note: 'NULLの場合は修正なし']
-  created_at        timestamp
-  updated_at        timestamp
-  deleted_at        timestamp
+  id                 uuid [pk]
+  title              varchar
+  body               text
+  source_type        varchar [note: 'ai / human / carried_over']
+  status             varchar [note: 'pending / approved / rejected']
+  topic_request_id   uuid [ref: > topic_requests.id, note: 'NULLの場合はtopic_requestに基づかない生成']
+  origin_meeting_id  uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
+  created_by         uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
+  modified_by        uuid [ref: > users.id, note: 'NULLの場合は修正なし']
+  created_at         timestamp
+  updated_at         timestamp
+  deleted_at         timestamp
 }
 
 Table meeting_agenda_items {

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -118,7 +118,6 @@ Table meeting_materials {
   uploaded_by uuid [ref: > users.id]
   file_name   varchar
   file_url    varchar
-  uploaded_at timestamp
   created_at  timestamp
   updated_at  timestamp
   deleted_at  timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -1,4 +1,5 @@
 Table users {
+  Note: 'システムのユーザー。認証はEntra IDに移譲し、外部IDとプロバイダー情報を保持する'
   id          uuid [pk]
   external_id varchar [unique, note: 'Entra IDのユーザーID']
   provider    varchar [note: 'microsoft など']
@@ -10,6 +11,7 @@ Table users {
 }
 
 Table user_roles {
+  Note: 'ユーザーのロール。1ユーザーが複数のロールを持てるよう中間テーブルとして管理する'
   id         uuid [pk]
   user_id    uuid [ref: > users.id]
   role       varchar [note: 'admin / member / guest など']
@@ -23,6 +25,7 @@ Table user_roles {
 }
 
 Table recurring_meetings {
+  Note: '定例会議の定義。cron形式のスケジュールを持ち、個別のmeetingを繰り返し生成する元になる'
   id            uuid [pk]
   title         varchar
   description   text
@@ -33,6 +36,7 @@ Table recurring_meetings {
 }
 
 Table recurring_meeting_members {
+  Note: '定例会議のデフォルトメンバー。この一覧をもとにmeeting_attendeesが自動生成される'
   id                   uuid [pk]
   recurring_meeting_id uuid [ref: > recurring_meetings.id]
   user_id              uuid [ref: > users.id]
@@ -46,6 +50,7 @@ Table recurring_meeting_members {
 }
 
 Table meetings {
+  Note: '個別の会議。定例会議から生成される場合もあれば、単発で作成される場合もある。文字起こし本文を直接保持する'
   id                   uuid [pk]
   recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は単発の会議']
   title                varchar
@@ -58,6 +63,7 @@ Table meetings {
 }
 
 Table meeting_attendees {
+  Note: '会議ごとの参加者。AIによる提案・人間による招待から始まり、承認/辞退/参加/欠席へと状態遷移する'
   id         uuid [pk]
   meeting_id uuid [ref: > meetings.id]
   user_id    uuid [ref: > users.id]
@@ -74,6 +80,7 @@ Table meeting_attendees {
 }
 
 Table topic_requests {
+  Note: '人間が会議に対して入力する議題リクエスト。AIによるagenda_items生成のインプットになる'
   id           uuid [pk]
   meeting_id   uuid [ref: > meetings.id]
   requested_by uuid [ref: > users.id]
@@ -85,6 +92,7 @@ Table topic_requests {
 }
 
 Table agenda_items {
+  Note: 'AIまたは人間が作成するアジェンダ。会議をまたいで持ち越しが可能で、meeting_agenda_itemsで会議と紐づく'
   id                 uuid [pk]
   title              varchar
   body               text
@@ -100,6 +108,7 @@ Table agenda_items {
 }
 
 Table meeting_agenda_items {
+  Note: 'agenda_itemsとmeetingsの中間テーブル。order_indexで表示順を管理する'
   id             uuid [pk]
   meeting_id     uuid [ref: > meetings.id]
   agenda_item_id uuid [ref: > agenda_items.id]
@@ -114,6 +123,7 @@ Table meeting_agenda_items {
 }
 
 Table meeting_materials {
+  Note: '会議に添付された資料ファイル。ファイル本体はストレージに保存し、URLのみDBで管理する'
   id          uuid [pk]
   meeting_id  uuid [ref: > meetings.id]
   uploaded_by uuid [ref: > users.id]
@@ -125,6 +135,7 @@ Table meeting_materials {
 }
 
 Table issues {
+  Note: '会議から抽出された課題。ドラフト→レビュー→オープン→解決/却下のライフサイクルを持つ'
   id         uuid [pk]
   meeting_id uuid [ref: > meetings.id]
   title      varchar
@@ -136,6 +147,7 @@ Table issues {
 }
 
 Table issue_assignees {
+  Note: '課題の担当者。1つの課題に複数の担当者を紐づけられるよう中間テーブルとして管理する'
   id         uuid [pk]
   issue_id   uuid [ref: > issues.id]
   user_id    uuid [ref: > users.id]
@@ -149,6 +161,7 @@ Table issue_assignees {
 }
 
 Table tasks {
+  Note: '会議から抽出されたタスク。issueに紐づく場合と、issueに紐づかない独立したタスクの両方を表現できる'
   id         uuid [pk]
   meeting_id uuid [ref: > meetings.id]
   issue_id   uuid [ref: > issues.id, note: 'NULLの場合は課題に紐づかない独立したタスク']
@@ -162,6 +175,7 @@ Table tasks {
 }
 
 Table task_assignees {
+  Note: 'タスクの担当者。1つのタスクに複数の担当者を紐づけられるよう中間テーブルとして管理する'
   id         uuid [pk]
   task_id    uuid [ref: > tasks.id]
   user_id    uuid [ref: > users.id]
@@ -175,6 +189,7 @@ Table task_assignees {
 }
 
 Table ambiguous_info {
+  Note: '会議中に発生した曖昧な情報。resolution_typeによってタスク・課題への解消、または対応不要の棄却を管理する'
   id                   uuid [pk]
   meeting_id           uuid [ref: > meetings.id]
   body                 text
@@ -188,6 +203,7 @@ Table ambiguous_info {
 }
 
 Table audit_logs {
+  Note: '各リソースへの操作履歴。変更前後の値をJSONで保持する追記専用の不変ログ'
   id            uuid [pk]
   actor_id      uuid [ref: > users.id]
   resource_type varchar [note: 'task / issue / ambiguous_info など']
@@ -199,6 +215,7 @@ Table audit_logs {
 }
 
 Table read_logs {
+  Note: 'ユーザーによるリソースの既読履歴。未読バッジ表示などの既読管理に使用する追記専用の不変ログ'
   id            uuid [pk]
   user_id       uuid [ref: > users.id]
   resource_type varchar [note: 'task / issue / ambiguous_info など']

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -1,3 +1,28 @@
+Table teams {
+  Note: 'チーム。複数の定例会議を束ねる単位。将来的にOrganizationを上位に追加できるよう team_id 経由で参照する設計にしている'
+  id         uuid [pk]
+  name       varchar
+  created_by uuid [ref: > users.id]
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table team_members {
+  Note: 'チームのメンバー管理。role により閲覧・編集・管理の権限を制御する'
+  id         uuid [pk]
+  team_id    uuid [ref: > teams.id]
+  user_id    uuid [ref: > users.id]
+  role       varchar [note: 'owner / member / viewer']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+
+  indexes {
+    (team_id, user_id) [unique]
+  }
+}
+
 Table users {
   Note: 'システムのユーザー。認証はEntra IDに移譲し、外部IDとプロバイダー情報を保持する'
   id          uuid [pk]
@@ -11,22 +36,24 @@ Table users {
 }
 
 Table user_roles {
-  Note: 'ユーザーのロール。1ユーザーが複数のロールを持てるよう中間テーブルとして管理する'
+  Note: 'ユーザーのロール。team_idがNULLの場合はグローバルロール、値がある場合はチームスコープのロールとして機能する'
   id         uuid [pk]
   user_id    uuid [ref: > users.id]
+  team_id    uuid [ref: > teams.id, note: 'NULLの場合はグローバルロール']
   role       varchar [note: 'admin / member / guest など']
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp
 
   indexes {
-    (user_id, role) [unique]
+    (user_id, team_id, role) [unique]
   }
 }
 
 Table recurring_meetings {
-  Note: '定例会議の定義。cron形式のスケジュールを持ち、個別のmeetingを繰り返し生成する元になる'
+  Note: '定例会議の定義。cron形式のスケジュールを持ち、個別のmeetingを繰り返し生成する元になる。チームに複数の定例を持てる'
   id            uuid [pk]
+  team_id       uuid [ref: > teams.id]
   title         varchar
   description   text
   schedule_cron varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
@@ -36,10 +63,11 @@ Table recurring_meetings {
 }
 
 Table recurring_meeting_members {
-  Note: '定例会議のデフォルトメンバー。この一覧をもとにmeeting_attendeesが自動生成される'
+  Note: '定例会議のデフォルトメンバー。roleにより閲覧・編集・管理を制御し、この一覧をもとにmeeting_attendeesが自動生成される'
   id                   uuid [pk]
   recurring_meeting_id uuid [ref: > recurring_meetings.id]
   user_id              uuid [ref: > users.id]
+  role                 varchar [note: 'owner / member / viewer']
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -85,6 +85,7 @@ Table meetings {
   scheduled_at         timestamp
   status               varchar [note: 'scheduled / done / canceled']
   processing_status    varchar [note: 'pending / analyzing / review_waiting / completed / failed']
+  summary              text [note: 'AIが生成した会議要約。NULLの場合は未生成']
   transcription        text [note: '文字起こし本文']
   created_at           timestamp
   updated_at           timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -214,6 +214,7 @@ Table decision_items {
   planned_meeting_id   uuid [ref: > meetings.id, note: 'どの会議で議題に上げるか。status = open のときに使用']
   decided_at           timestamp [note: 'status = decided になった日時']
   decided_by           uuid [ref: > users.id, note: '最後に decided に変更したユーザー']
+  version              int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
@@ -251,6 +252,7 @@ Table tasks {
   due_date       timestamp [note: '完了期限']
   start_date     timestamp [note: '着手予定日。NULLの場合は未設定']
   follow_up_date timestamp [note: '再検討日。期限が決められない場合にいつ期限を決め直すかを記録']
+  version        int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
   created_at     timestamp
   updated_at     timestamp
   deleted_at     timestamp
@@ -288,6 +290,7 @@ Table ambiguous_info {
   resolution_type              varchar [note: 'null = 未解消 / task / decision_item / discarded']
   resolved_to_task_id          uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
   resolved_to_decision_item_id uuid [ref: > decision_items.id, note: 'resolution_type = decision_item のときのみ値が入る']
+  version                      int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -182,6 +182,8 @@ Table decision_items {
   meeting_id           uuid [ref: > meetings.id, note: '発生元の会議']
   title                varchar
   body                 text
+  source_quote         text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
+  source_context       text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
   status               varchar [note: 'draft / reviewing / open / decided / cancelled']
   decision_deadline    timestamp [note: 'いつまでに決めるか。status = open のときに使用']
   planned_meeting_id   uuid [ref: > meetings.id, note: 'どの会議で議題に上げるか。status = open のときに使用']
@@ -213,6 +215,8 @@ Table tasks {
   decision_item_id   uuid [ref: > decision_items.id, note: 'NULLの場合はdecision_itemに紐づかない独立したタスク']
   title          varchar
   body           text
+  source_quote   text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
+  source_context text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
   status         varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
   due_date       timestamp [note: '完了期限']
   start_date     timestamp [note: '着手予定日。NULLの場合は未設定']
@@ -241,6 +245,8 @@ Table ambiguous_info {
   id                           uuid [pk]
   meeting_id                   uuid [ref: > meetings.id]
   body                         text
+  source_quote                 text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
+  source_context               text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
   status                       varchar [note: 'draft / reviewing / resolved / rejected']
   resolution_type              varchar [note: 'null = 未解消 / task / decision_item / discarded']
   resolved_to_task_id          uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -91,6 +91,11 @@ Table meetings {
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
+
+  indexes {
+    recurring_meeting_id
+    scheduled_at
+  }
 }
 
 Table meeting_attendees {
@@ -121,6 +126,11 @@ Table topic_requests {
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
+
+  indexes {
+    meeting_id
+    recurring_meeting_id
+  }
 }
 
 Table agenda_generation_batches {
@@ -131,6 +141,11 @@ Table agenda_generation_batches {
   generated_by         varchar [note: 'ai / human']
   created_by           uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
   created_at           timestamp
+
+  indexes {
+    meeting_id
+    recurring_meeting_id
+  }
 }
 
 Table agenda_items {
@@ -148,6 +163,10 @@ Table agenda_items {
   created_at              timestamp
   updated_at              timestamp
   deleted_at              timestamp
+
+  indexes {
+    generation_batch_id
+  }
 }
 
 Table meeting_agenda_items {
@@ -175,6 +194,10 @@ Table meeting_materials {
   created_at  timestamp
   updated_at  timestamp
   deleted_at  timestamp
+
+  indexes {
+    meeting_id
+  }
 }
 
 Table decision_items {
@@ -193,6 +216,11 @@ Table decision_items {
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
+
+  indexes {
+    meeting_id
+    status
+  }
 }
 
 Table decision_item_assignees {
@@ -225,6 +253,13 @@ Table tasks {
   created_at     timestamp
   updated_at     timestamp
   deleted_at     timestamp
+
+  indexes {
+    meeting_id
+    decision_item_id
+    due_date
+    start_date
+  }
 }
 
 Table task_assignees {
@@ -255,6 +290,11 @@ Table ambiguous_info {
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
+
+  indexes {
+    meeting_id
+    status
+  }
 }
 
 Table audit_logs {
@@ -267,6 +307,11 @@ Table audit_logs {
   before_value  json
   after_value   json
   created_at    timestamp
+
+  indexes {
+    (resource_type, resource_id)
+    actor_id
+  }
 }
 
 Table read_logs {

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -1,0 +1,188 @@
+Table users {
+  id          uuid [pk]
+  external_id varchar [unique, note: 'Entra IDのユーザーID']
+  provider    varchar [note: 'microsoft など']
+  name        varchar
+  email       varchar [unique]
+  created_at  timestamp
+  updated_at  timestamp
+  deleted_at  timestamp
+}
+
+Table user_roles {
+  id         uuid [pk]
+  user_id    uuid [ref: > users.id]
+  role       varchar [note: 'admin / member / guest など']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table recurring_meetings {
+  id            uuid [pk]
+  title         varchar
+  description   text
+  schedule_cron varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}
+
+Table recurring_meeting_members {
+  id                   uuid [pk]
+  recurring_meeting_id uuid [ref: > recurring_meetings.id]
+  user_id              uuid [ref: > users.id]
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table meetings {
+  id                   uuid [pk]
+  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は単発の会議']
+  title                varchar
+  scheduled_at         timestamp
+  status               varchar [note: 'scheduled / done / canceled']
+  transcription        text [note: '文字起こし本文']
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table meeting_attendees {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  user_id    uuid [ref: > users.id]
+  status     varchar [note: 'proposed / invited / accepted / declined / attended / absent']
+  is_default boolean [note: 'true = 定例メンバー / false = 今回だけの参加']
+  invited_by uuid [ref: > users.id, note: 'NULLの場合はAIによる提案']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table topic_requests {
+  id           uuid [pk]
+  meeting_id   uuid [ref: > meetings.id]
+  requested_by uuid [ref: > users.id]
+  title        varchar
+  body         text
+  created_at   timestamp
+  updated_at   timestamp
+  deleted_at   timestamp
+}
+
+Table agenda_items {
+  id                uuid [pk]
+  title             varchar
+  body              text
+  source_type       varchar [note: 'ai / human / carried_over']
+  status            varchar [note: 'pending / approved / rejected']
+  origin_meeting_id uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
+  created_by        uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
+  modified_by       uuid [ref: > users.id, note: 'NULLの場合は修正なし']
+  created_at        timestamp
+  updated_at        timestamp
+  deleted_at        timestamp
+}
+
+Table meeting_agenda_items {
+  id             uuid [pk]
+  meeting_id     uuid [ref: > meetings.id]
+  agenda_item_id uuid [ref: > agenda_items.id]
+  order_index    int
+  created_at     timestamp
+  updated_at     timestamp
+  deleted_at     timestamp
+}
+
+Table meeting_materials {
+  id          uuid [pk]
+  meeting_id  uuid [ref: > meetings.id]
+  uploaded_by uuid [ref: > users.id]
+  file_name   varchar
+  file_url    varchar
+  uploaded_at timestamp
+  created_at  timestamp
+  updated_at  timestamp
+  deleted_at  timestamp
+}
+
+Table issues {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  title      varchar
+  body       text
+  status     varchar [note: 'draft / reviewing / open / rejected / resolved / cancelled']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table issue_assignees {
+  id         uuid [pk]
+  issue_id   uuid [ref: > issues.id]
+  user_id    uuid [ref: > users.id]
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table tasks {
+  id         uuid [pk]
+  meeting_id uuid [ref: > meetings.id]
+  issue_id   uuid [ref: > issues.id, note: 'NULLの場合は課題に紐づかない独立したタスク']
+  title      varchar
+  body       text
+  status     varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
+  due_date   timestamp
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table task_assignees {
+  id         uuid [pk]
+  task_id    uuid [ref: > tasks.id]
+  user_id    uuid [ref: > users.id]
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+}
+
+Table ambiguous_info {
+  id                   uuid [pk]
+  meeting_id           uuid [ref: > meetings.id]
+  body                 text
+  status               varchar [note: 'draft / reviewing / resolved / rejected']
+  resolution_type      varchar [note: 'null = 未解決 / task / issue / discarded']
+  resolved_to_task_id  uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
+  resolved_to_issue_id uuid [ref: > issues.id, note: 'resolution_type = issue のときのみ値が入る']
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table audit_logs {
+  id            uuid [pk]
+  actor_id      uuid [ref: > users.id]
+  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_id   uuid
+  action        varchar [note: 'create / update / delete']
+  before_value  json
+  after_value   json
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}
+
+Table read_logs {
+  id            uuid [pk]
+  user_id       uuid [ref: > users.id]
+  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_id   uuid
+  read_at       timestamp
+  created_at    timestamp
+  updated_at    timestamp
+  deleted_at    timestamp
+}

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -84,6 +84,7 @@ Table meetings {
   title                varchar
   scheduled_at         timestamp
   status               varchar [note: 'scheduled / done / canceled']
+  processing_status    varchar [note: 'pending / analyzing / review_waiting / completed / failed']
   transcription        text [note: '文字起こし本文']
   created_at           timestamp
   updated_at           timestamp
@@ -108,31 +109,43 @@ Table meeting_attendees {
 }
 
 Table topic_requests {
-  Note: '人間が会議に対して入力する議題リクエスト。AIによるagenda_items生成のインプットになる'
-  id           uuid [pk]
-  meeting_id   uuid [ref: > meetings.id]
-  requested_by uuid [ref: > users.id]
-  title        varchar
-  body         text
-  created_at   timestamp
-  updated_at   timestamp
-  deleted_at   timestamp
+  Note: '人間が会議に対して入力する議題リクエスト。AIによるagenda_items生成のインプットになる。meeting_idとrecurring_meeting_idのどちらか一方が必須'
+  id                   uuid [pk]
+  meeting_id           uuid [ref: > meetings.id, note: 'NULLの場合はrecurring_meeting向けリクエスト']
+  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は特定会議向けリクエスト']
+  requested_by         uuid [ref: > users.id]
+  title                varchar
+  body                 text
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
+}
+
+Table agenda_generation_batches {
+  Note: 'アジェンダの生成バッチ。再生成のたびに1レコード追加され、最新バッチ（created_at最大）が現在のアジェンダとなる。過去バッチを参照することで履歴閲覧・復元が可能'
+  id                   uuid [pk]
+  meeting_id           uuid [ref: > meetings.id, note: 'NULLの場合はrecurring_meeting向けバッチ']
+  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は特定会議向けバッチ']
+  generated_by         varchar [note: 'ai / human']
+  created_by           uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
+  created_at           timestamp
 }
 
 Table agenda_items {
-  Note: 'AIまたは人間が作成するアジェンダ。会議をまたいで持ち越しが可能で、meeting_agenda_itemsで会議と紐づく'
-  id                 uuid [pk]
-  title              varchar
-  body               text
-  source_type        varchar [note: 'ai / human / carried_over']
-  status             varchar [note: 'pending / approved / rejected']
-  topic_request_id   uuid [ref: > topic_requests.id, note: 'NULLの場合はtopic_requestに基づかない生成']
-  origin_meeting_id  uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
-  created_by         uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
-  modified_by        uuid [ref: > users.id, note: 'NULLの場合は修正なし']
-  created_at         timestamp
-  updated_at         timestamp
-  deleted_at         timestamp
+  Note: 'AIまたは人間が作成するアジェンダ。generation_batch_idで生成バッチと紐づき、会議をまたいで持ち越しが可能'
+  id                      uuid [pk]
+  generation_batch_id     uuid [ref: > agenda_generation_batches.id, note: 'NULLの場合はバッチに属さない手動作成']
+  title                   varchar
+  body                    text
+  source_type             varchar [note: 'ai / human / carried_over']
+  status                  varchar [note: 'pending / approved / rejected']
+  topic_request_id        uuid [ref: > topic_requests.id, note: 'NULLの場合はtopic_requestに基づかない生成']
+  origin_meeting_id       uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
+  created_by              uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
+  modified_by             uuid [ref: > users.id, note: 'NULLの場合は修正なし']
+  created_at              timestamp
+  updated_at              timestamp
+  deleted_at              timestamp
 }
 
 Table meeting_agenda_items {
@@ -197,13 +210,15 @@ Table tasks {
   id                 uuid [pk]
   meeting_id         uuid [ref: > meetings.id]
   decision_item_id   uuid [ref: > decision_items.id, note: 'NULLの場合はdecision_itemに紐づかない独立したタスク']
-  title      varchar
-  body       text
-  status     varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
-  due_date   timestamp
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+  title          varchar
+  body           text
+  status         varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
+  due_date       timestamp [note: '完了期限']
+  start_date     timestamp [note: '着手予定日。NULLの場合は未設定']
+  follow_up_date timestamp [note: '再検討日。期限が決められない場合にいつ期限を決め直すかを記録']
+  created_at     timestamp
+  updated_at     timestamp
+  deleted_at     timestamp
 }
 
 Table task_assignees {

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -196,8 +196,6 @@ Table audit_logs {
   before_value  json
   after_value   json
   created_at    timestamp
-  updated_at    timestamp
-  deleted_at    timestamp
 }
 
 Table read_logs {
@@ -207,6 +205,4 @@ Table read_logs {
   resource_id   uuid
   read_at       timestamp
   created_at    timestamp
-  updated_at    timestamp
-  deleted_at    timestamp
 }

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -16,6 +16,10 @@ Table user_roles {
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp
+
+  indexes {
+    (user_id, role) [unique]
+  }
 }
 
 Table recurring_meetings {
@@ -35,6 +39,10 @@ Table recurring_meeting_members {
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
+
+  indexes {
+    (recurring_meeting_id, user_id) [unique]
+  }
 }
 
 Table meetings {
@@ -59,6 +67,10 @@ Table meeting_attendees {
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp
+
+  indexes {
+    (meeting_id, user_id) [unique]
+  }
 }
 
 Table topic_requests {
@@ -94,6 +106,10 @@ Table meeting_agenda_items {
   created_at     timestamp
   updated_at     timestamp
   deleted_at     timestamp
+
+  indexes {
+    (meeting_id, agenda_item_id) [unique]
+  }
 }
 
 Table meeting_materials {
@@ -126,6 +142,10 @@ Table issue_assignees {
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp
+
+  indexes {
+    (issue_id, user_id) [unique]
+  }
 }
 
 Table tasks {
@@ -148,6 +168,10 @@ Table task_assignees {
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp
+
+  indexes {
+    (task_id, user_id) [unique]
+  }
 }
 
 Table ambiguous_info {

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -134,37 +134,41 @@ Table meeting_materials {
   deleted_at  timestamp
 }
 
-Table issues {
-  Note: '会議から抽出された課題。ドラフト→レビュー→オープン→解決/却下のライフサイクルを持つ'
-  id         uuid [pk]
-  meeting_id uuid [ref: > meetings.id]
-  title      varchar
-  body       text
-  status     varchar [note: 'draft / reviewing / open / rejected / resolved / cancelled']
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+Table decision_items {
+  Note: '会議から抽出された決定事項・未決事項。open（未決）⇔ decided（決定）のサイクルを持ち、再開も表現できる。決定期限・予定会議を持つことで未決事項の追跡も可能'
+  id                   uuid [pk]
+  meeting_id           uuid [ref: > meetings.id, note: '発生元の会議']
+  title                varchar
+  body                 text
+  status               varchar [note: 'draft / reviewing / open / decided / cancelled']
+  decision_deadline    timestamp [note: 'いつまでに決めるか。status = open のときに使用']
+  planned_meeting_id   uuid [ref: > meetings.id, note: 'どの会議で議題に上げるか。status = open のときに使用']
+  decided_at           timestamp [note: 'status = decided になった日時']
+  decided_by           uuid [ref: > users.id, note: '最後に decided に変更したユーザー']
+  created_at           timestamp
+  updated_at           timestamp
+  deleted_at           timestamp
 }
 
-Table issue_assignees {
-  Note: '課題の担当者。1つの課題に複数の担当者を紐づけられるよう中間テーブルとして管理する'
-  id         uuid [pk]
-  issue_id   uuid [ref: > issues.id]
-  user_id    uuid [ref: > users.id]
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+Table decision_item_assignees {
+  Note: '決定事項・未決事項の担当者。1つのdecision_itemに複数の担当者を紐づけられるよう中間テーブルとして管理する'
+  id                 uuid [pk]
+  decision_item_id   uuid [ref: > decision_items.id]
+  user_id            uuid [ref: > users.id]
+  created_at         timestamp
+  updated_at         timestamp
+  deleted_at         timestamp
 
   indexes {
-    (issue_id, user_id) [unique]
+    (decision_item_id, user_id) [unique]
   }
 }
 
 Table tasks {
-  Note: '会議から抽出されたタスク。issueに紐づく場合と、issueに紐づかない独立したタスクの両方を表現できる'
-  id         uuid [pk]
-  meeting_id uuid [ref: > meetings.id]
-  issue_id   uuid [ref: > issues.id, note: 'NULLの場合は課題に紐づかない独立したタスク']
+  Note: '会議から抽出されたタスク。decision_itemに紐づく場合と、紐づかない独立したタスクの両方を表現できる'
+  id                 uuid [pk]
+  meeting_id         uuid [ref: > meetings.id]
+  decision_item_id   uuid [ref: > decision_items.id, note: 'NULLの場合はdecision_itemに紐づかない独立したタスク']
   title      varchar
   body       text
   status     varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
@@ -189,14 +193,14 @@ Table task_assignees {
 }
 
 Table ambiguous_info {
-  Note: '会議中に発生した曖昧な情報。resolution_typeによってタスク・課題への解消、または対応不要の棄却を管理する'
-  id                   uuid [pk]
-  meeting_id           uuid [ref: > meetings.id]
-  body                 text
-  status               varchar [note: 'draft / reviewing / resolved / rejected']
-  resolution_type      varchar [note: 'null = 未解決 / task / issue / discarded']
-  resolved_to_task_id  uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
-  resolved_to_issue_id uuid [ref: > issues.id, note: 'resolution_type = issue のときのみ値が入る']
+  Note: '会議中に発生した曖昧な情報。resolution_typeによってタスク・決定事項未決事項への解消、または対応不要の棄却を管理する'
+  id                           uuid [pk]
+  meeting_id                   uuid [ref: > meetings.id]
+  body                         text
+  status                       varchar [note: 'draft / reviewing / resolved / rejected']
+  resolution_type              varchar [note: 'null = 未解消 / task / decision_item / discarded']
+  resolved_to_task_id          uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
+  resolved_to_decision_item_id uuid [ref: > decision_items.id, note: 'resolution_type = decision_item のときのみ値が入る']
   created_at           timestamp
   updated_at           timestamp
   deleted_at           timestamp
@@ -206,7 +210,7 @@ Table audit_logs {
   Note: '各リソースへの操作履歴。変更前後の値をJSONで保持する追記専用の不変ログ'
   id            uuid [pk]
   actor_id      uuid [ref: > users.id]
-  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_type varchar [note: 'task / decision_item / ambiguous_info など']
   resource_id   uuid
   action        varchar [note: 'create / update / delete']
   before_value  json
@@ -218,7 +222,7 @@ Table read_logs {
   Note: 'ユーザーによるリソースの既読履歴。未読バッジ表示などの既読管理に使用する追記専用の不変ログ'
   id            uuid [pk]
   user_id       uuid [ref: > users.id]
-  resource_type varchar [note: 'task / issue / ambiguous_info など']
+  resource_type varchar [note: 'task / decision_item / ambiguous_info など']
   resource_id   uuid
   read_at       timestamp
   created_at    timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -86,6 +86,7 @@ Table meetings {
   scheduled_at         timestamp
   status               varchar [note: 'scheduled / done / canceled']
   processing_status    varchar [note: 'pending / analyzing / review_waiting / completed / failed']
+  processing_error     text [note: 'processing_status = failed のときのエラー詳細。NULLの場合は正常']
   summary              text [note: 'AIが生成した会議要約。NULLの場合は未生成']
   transcription        text [note: '文字起こし本文']
   created_at           timestamp

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -56,8 +56,9 @@ Table recurring_meetings {
   team_id       uuid [ref: > teams.id]
   title         varchar
   description   text
-  schedule_cron varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
-  created_at    timestamp
+  schedule_cron     varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
+  agenda_lead_days  int [note: 'アジェンダを何日前に自動生成するか。デフォルト3']
+  created_at        timestamp
   updated_at    timestamp
   deleted_at    timestamp
 }


### PR DESCRIPTION
## 概要

Decision Loop の MVP に必要な DB 設計を DBML で定義する。
Issue #49（設計全体）・#50（画面設計）・#51（レビューUX）・#52（DB設計）の議論を経て、
画面要件・AI処理フロー・レビュー操作に対応したスキーマを構築した。

## テーブル構成

| テーブル | 役割 |
|---|---|
| teams / team_members | チームと権限管理 |
| users / user_roles | ユーザー・ロール（Entra ID連携） |
| recurring_meetings / recurring_meeting_members | 定例会議の定義とメンバー |
| meetings / meeting_attendees | 個別会議と参加者 |
| topic_requests | 人間が入力する次回議題リクエスト |
| agenda_generation_batches | アジェンダ生成バッチ（履歴管理） |
| agenda_items / meeting_agenda_items | アジェンダと会議への紐づけ |
| meeting_materials | 会議添付資料 |
| decision_items / decision_item_assignees | 決定事項・未決事項と担当者 |
| tasks / task_assignees | タスクと担当者 |
| ambiguous_info | 曖昧箇所と解消先 |
| audit_logs / read_logs | 操作履歴・既読管理 |

## 主な設計変更

### 認証・ロール
- パスワードハッシュを削除し、Entra ID などの外部 IdP に認証を移譲
- `user_roles` を中間テーブルとして切り出し（1ユーザー複数ロール・グローバルとチームスコープを区別）

### 定例会議
- `schedule_cron` でデフォルトスケジュールを cron 形式で保持
- `agenda_lead_days`: アジェンダを何日前に自動生成するか（定例ごとに設定可能）

### 会議処理状態の分離
- `meetings.status`: 会議の開催状態（scheduled / done / canceled）
- `meetings.processing_status`: AI 処理状態（pending / analyzing / review_waiting / completed / failed）
- `meetings.processing_error`: AI 処理失敗時のエラー詳細
- `meetings.summary`: AI が生成した会議要約

### アジェンダ履歴管理
- `topic_requests`: 人間が入力する議題リクエスト（特定会議向け・次回会議向けの両方に対応）
- `agenda_generation_batches`: 再生成のたびに1レコード追加。最新バッチが現在のアジェンダ
- `agenda_items.generation_batch_id`: バッチとの紐づけ
- `topic_requests / agenda_generation_batches` は `meeting_id` または `recurring_meeting_id` の
  どちらか一方が必須（次回会議インスタンス未生成時のリクエストに対応）

### 決定事項・未決事項
- `decision_items` で決定（decided）・未決（open）の両状態を管理
- `decision_deadline`: いつまでに決めるか
- `planned_meeting_id`: どの会議で議題に上げるか
- `source_quote / source_context`: AI 根拠文脈（レビュー画面の折りたたみ表示に使用）

### タスク
- `due_date`: 完了期限
- `start_date`: 着手予定日（今週のタスク表示条件に使用）
- `follow_up_date`: 再検討日（期限が決められない場合のネクストアクション）
- `source_quote / source_context`: AI 根拠文脈
- `task_assignees` で複数担当者に対応

### 曖昧箇所
- `ambiguous_info.resolution_type`: タスク / 決定事項（未決） / 破棄 への振り分け先を管理
- `source_quote / source_context`: AI 根拠文脈（レビュー必須カテゴリのためスキップ不可）

### 楽観的ロック
- `decision_items / tasks / ambiguous_info` に `version int` を追加
- UPDATE 時に `WHERE version = :expected` を条件に加え、0件更新の場合は 409 Conflict を返す
- 複数人が同時にレビュー画面を操作した場合の競合を防ぐ

### インデックス
主要クエリパス（定例の会議一覧・レビュー待ち件数・今週のタスク・監査ログ検索）をカバーする
インデックスをすべての FK カラムに追加

### 履歴・監査
- `audit_logs`: AI 提案（create）・人間修正（update）を統合管理
- `read_logs`: 汎用の既読管理

## 設計上の判断

- AI は自動確定しない。すべての抽出結果はレビューを経て確定する
- 曖昧箇所のみレビューをスキップ不可。決定事項・タスク・未決事項はスキップ可
- アジェンダ差分表示はMVP外。バッチ管理により履歴閲覧・復元は可能
- `audit_logs` に AI 提案と人間修正の差分を統合することでレビュー履歴を追跡可能

## 関連 Issue

- #50 画面・ユーザーフロー
- #51 AI提案・レビュー体験
- #52 DB設計
- #54 API設計方針（集計・トランザクション・認可）