### PR TITLE
feat(fake-auth): API用ログインエンドポイントを追加

### DIFF
--- a/services/fake-auth/src/index.ts
+++ b/services/fake-auth/src/index.ts
@@ -3,7 +3,13 @@ import { join } from "node:path";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { SignJWT, exportJWK, importPKCS8, importSPKI } from "jose";
-import { createUser, getAllUsers, getUserByKey } from "./users.js";
+import {
+  createUser,
+  getAllUsers,
+  getUserByEmail,
+  getUserByKey,
+  type FakeUser,
+} from "./users.js";
 
 const app = new Hono();
 
@@ -16,6 +22,27 @@ const ISSUER = process.env.ISSUER ?? "http://localhost:3007";
 
 async function getPrivateKey() {
   return await importPKCS8(privateKeyPem, "RS256");
+}
+
+async function generateIdToken(
+  user: FakeUser,
+  nonce: string,
+): Promise<string> {
+  const privateKey = await getPrivateKey();
+
+  return await new SignJWT({
+    sub: user.id,
+    email: user.email,
+    email_verified: user.emailVerified,
+    name: user.name,
+    nonce: nonce,
+  })
+    .setProtectedHeader({ alg: "RS256", kid: KEY_ID })
+    .setIssuedAt()
+    .setIssuer(ISSUER)
+    .setAudience("fake-auth-client")
+    .setExpirationTime("24h")
+    .sign(privateKey);
 }
 
 // OIDC Discovery
@@ -133,21 +160,7 @@ app.post("/authorize", async (c) => {
     return c.text("Invalid user", 400);
   }
 
-  const privateKey = await getPrivateKey();
-
-  const idToken = await new SignJWT({
-    sub: user.id,
-    email: user.email,
-    email_verified: user.emailVerified,
-    name: user.name,
-    nonce: nonce,
-  })
-    .setProtectedHeader({ alg: "RS256", kid: KEY_ID })
-    .setIssuedAt()
-    .setIssuer(ISSUER)
-    .setAudience("fake-auth-client")
-    .setExpirationTime("24h")
-    .sign(privateKey);
+  const idToken = await generateIdToken(user, nonce);
 
   // Redirect with fragment (implicit flow style)
   const redirectUrl = new URL(redirectUri);
@@ -163,6 +176,33 @@ app.post("/authorize", async (c) => {
 app.get("/users", (c) => {
   const usersList = getAllUsers().map(([key, user]) => ({ key, ...user }));
   return c.json(usersList);
+});
+
+// ログイン（API用）
+app.post("/login", async (c) => {
+  const body = await c.req.json<{
+    userKey?: string;
+    email?: string;
+  }>();
+
+  if (!body.userKey && !body.email) {
+    return c.json({ error: "userKey または email が必要です" }, 400);
+  }
+
+  const user = body.userKey
+    ? getUserByKey(body.userKey)
+    : getUserByEmail(body.email!);
+
+  if (!user) {
+    return c.json({ error: "ユーザーが見つかりません" }, 404);
+  }
+
+  const idToken = await generateIdToken(user, "");
+
+  return c.json({
+    id_token: idToken,
+    expires_in: 86400, // 24時間（秒）
+  });
 });
 
 // アカウント作成

--- a/services/fake-auth/src/users.ts
+++ b/services/fake-auth/src/users.ts
@@ -44,6 +44,10 @@ export function getAllUsers(): [string, FakeUser][] {
   return Object.entries(users);
 }
 
+export function getUserByEmail(email: string): FakeUser | undefined {
+  return Object.values(users).find((u) => u.email === email);
+}
+
 export interface CreateUserInput {
   email: string;
   name: string;


### PR DESCRIPTION
## 関連Issue
Closes #69

## 概要・目的
SPAやモバイルアプリなどのAPIクライアントから利用可能なJSON形式のログインエンドポイントを追加した。

## 背景
PR #67 でアカウント作成APIを実装したが、ブラウザフォームベースのOIDC Implicit Flow（`/authorize`）のみで、APIクライアントからの利用が困難だった。

## 変更内容
* `POST /login` エンドポイントを追加
  * リクエスト: `{ "userKey": string }` または `{ "email": string }`
  * レスポンス: `{ "id_token": string, "expires_in": number }`
* `users.ts` に `getUserByEmail()` 関数を追加
* IDトークン生成ロジックを `generateIdToken()` 関数に共通化
* 既存の `POST /authorize` も共通化した関数を使用するようリファクタ

## 動作確認手順
1. ブランチをcheckout: `git checkout feat/69-login-api`
2. fake-authサービスを起動: `cd services/fake-auth && npm run dev`
3. ログインAPIをテスト:
   ```bash
   curl -X POST http://localhost:3007/login \
     -H "Content-Type: application/json" \
     -d '{"userKey": "admin"}'
   ```
4. emailでもテスト:
   ```bash
   curl -X POST http://localhost:3007/login \
     -H "Content-Type: application/json" \
     -d '{"email": "admin@example.com"}'
   ```

## スクリーンショット
レスポンス例:
```json
{
  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZha2UtYXV0aC1rZXktMSIsInR5cCI6IkpXVCJ9...",
  "expires_in": 86400
}
```