### PR TITLE
docs(fake-auth): READMEに開発支援APIを追加

### DIFF
--- a/services/fake-auth/README.md
+++ b/services/fake-auth/README.md
@@ -11,6 +11,9 @@ Entra IDのローカルシミュレータとして動作します。
 - ID Token発行 (RS256署名)
 - アカウント作成 API (`POST /users`)
 - ユーザー一覧 API (`GET /users`)
+- APIログイン (`POST /login`)
+- トークン検証 (`POST /verify`)
+- ユーザー情報取得 (`GET /me`)
 
 ## 開発サーバー起動
 
@@ -56,6 +59,99 @@ curl http://localhost:3007/users
 | name | o | - | ユーザー名（キーとしても使用） |
 | displayName | - | name と同値 | 表示名 |
 | roles | - | `["member"]` | ロール配列 |
+
+## APIクライアント用認証フロー
+
+SPAやモバイルアプリなどのAPIクライアント向けに、シンプルなログインAPIを提供している。
+
+```bash
+# ログイン（userKeyまたはemailで認証）
+curl -X POST http://localhost:3007/login \
+  -H "Content-Type: application/json" \
+  -d '{"userKey": "admin"}'
+
+# レスポンス
+{
+  "id_token": "eyJhbGciOiJSUzI1NiIs...",
+  "expires_in": 86400
+}
+```
+
+## 開発支援API
+
+### トークン検証
+
+JWTの内容確認や署名検証を行える。トークンのデバッグに使用する。
+
+```bash
+# トークン検証
+curl -X POST http://localhost:3007/verify \
+  -H "Content-Type: application/json" \
+  -d '{"id_token": "<your-token>"}'
+
+# レスポンス（成功）
+{
+  "valid": true,
+  "payload": {
+    "sub": "1",
+    "email": "admin@example.com",
+    "email_verified": true,
+    "name": "admin",
+    "iss": "http://localhost:3007",
+    "aud": "fake-auth-client",
+    "exp": 1777959344
+  },
+  "header": {
+    "alg": "RS256",
+    "kid": "fake-auth-key-1"
+  }
+}
+
+# レスポンス（失敗）
+{
+  "valid": false,
+  "error": "トークンの検証に失敗しました"
+}
+```
+
+### ユーザー情報取得
+
+Bearerトークンから現在のユーザー情報を取得する。
+
+```bash
+# ユーザー情報取得
+curl http://localhost:3007/me \
+  -H "Authorization: Bearer <your-token>"
+
+# レスポンス
+{
+  "key": "admin",
+  "id": "1",
+  "email": "admin@example.com",
+  "emailVerified": true,
+  "name": "admin",
+  "displayName": "Admin User (管理者)",
+  "roles": ["admin"]
+}
+```
+
+## 独自拡張APIについて
+
+本サービスはOIDC標準エンドポイントに加え、ローカル開発効率向上のための独自APIを提供している。
+
+| エンドポイント | 種別 | 説明 |
+|--------------|------|------|
+| `/.well-known/openid-configuration` | OIDC標準 | Discovery |
+| `/.well-known/jwks.json` | OIDC標準 | JWKS |
+| `/authorize` | OIDC準拠 | ブラウザ認証 |
+| `/login` | **独自拡張** | API用簡易ログイン |
+| `/users` | **独自拡張** | ユーザー管理 |
+| `/verify` | **独自拡張** | トークン検証 |
+| `/me` | **独自拡張** | ユーザー情報取得 |
+
+実際のEntra ID移行時は、以下の対応が必要となる場合がある：
+- `/login` → `/token`（Authorization Code Flow）
+- `/me` → `/userinfo`（OIDC標準）
 
 ## APIとの連携
 


### PR DESCRIPTION
## 関連Issue

なし（ドキュメント改善）

## 概要・目的

fake-authの開発支援API（`/login`, `/verify`, `/me`）について、READMEに使い方と注意事項を追加した。

## 背景

PR #70, #73 で開発支援APIを追加したが、READMEに記載がなく開発者が利用方法を把握しにくかった。

## 変更内容

* 機能一覧に `/login`, `/verify`, `/me` を追加（開発支援用として明示）
* APIクライアント用認証フローセクションを追加
  * `POST /login` の使い方とレスポンス例
* 開発支援APIセクションを追加
  * `POST /verify` - トークン検証・デコード
  * `GET /me` - Bearerトークンからユーザー情報取得
* 独自拡張APIについての説明を追加
  * OIDC標準と独自APIの違いを表で明記
  * Entra ID移行時の対応について記載

## 動作確認手順

ドキュメント変更のため、コードの動作確認は不要。

## スクリーンショット

なし

## 特に見てほしい箇所

* 独自拡張APIの説明が適切か
* Entra ID移行時の注意点の記載が正確か