### PR TITLE
fix: fake-auth の Dockerfile を workspace 構成に対応

### DIFF
--- a/services/fake-auth/Dockerfile
+++ b/services/fake-auth/Dockerfile
@@ -4,9 +4,13 @@ WORKDIR /app/services/fake-auth
 # pnpmを有効化
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# 依存関係ファイルをコピーしてインストール（キャッシュ効率化）
-COPY services/fake-auth/package.json services/fake-auth/pnpm-lock.yaml* ./
+# ワークスペースのロックファイルをコピー
+COPY pnpm-lock.yaml /app/
 COPY pnpm-workspace.yaml /app/
+COPY package.json /app/
+
+# 依存関係ファイルをコピーしてインストール（キャッシュ効率化）
+COPY services/fake-auth/package.json ./
 RUN pnpm install --frozen-lockfile
 
 # ソースコードと鍵をコピー


### PR DESCRIPTION
## 概要

`make dev` 実行時に fake-auth サービスのビルドが失敗する問題を修正しました。

## 問題

`services/fake-auth/Dockerfile` が monorepo workspace 構成に対応しておらず、`pnpm-lock.yaml` が見つからないエラーが発生していました。

```
ERR_PNPM_NO_LOCKFILE Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
```

## 修正内容

- ルートの `pnpm-lock.yaml`、`pnpm-workspace.yaml`、`package.json` をコンテナにコピーするよう変更
- これにより workspace 全体の依存関係を正しく解決できるようになった

## 動作確認方法

```bash
make dev
```

## 関連Issue

Closes #77