### PR TITLE
fix(web): VITE_FAKE_AUTH_URL のデフォルト値が PROD ビルドに紛れ込まないようガードする

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,12 @@
+# =====================
+# Vite (web) 環境変数
+# =====================
+# `apps/web/` ディレクトリで `vite` 起動時に読み込まれる。
+# クライアント側に露出するため、機密情報を入れないこと。
+
+# fake-auth (OIDC Provider) のオリジン。
+# - 開発時 (vite dev): 未設定なら http://localhost:3007 にフォールバック。
+# - 本番ビルド時 (vite build with PROD): 未設定だとビルド成果物の起動時に
+#   "Required Vite env \"VITE_FAKE_AUTH_URL\" is not set." を throw する。
+# 本番では Entra ID 等の OIDC プロバイダのオリジンに置き換える前提。
+VITE_FAKE_AUTH_URL="http://localhost:3007"

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -4,9 +4,18 @@
 // 値を返す。
 
 export function readRequiredViteEnv(
-  _key: string,
-  _devFallback: string,
-  _env: ImportMetaEnv = import.meta.env,
+  key: string,
+  devFallback: string,
+  env: ImportMetaEnv = import.meta.env,
 ): string {
-  throw new Error("not implemented");
+  const value = env[key];
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (env.PROD) {
+    throw new Error(
+      `Required Vite env "${key}" is not set. Set it before building for production.`,
+    );
+  }
+  return devFallback;
 }

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,0 +1,12 @@
+// Vite の import.meta.env を介した環境変数読み出しの薄いラッパ。
+// PROD ビルド時の必須変数の取り漏れを早期検知するため、未設定なら
+// throw して fail-fast する。DEV 時は開発の利便性のためフォールバック
+// 値を返す。
+
+export function readRequiredViteEnv(
+  _key: string,
+  _devFallback: string,
+  _env: ImportMetaEnv = import.meta.env,
+): string {
+  throw new Error("not implemented");
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -4,6 +4,7 @@ import {
   saveExpectedAuthParams,
   verifyAndConsumeAuthParams,
 } from "@/lib/auth";
+import { readRequiredViteEnv } from "@/lib/env";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
@@ -12,8 +13,12 @@ export const Route = createFileRoute("/login")({
   component: Login,
 });
 
-const FAKE_AUTH_URL =
-  import.meta.env.VITE_FAKE_AUTH_URL ?? "http://localhost:3007";
+// PROD では未設定だと throw（デプロイ事故の早期検知）。DEV ではローカル
+// fake-auth のデフォルト URL にフォールバックする。
+const FAKE_AUTH_URL = readRequiredViteEnv(
+  "VITE_FAKE_AUTH_URL",
+  "http://localhost:3007",
+);
 
 function Login() {
   const navigate = useNavigate();

--- a/apps/web/src/test/env.test.ts
+++ b/apps/web/src/test/env.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { readRequiredViteEnv } from "../lib/env";
+
+// vitest は `import.meta.env` の差し替えが面倒なため、関数引数として
+// 任意の env を注入できる API に対し、必要最小限のオブジェクトを
+// 組み立てて検証する。
+function buildEnv(overrides: Partial<ImportMetaEnv>): ImportMetaEnv {
+  return {
+    MODE: "test",
+    BASE_URL: "/",
+    DEV: false,
+    PROD: false,
+    SSR: false,
+    ...overrides,
+  } as ImportMetaEnv;
+}
+
+describe("readRequiredViteEnv", () => {
+  it("PROD かつ値が設定されていればその値を返す", () => {
+    const env = buildEnv({
+      PROD: true,
+      VITE_FAKE_AUTH_URL: "https://auth.example.com",
+    });
+
+    expect(
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toBe("https://auth.example.com");
+  });
+
+  it("PROD かつ未設定なら key 名を含む Error を throw する", () => {
+    const env = buildEnv({ PROD: true });
+
+    expect(() =>
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toThrow(/VITE_FAKE_AUTH_URL/);
+  });
+
+  it("PROD かつ空文字は未設定とみなして throw する", () => {
+    const env = buildEnv({ PROD: true, VITE_FAKE_AUTH_URL: "" });
+
+    expect(() =>
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toThrow(/VITE_FAKE_AUTH_URL/);
+  });
+
+  it("DEV かつ値が設定されていればその値を返す", () => {
+    const env = buildEnv({
+      PROD: false,
+      DEV: true,
+      VITE_FAKE_AUTH_URL: "https://staging.example.com",
+    });
+
+    expect(
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toBe("https://staging.example.com");
+  });
+
+  it("DEV かつ未設定なら devFallback を返す", () => {
+    const env = buildEnv({ PROD: false, DEV: true });
+
+    expect(
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toBe("http://localhost:3007");
+  });
+
+  it("DEV かつ空文字も未設定とみなして devFallback を返す", () => {
+    const env = buildEnv({
+      PROD: false,
+      DEV: true,
+      VITE_FAKE_AUTH_URL: "",
+    });
+
+    expect(
+      readRequiredViteEnv("VITE_FAKE_AUTH_URL", "http://localhost:3007", env),
+    ).toBe("http://localhost:3007");
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #79

## 概要・目的
* `VITE_FAKE_AUTH_URL` が未設定のまま PROD ビルドした場合に明示的な `Error` で fail-fast し、ローカル URL がそのまま本番に紛れ込む事故を防ぐ。
* DEV モードの利便性は維持し、未設定時は従来どおり `http://localhost:3007` にフォールバックする。

## 背景
* `apps/web/src/routes/login.tsx` で `import.meta.env.VITE_FAKE_AUTH_URL ?? "http://localhost:3007"` というフォールバックを置いていたが、PROD ビルドでも同じフォールバックが効いてしまい、設定漏れが検知できなかった。
* 本番デプロイ後にローカル URL を踏みに行く事故の温床になり得るため、ビルド時または起動時に「原因が一目で分かる形」で失敗させる必要があった。

## 変更内容
* `apps/web/src/lib/env.ts` を新設し、純粋関数 `readRequiredViteEnv(key, devFallback, env?)` を提供。
  * PROD かつ値が空または未設定 → key 名を含む `Error` を throw。
  * DEV → `devFallback` を返す。
  * `env` 引数で `import.meta.env` を注入可能にし、純粋関数として単体テストできる形にしている。
* `apps/web/src/routes/login.tsx` の `FAKE_AUTH_URL` 取得を `readRequiredViteEnv` 経由に置き換え。
* `apps/web/.env.example` を新設し、`VITE_FAKE_AUTH_URL` の役割と DEV/PROD の挙動差を明示。
* `apps/web/src/test/env.test.ts` に PROD/DEV × 値あり/空/未設定 の 6 ケースを追加（カバレッジ 100%）。

## 動作確認手順

### 1. 依存セットアップ（初回のみ）
```bash
make install
make fake-auth-keys
```

### 2. テスト・Lint
```bash
make test    # web 含む全パッケージで実行。web は新規 6 ケース込みの 40 テストすべて GREEN になる
make lint    # biome / ruff いずれもエラーなしで完了する
```

### 3. DEV モードでフォールバックが効くこと（従来挙動の維持）
1. `apps/web/.env` を作らない状態で `make dev-native` を実行する。
2. http://localhost:5173 を開く。
3. 認証ガードで `/login` にリダイレクトされ、続いて `http://localhost:3007/authorize?...`（fake-auth）に遷移する。`VITE_FAKE_AUTH_URL` 未設定でも `http://localhost:3007` にフォールバックすることを確認する。
4. ユーザーを選択してログインすると `/` に戻る。

### 4. PROD ビルドで未設定が `Error` になること（Makefile 未対応のため pnpm 直接実行）
```bash
# 未設定でビルド・プレビュー
pnpm --filter web build
pnpm --filter web preview
```
- http://localhost:4173 を開いて `/login` に遷移すると、ブラウザコンソールに以下の `Error` が出てログインフローが進まないことを確認する:
  - `Required Vite env "VITE_FAKE_AUTH_URL" is not set. Set it before building for production.`

```bash
# env を指定してビルド・プレビュー（正常動作の対照）
VITE_FAKE_AUTH_URL=https://auth.example.com pnpm --filter web build
pnpm --filter web preview
```
- http://localhost:4173 → `/login` で、指定したオリジン `https://auth.example.com/authorize?...` にリダイレクトされることを確認する。

## スクリーンショット
* UI 変更なし。本変更はビルド/起動時の挙動のみで、`/login` の見た目や DEV モードの遷移には影響なし。
