### PR TITLE
refactor(web): authAtom を atomWithStorage 経由で localStorage 真実源に統一

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -6,12 +6,28 @@
 // 移行後も呼び出し側に閉じた変更だけで済むよう、保存実装を内部に隠蔽
 // しておく。
 //
-// 真実源: localStorage を真実源、authAtom を UI 用キャッシュとして扱う。
-// 初期化時のみ getInitialState() で localStorage から復元する設計のため、
-// 他タブからの変更や直接の localStorage 操作で両者が乖離する余地は残る。
-// atomWithStorage 等で根本解消する作業は別途 Issue (#80) で進める。
+// 真実源: localStorage（id_token キー）に一本化する。authAtom はそこから
+// 派生する読み取り専用 atom であり、storage イベント購読により他タブの
+// ログイン／ログアウトにも追従する。書き込みは loginAtom / logoutAtom が
+// 内部の idTokenAtom（atomWithStorage）を介して行うため、UI と localStorage
+// の二重管理は構造的に発生しない。
 
-import { atom } from "jotai";
+import { type Atom, atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+// jotai/utils は SyncStorage 型を public な entry point から再エクスポートして
+// いないため、atomWithStorage が受け付ける形に合わせてローカルで定義する。
+// （raw 文字列を扱う storage を実装するための最小定義に留める）
+type IdTokenStorage = {
+  getItem: (key: string, initialValue: string | null) => string | null;
+  setItem: (key: string, newValue: string | null) => void;
+  removeItem: (key: string) => void;
+  subscribe: (
+    key: string,
+    callback: (value: string | null) => void,
+    initialValue: string | null,
+  ) => (() => void) | undefined;
+};
 
 const ID_TOKEN_KEY = "id_token";
 
@@ -25,18 +41,20 @@ export interface AuthState {
   } | null;
 }
 
+const UNAUTHENTICATED: AuthState = {
+  isAuthenticated: false,
+  idToken: null,
+  user: null,
+};
+
 function getStoredToken(): string | null {
   if (typeof window === "undefined") return null;
   return localStorage.getItem(ID_TOKEN_KEY);
 }
 
-function setStoredToken(token: string | null): void {
+function removeStoredToken(): void {
   if (typeof window === "undefined") return;
-  if (token) {
-    localStorage.setItem(ID_TOKEN_KEY, token);
-  } else {
-    localStorage.removeItem(ID_TOKEN_KEY);
-  }
+  localStorage.removeItem(ID_TOKEN_KEY);
 }
 
 // JWT のペイロードは Base64URL（RFC 7515）でエンコードされており、
@@ -76,51 +94,97 @@ export function parseToken(token: string): AuthState["user"] {
   }
 }
 
+function deriveAuthState(token: string | null): AuthState {
+  if (!token) return UNAUTHENTICATED;
+  const user = parseToken(token);
+  if (!user) return UNAUTHENTICATED;
+  return { isAuthenticated: true, idToken: token, user };
+}
+
 export function getInitialState(): AuthState {
   const token = getStoredToken();
   if (token) {
     const user = parseToken(token);
     if (user) {
-      return {
-        isAuthenticated: true,
-        idToken: token,
-        user,
-      };
+      return { isAuthenticated: true, idToken: token, user };
     }
     // 期限切れ等で復元できないトークンはここで破棄しておくと
     // 次回以降のガードがログインループに陥らない。
-    setStoredToken(null);
+    removeStoredToken();
   }
-  return {
-    isAuthenticated: false,
-    idToken: null,
-    user: null,
-  };
+  return UNAUTHENTICATED;
 }
 
-export const authAtom = atom<AuthState>(getInitialState());
+// raw な id_token 文字列を localStorage に保存するためのカスタムストレージ。
+// jotai/utils 既定の createJSONStorage は値を JSON エンコードするため、
+// 既存レイアウト（プレーン文字列の id_token）との互換が崩れてしまう。
+// subscribe で `storage` イベントを購読し、他タブからの変更を atom に伝搬する。
+const idTokenStorage: IdTokenStorage = {
+  getItem(key, initialValue) {
+    if (typeof window === "undefined") return initialValue;
+    return localStorage.getItem(key);
+  },
+  setItem(key, newValue) {
+    if (typeof window === "undefined") return;
+    if (newValue === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, newValue);
+    }
+  },
+  removeItem(key) {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(key);
+  },
+  subscribe(key, callback, _initialValue) {
+    if (typeof window === "undefined") return undefined;
+    const handler = (e: StorageEvent) => {
+      if (e.storageArea !== localStorage) return;
+      // localStorage.clear() の場合は key=null で発火するため、それも未認証扱い。
+      if (e.key === null || e.key === key) {
+        callback(e.newValue);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  },
+};
+
+// 真実源としての id_token atom（モジュール外には公開しない）。
+// getOnInit:true でモジュール load 時に同期的に localStorage を読み取り、
+// 初期化フェーズで `getInitialState` の挙動と整合させる。
+const idTokenAtom = atomWithStorage<string | null>(
+  ID_TOKEN_KEY,
+  null,
+  idTokenStorage,
+  { getOnInit: true },
+);
+
+// authAtom は idTokenAtom から派生する読み取り専用 atom。
+// localStorage との二重管理を構造的に排除し、storage イベントを介して
+// 他タブの変更にも追従する。
+export const authAtom: Atom<AuthState> = atom((get) =>
+  deriveAuthState(get(idTokenAtom)),
+);
 
 export const loginAtom = atom(null, (_get, set, token: string) => {
-  setStoredToken(token);
-  const user = parseToken(token);
-  set(authAtom, {
-    isAuthenticated: !!user,
-    idToken: token,
-    user,
-  });
+  set(idTokenAtom, token);
 });
 
 export const logoutAtom = atom(null, (_get, set) => {
-  setStoredToken(null);
-  set(authAtom, {
-    isAuthenticated: false,
-    idToken: null,
-    user: null,
-  });
+  set(idTokenAtom, null);
 });
 
 export function getIdToken(): string | null {
-  return getStoredToken();
+  const token = getStoredToken();
+  if (!token) return null;
+  // authAtom は parseToken 検証後の値しか返さないため、getIdToken も
+  // 期限切れトークンを返さないように揃える（読み取り結果の整合性を保つ）。
+  if (!parseToken(token)) {
+    removeStoredToken();
+    return null;
+  }
+  return token;
 }
 
 // ---- OIDC implicit flow の state / nonce 検証 ----------------------------

--- a/apps/web/src/test/auth.test.ts
+++ b/apps/web/src/test/auth.test.ts
@@ -1,12 +1,30 @@
+import { createStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  authAtom,
+  getIdToken,
   getInitialState,
   getTokenNonce,
+  loginAtom,
+  logoutAtom,
   parseToken,
   saveExpectedAuthParams,
   verifyAndConsumeAuthParams,
 } from "../lib/auth";
 import { makeFakeIdToken } from "./helpers/auth";
+
+// 他タブからの localStorage 変更を擬似的に再現するヘルパー。
+// 同一 window 内の localStorage.setItem では storage イベントは発火しないため、
+// dispatchEvent で別タブからの通知を模す。
+function dispatchStorageEvent(key: string | null, newValue: string | null) {
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key,
+      newValue,
+      storageArea: localStorage,
+    }),
+  );
+}
 
 describe("parseToken", () => {
   it("Base64URL エンコードされた多バイト文字ペイロードを復元できる", () => {
@@ -136,6 +154,203 @@ describe("getTokenNonce", () => {
 
   it("不正な形式は null を返す", () => {
     expect(getTokenNonce("not-a-jwt")).toBeNull();
+  });
+});
+
+describe("authAtom（localStorage 真実源・派生 atom）", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("loginAtom 経由で書き込むと localStorage と authAtom の双方が更新される", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+
+    store.set(loginAtom, token);
+
+    expect(localStorage.getItem("id_token")).toBe(token);
+    expect(store.get(authAtom)).toEqual({
+      isAuthenticated: true,
+      idToken: token,
+      user: { sub: "u1", email: "u1@example.com", name: "u1" },
+    });
+  });
+
+  it("logoutAtom 経由で書き込むと localStorage と authAtom の双方が未認証に揃う", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+    store.set(loginAtom, token);
+
+    store.set(logoutAtom);
+
+    expect(localStorage.getItem("id_token")).toBeNull();
+    expect(store.get(authAtom)).toEqual({
+      isAuthenticated: false,
+      idToken: null,
+      user: null,
+    });
+  });
+
+  it("他タブの logout（storage イベント newValue=null）で authAtom が未認証に追従する", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+    store.set(loginAtom, token);
+    // atomWithStorage の subscribe は購読者がいる時のみ有効化されるため、
+    // テストでも store.sub で明示的にサブスクライブする。
+    const unsubscribe = store.sub(authAtom, () => {});
+
+    try {
+      dispatchStorageEvent("id_token", null);
+      expect(store.get(authAtom)).toEqual({
+        isAuthenticated: false,
+        idToken: null,
+        user: null,
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("他タブの login（storage イベント newValue=有効トークン）で authAtom が認証済みに追従する", () => {
+    const store = createStore();
+    const unsubscribe = store.sub(authAtom, () => {});
+
+    try {
+      const token = makeFakeIdToken({
+        sub: "u2",
+        email: "u2@example.com",
+        name: "u2",
+      });
+      // 他タブが localStorage に書き込んだのを模す。同タブの localStorage は
+      // 既に書かれた前提で、storage イベントだけ発火させる。
+      localStorage.setItem("id_token", token);
+      dispatchStorageEvent("id_token", token);
+
+      expect(store.get(authAtom)).toEqual({
+        isAuthenticated: true,
+        idToken: token,
+        user: { sub: "u2", email: "u2@example.com", name: "u2" },
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("storage イベントが期限切れトークンを通知しても authAtom は未認証のままになる", () => {
+    const store = createStore();
+    const unsubscribe = store.sub(authAtom, () => {});
+
+    try {
+      const expired = makeFakeIdToken({
+        sub: "u1",
+        email: "u1@example.com",
+        name: "u1",
+        exp: Math.floor(Date.now() / 1000) - 60,
+      });
+      localStorage.setItem("id_token", expired);
+      dispatchStorageEvent("id_token", expired);
+
+      expect(store.get(authAtom)).toEqual({
+        isAuthenticated: false,
+        idToken: null,
+        user: null,
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("localStorage.clear() 相当の storage イベント（key=null）でも authAtom がクリアされる", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+    store.set(loginAtom, token);
+    const unsubscribe = store.sub(authAtom, () => {});
+
+    try {
+      dispatchStorageEvent(null, null);
+      expect(store.get(authAtom)).toEqual({
+        isAuthenticated: false,
+        idToken: null,
+        user: null,
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("getIdToken と authAtom.idToken が同じ値を返す（整合性）", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+
+    store.set(loginAtom, token);
+    expect(getIdToken()).toBe(token);
+    expect(store.get(authAtom).idToken).toBe(token);
+
+    store.set(logoutAtom);
+    expect(getIdToken()).toBeNull();
+    expect(store.get(authAtom).idToken).toBeNull();
+  });
+});
+
+describe("getIdToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("有効なトークンが localStorage にある場合はそのトークンを返す", () => {
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    localStorage.setItem("id_token", token);
+
+    expect(getIdToken()).toBe(token);
+  });
+
+  it("期限切れトークンは null を返し、localStorage からも除去する", () => {
+    const expired = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    localStorage.setItem("id_token", expired);
+
+    expect(getIdToken()).toBeNull();
+    expect(localStorage.getItem("id_token")).toBeNull();
+  });
+
+  it("トークン未保存時は null を返す", () => {
+    expect(getIdToken()).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #80

## 概要・目的
* `apps/web/src/lib/auth.ts` で `authAtom`（jotai）と `localStorage` が二重の真実源になっていた状態を解消する
* `localStorage` の `id_token` を唯一の真実源とし、`authAtom` をそこから派生する読み取り専用 atom に変更することで、他タブでの login/logout に当該タブの atom 値が追従するようにする

## 背景
* `getInitialState()` はモジュール初回ロード時に 1 回だけ `localStorage` を読み、以後 `loginAtom` / `logoutAtom` が双方を手動同期する設計だった
* 一方 `__root.tsx` の `beforeLoad` ガードや `api.ts` の `authHeaders()` は `getIdToken()` 経由で `localStorage` を直接読むため、UI が将来 `useAtomValue(authAtom)` を増やした瞬間に「他タブで logout 済みなのに atom 側だけ古い値が残る」整合性バグの土台になる
* PR #76 のレビュー（`docs/reviews/login-page-20260505.md` 項目 #4）から派生

## 変更内容
* `apps/web/src/lib/auth.ts`:
  * 内部 `idTokenAtom` を `atomWithStorage<string \| null>` で定義し、真実源を `localStorage` 一本化
  * `jotai/utils` 既定の JSON ストレージは raw 文字列レイアウトと非互換のため、独自 `IdTokenStorage` を実装。`subscribe` 内で `window.addEventListener("storage", ...)` を張り、他タブからの変更を atom に伝搬
  * `authAtom` を `Atom<AuthState>`（読み取り専用）に変更し、`get(idTokenAtom)` を `parseToken` で検証する派生 atom にした
  * `loginAtom` / `logoutAtom` の書き込み経路を `idTokenAtom` 一本化（`set(authAtom, ...)` を撤去）
  * `getIdToken()` に `parseToken` ベースの exp 検証を追加し、期限切れトークン時は `null` を返して `localStorage` からも除去（atom リードと一致）
  * 冒頭コメントを真実源統一後の設計説明に書き換え
* `apps/web/src/test/auth.test.ts`:
  * `authAtom` 派生・loginAtom/logoutAtom 経由の双方向更新・他タブ login/logout（`StorageEvent` 発火）追従・期限切れトークンに対する未認証維持・`localStorage.clear()` 相当の追従・`getIdToken` と `authAtom.idToken` の整合・`getIdToken` 単体の exp 検証 を網羅する 10 件のテストを追加
* 公開 API（`__root.tsx` / `api.ts` / `login.tsx` / `App.test.tsx` の呼び出し方）は不変

## 動作確認手順
1. ブランチを checkout: `git checkout issue-80-auth-localstorage-truth-source`
2. リポジトリルートで `make install` を実行（依存解決）
3. リポジトリルートで `make lint` を実行し、`web` / `api` / `fake-auth` / `services/ai` のすべてが通過することを確認
4. リポジトリルートで `make test` を実行し、`apps/web` の 50/50 GREEN（うち `auth.test.ts` は 24/24）と `services/ai` の 10/10 GREEN を確認
5. 任意: ローカル fake-auth で 2 タブを開き、片方で logout すると他方の `useAtomValue(authAtom)` 結果が `isAuthenticated: false` に追従することを目視確認

## スクリーンショット
* なし（UI 変更なし、内部 API のリファクタリングのみ）
