### PR TITLE
fix(web): hono RPC の型推論エラーを修正（TypeScript 6 対応）

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,10 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    "./types": {
-      "types": "./dist/types.d.ts",
-      "default": "./dist/types.js"
-    }
+    "./types": "./src/types.ts"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    "./types": "./src/types.ts"
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    }
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,10 +1,13 @@
 // hono/client で型安全な API クライアントを生成する際に使用する型
 // 使用例（web 側）:
-//   import type { ClientType } from "api/types";
-import type { hc } from "hono/client";
+//   import { hcWithType } from "api/types";
+//   const client = hcWithType("http://localhost:3001");
+import { hc } from "hono/client";
 import type { AppType } from "./app.js";
 
 export type { AppType };
 
 // コンパイル時に型を確定させるトリック（hono 公式推奨パターン）
 export type ClientType = ReturnType<typeof hc<AppType>>;
+export const hcWithType = (...args: Parameters<typeof hc>): ClientType =>
+  hc<AppType>(...args);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,7 @@
-import type { AppType } from "api/types";
-import { hc } from "hono/client";
+import { hcWithType } from "api/types";
 import { getIdToken } from "./auth";
 
-export const api = hc<AppType>("/api");
+export const api = hcWithType("/api");
 
 export function authHeaders(): { headers: Record<string, string> } {
   const token = getIdToken();

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../api" }
   ]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "api/types": path.resolve(__dirname, "../api/src/types.ts"),
     },
   },
 });


### PR DESCRIPTION
## 関連Issue
dependabot PR #59 #61 #62 #63 #64 の CI TypeCheck FAILURE 修正

## 概要・目的
* TypeScript 6 環境で `hc<AppType>()` の戻り値が `unknown` に推論される問題を修正した。
* hono 公式推奨パターンの `hcWithType` を導入し、`api` 変数が正しく型付けされるようにした。

## 背景
* dependabot が作成した PR #59〜#64 すべてで `Lint & TypeCheck (TypeScript)` が FAILURE になっていた。
* エラー内容は `error TS18046: 'api' is of type 'unknown'.` で、`apps/web/src/routes/index.tsx` や `apps/web/src/test/` で `api.meetings.$get` 等を呼び出す箇所が型エラーになっていた。
* 原因は `hc<AppType>()` の型推論が TypeScript 6 で `unknown` になるバグで、hono の公式 workaround（`hcWithType`）を使うことで解消できる。
* また `web/tsconfig.json` に `api` への project reference がなく、`tsc -b` 実行時に型情報が正しく解決されていなかった。

## 変更内容
* `apps/api/src/types.ts`: `hcWithType` ファクトリ関数を追加（`hc<AppType>` をラップして戻り値型を `ClientType` に固定）
* `apps/web/src/lib/api.ts`: `hc<AppType>` を `hcWithType` に変更
* `apps/api/package.json`: `exports["./types"]` を `dist/types.d.ts` 参照に変更（composite build 対応）
* `apps/web/tsconfig.json`: `../api` への project reference を追加

## 動作確認手順
1. このブランチを checkout
2. `pnpm install` で依存関係をインストール
3. `pnpm --filter api exec prisma generate` を実行
4. `pnpm run typecheck`（turbo 経由）でエラーが出ないことを確認

## スクリーンショット
* なし（型エラー修正のみ）