### PR TITLE
feat(api): 組織・定例の Prisma スキーマとマイグレーションを追加

### DIFF
--- a/apps/api/prisma/migrations/20260506124127_add_organization_models/migration.sql
+++ b/apps/api/prisma/migrations/20260506124127_add_organization_models/migration.sql
@@ -1,0 +1,101 @@
+-- CreateEnum
+CREATE TYPE "OrgRole" AS ENUM ('owner', 'admin', 'member');
+
+-- CreateEnum
+CREATE TYPE "InvitationStatus" AS ENUM ('pending', 'accepted', 'expired');
+
+-- CreateEnum
+CREATE TYPE "MeetingRole" AS ENUM ('owner', 'member');
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationMembership" (
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "role" "OrgRole" NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OrganizationMembership_pkey" PRIMARY KEY ("userId","organizationId")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationInvitation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "invitedBy" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "status" "InvitationStatus" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OrganizationInvitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RecurringMeeting" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "scheduleCron" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringMeeting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MeetingMember" (
+    "recurringMeetingId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "MeetingRole" NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MeetingMember_pkey" PRIMARY KEY ("recurringMeetingId","userId")
+);
+
+-- CreateIndex
+CREATE INDEX "OrganizationMembership_organizationId_idx" ON "OrganizationMembership"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "OrganizationInvitation_email_idx" ON "OrganizationInvitation"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationInvitation_organizationId_email_status_key" ON "OrganizationInvitation"("organizationId", "email", "status");
+
+-- CreateIndex
+CREATE INDEX "RecurringMeeting_organizationId_idx" ON "RecurringMeeting"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "MeetingMember_userId_idx" ON "MeetingMember"("userId");
+
+-- AddForeignKey
+ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationInvitation" ADD CONSTRAINT "OrganizationInvitation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationInvitation" ADD CONSTRAINT "OrganizationInvitation_invitedBy_fkey" FOREIGN KEY ("invitedBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RecurringMeeting" ADD CONSTRAINT "RecurringMeeting_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingMember" ADD CONSTRAINT "MeetingMember_recurringMeetingId_fkey" FOREIGN KEY ("recurringMeetingId") REFERENCES "RecurringMeeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingMember" ADD CONSTRAINT "MeetingMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -24,4 +24,65 @@ model User {
   displayName String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+
+  memberships     OrganizationMembership[]
+  invitationsSent OrganizationInvitation[] @relation("InvitedBy")
+}
+
+// 組織内メンバー権限。owner は組織削除可、admin は招待・編集可、member は閲覧中心。
+enum OrgRole {
+  owner
+  admin
+  member
+}
+
+// 組織への招待状態。pending → accepted/expired のいずれかに遷移する。
+enum InvitationStatus {
+  pending
+  accepted
+  expired
+}
+
+// 組織。所属メンバーと配下定例の親エンティティ。
+model Organization {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  memberships OrganizationMembership[]
+  invitations OrganizationInvitation[]
+}
+
+// 組織への所属。userId × organizationId を複合主キーとする。
+model OrganizationMembership {
+  userId         String
+  organizationId String
+  role           OrgRole
+  joinedAt       DateTime @default(now())
+
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@id([userId, organizationId])
+  @@index([organizationId])
+}
+
+// 組織への招待。inviter は履歴保持のため User 削除時 Restrict。
+// 同一組織への同一メールアドレスの同一 status の招待は重複させない。
+model OrganizationInvitation {
+  id             String           @id @default(cuid())
+  organizationId String
+  email          String
+  invitedBy      String
+  expiresAt      DateTime
+  status         InvitationStatus @default(pending)
+  createdAt      DateTime         @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  inviter      User         @relation("InvitedBy", fields: [invitedBy], references: [id], onDelete: Restrict)
+
+  @@unique([organizationId, email, status])
+  @@index([email])
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
 
   memberships     OrganizationMembership[]
   invitationsSent OrganizationInvitation[] @relation("InvitedBy")
+  meetingMembers  MeetingMember[]
 }
 
 // 組織内メンバー権限。owner は組織削除可、admin は招待・編集可、member は閲覧中心。
@@ -51,8 +52,9 @@ model Organization {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  memberships OrganizationMembership[]
-  invitations OrganizationInvitation[]
+  memberships       OrganizationMembership[]
+  invitations       OrganizationInvitation[]
+  recurringMeetings RecurringMeeting[]
 }
 
 // 組織への所属。userId × organizationId を複合主キーとする。
@@ -85,4 +87,39 @@ model OrganizationInvitation {
 
   @@unique([organizationId, email, status])
   @@index([email])
+}
+
+// 定例会議。組織配下の継続的なミーティング枠。
+model RecurringMeeting {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String
+  description    String?
+  scheduleCron   String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  members      MeetingMember[]
+
+  @@index([organizationId])
+}
+
+// 定例ごとのメンバー。recurringMeetingId × userId を複合主キーとする。
+enum MeetingRole {
+  owner
+  member
+}
+
+model MeetingMember {
+  recurringMeetingId String
+  userId             String
+  role               MeetingRole
+  joinedAt           DateTime    @default(now())
+
+  recurringMeeting RecurringMeeting @relation(fields: [recurringMeetingId], references: [id], onDelete: Cascade)
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([recurringMeetingId, userId])
+  @@index([userId])
 }

--- a/apps/api/test/organization.test.ts
+++ b/apps/api/test/organization.test.ts
@@ -1,0 +1,41 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { afterAll, describe, expect, it } from "vitest";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/decision_loop";
+
+// Prisma 7 は接続にアダプターが必要
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// schema.prisma で定義した組織関連モデルが PrismaClient にデリゲートされているかを検証する
+describe("Organization モデル", () => {
+  it("PrismaClient に organization プロパティが存在する", () => {
+    expect(prisma.organization).toBeDefined();
+    expect(typeof prisma.organization.findMany).toBe("function");
+    expect(typeof prisma.organization.create).toBe("function");
+    expect(typeof prisma.organization.findUnique).toBe("function");
+  });
+});
+
+describe("OrganizationMembership モデル", () => {
+  it("PrismaClient に organizationMembership プロパティが存在する", () => {
+    expect(prisma.organizationMembership).toBeDefined();
+    expect(typeof prisma.organizationMembership.findMany).toBe("function");
+    expect(typeof prisma.organizationMembership.create).toBe("function");
+  });
+});
+
+describe("OrganizationInvitation モデル", () => {
+  it("PrismaClient に organizationInvitation プロパティが存在する", () => {
+    expect(prisma.organizationInvitation).toBeDefined();
+    expect(typeof prisma.organizationInvitation.findMany).toBe("function");
+    expect(typeof prisma.organizationInvitation.create).toBe("function");
+  });
+});

--- a/apps/api/test/recurring-meeting.test.ts
+++ b/apps/api/test/recurring-meeting.test.ts
@@ -1,0 +1,33 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { afterAll, describe, expect, it } from "vitest";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/decision_loop";
+
+// Prisma 7 は接続にアダプターが必要
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// schema.prisma で定義した定例関連モデルが PrismaClient にデリゲートされているかを検証する
+describe("RecurringMeeting モデル", () => {
+  it("PrismaClient に recurringMeeting プロパティが存在する", () => {
+    expect(prisma.recurringMeeting).toBeDefined();
+    expect(typeof prisma.recurringMeeting.findMany).toBe("function");
+    expect(typeof prisma.recurringMeeting.create).toBe("function");
+    expect(typeof prisma.recurringMeeting.findUnique).toBe("function");
+  });
+});
+
+describe("MeetingMember モデル", () => {
+  it("PrismaClient に meetingMember プロパティが存在する", () => {
+    expect(prisma.meetingMember).toBeDefined();
+    expect(typeof prisma.meetingMember.findMany).toBe("function");
+    expect(typeof prisma.meetingMember.create).toBe("function");
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #84

## 概要・目的
* 組織・定例の 3 階層データモデル（Organization → RecurringMeeting → Meeting）のスキーマ層を構築する
* 後続の組織 CRUD・招待 API (#85)、定例 CRUD API (#86) が本スキーマに依存するため、API 実装よりも先にスキーマとマイグレーションだけを切り出して反映する

## 背景
* これまで `User` と `Meeting` の 2 モデルのみだった Prisma スキーマに、組織と定例の概念が存在しなかった
* DB 設計の議論 (#52) を経て、組織配下に定例（RecurringMeeting）を持ち、定例ごとにメンバーシップを管理する 3 階層が必要と整理されている
* API/UI を作る前にスキーマだけ先行して固めた方が、後続 Issue を並行で進めやすい

## 変更内容
* `apps/api/prisma/schema.prisma` に 5 モデルを追加: `Organization`, `OrganizationMembership`, `OrganizationInvitation`, `RecurringMeeting`, `MeetingMember`
* 3 enum を追加: `OrgRole` (owner/admin/member), `InvitationStatus` (pending/accepted/expired), `MeetingRole` (owner/member)
* `User` モデルに新モデルへのリレーション宣言 3 本を追加（テーブル定義の SQL には影響しないため既存データへの影響なし）
* onDelete 方針: 招待の `inviter` のみ Restrict（招待履歴を保持するため）、それ以外はすべて Cascade。組織削除で配下の定例・メンバーシップ・招待まで連鎖削除される
* `OrganizationInvitation` に `@@unique([organizationId, email, status])` を付与し、同一組織への同一メール・同一 status の重複招待を防止
* マイグレーション `20260506124127_add_organization_models` を追加（5 テーブル + 3 enum + index/FK 一式を 1 件にまとめた）
* スモークテストを追加し、PrismaClient に各モデルのデリゲートが生成されていることを確認: `apps/api/test/organization.test.ts`, `apps/api/test/recurring-meeting.test.ts`

## 動作確認手順
1. `git fetch origin && git switch issue-84-org-recurring-meeting-schema`
2. `make install` で依存関係をインストール
3. 別ターミナルで `make dev-native` を起動（DB / FakeAuth / Service Bus が立ち上がる）
4. `make migrate` で本 PR の新規マイグレーション (`20260506124127_add_organization_models`) を適用
5. `make migrate-status` で `Database schema is up to date!` を確認
6. `make test` で全 38 テスト pass を確認
7. （任意）`make db-shell` で接続し `\dt` を実行、`Organization` / `OrganizationMembership` / `OrganizationInvitation` / `RecurringMeeting` / `MeetingMember` の 5 テーブルが追加されていることを確認

## スクリーンショット
* スキーマ・マイグレーションのみで UI/API 変更なし
