### PR TITLE
fix(api): Biome v2 で発生する oidc.test.ts の lint 警告を解消

### DIFF
--- a/apps/api/test/oidc.test.ts
+++ b/apps/api/test/oidc.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   getAudience,
@@ -24,7 +24,6 @@ describe("getIssuerUrl", () => {
   });
 
   it("OIDC_ISSUER_URL 未設定時は FakeAuth の既定 URL を返す", () => {
-    // biome-ignore lint/performance/noDelete: process.env から真に未設定にするには delete が必要
     delete process.env.OIDC_ISSUER_URL;
     expect(getIssuerUrl()).toBe("http://localhost:3007");
   });
@@ -42,7 +41,6 @@ describe("getAudience", () => {
   });
 
   it("OIDC_AUDIENCE 未設定時は FakeAuth の既定 audience を返す", () => {
-    // biome-ignore lint/performance/noDelete: process.env から真に未設定にするには delete が必要
     delete process.env.OIDC_AUDIENCE;
     expect(getAudience()).toBe("fake-auth-client");
   });


### PR DESCRIPTION
## 関連Issue
Closes #

## 概要・目的
- Biome を v1.9.4 → v2.4.14 に更新した際に `apps/api/test/oidc.test.ts` で残った 3 件の警告（未使用 import 1 件、不要となった抑制コメント 2 件）を取り除き、`make lint` をクリーンに通す。

## 背景
- #63 で Biome を v2 系へ更新済み。v2 では `lint/performance/noDelete` ルールが廃止されており、既存の `// biome-ignore lint/performance/noDelete: ...` が「Suppression comment has no effect」と警告される状態だった。
- 併せて、テスト本体で使われていない `vi` の import も `lint/correctness/noUnusedImports` で警告となっていた。

## 変更内容
- `apps/api/test/oidc.test.ts`
  - `vitest` からの import から未使用の `vi` を削除
  - `delete process.env.OIDC_ISSUER_URL` / `delete process.env.OIDC_AUDIENCE` 直前の `biome-ignore lint/performance/noDelete` コメントを 2 件削除

## 動作確認手順
1. `pnpm install` で `node_modules` をロックファイル（Biome 2.4.14）と同期
2. `make lint` を実行し、`api` / `web` / `fake-auth` の 3 タスクすべてが警告 0 件で成功することを確認
3. `pnpm --filter api test` で OIDC 関連テストが従来どおり成功することを確認

## スクリーンショット
- なし（テストファイルの軽微な修正のため）