### PR TITLE
feat(db): 議事録メタ情報カラムを meetings テーブルに追加"

### DIFF
--- a/apps/api/prisma/migrations/20260510012213_add_meeting_meta_columns/migration.sql
+++ b/apps/api/prisma/migrations/20260510012213_add_meeting_meta_columns/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The required column `meetingType` was added to the `Meeting` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN     "estimatedDurationMinutes" INTEGER,
+ADD COLUMN     "estimationNote" TEXT,
+ADD COLUMN     "meetingType" TEXT NOT NULL,
+ADD COLUMN     "previousMeetingId" TEXT,
+ADD COLUMN     "sequenceNumber" INTEGER,
+ADD COLUMN     "supplementaryMemo" TEXT,
+ADD COLUMN     "transcriptionQuality" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_previousMeetingId_fkey" FOREIGN KEY ("previousMeetingId") REFERENCES "Meeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260511131408_add_meeting_meta_columns_and_chain_index/migration.sql
+++ b/apps/api/prisma/migrations/20260511131408_add_meeting_meta_columns_and_chain_index/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Meeting" ALTER COLUMN "meetingType" SET DEFAULT 'one_time';
+
+-- CreateIndex
+CREATE INDEX "Meeting_previousMeetingId_idx" ON "Meeting"("previousMeetingId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,11 +13,11 @@ model Meeting {
   createdAt DateTime @default(now())
 
   // 議事録メタ情報
-  meetingType String @default(one_time())
+  meetingType String @default("one_time")
   transcriptionQuality String?
   supplementaryMemo String?
   sequenceNumber Int?
-  previousMeetingId String @@index([heldAt])
+  previousMeetingId String?
   estimatedDurationMinutes Int?
   estimationNote String?
 
@@ -25,6 +25,8 @@ model Meeting {
   previousMeeting Meeting? @relation("MeetingChain", fields: [previousMeetingId], references: [id])
   nextMeetings Meeting[] @relation("MeetingChain")
 
+  // インデックス
+  @@index([previousMeetingId])
   @@index([heldAt])
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -12,6 +12,19 @@ model Meeting {
   heldAt    DateTime
   createdAt DateTime @default(now())
 
+  // 議事録メタ情報
+  meetingType String @default(cuid())
+  transcriptionQuality String?
+  supplementaryMemo String?
+  sequenceNumber Int?
+  previousMeetingId String?
+  estimatedDurationMinutes Int?
+  estimationNote String?
+
+  // 自己参照リレーション
+  previousMeeting Meeting? @relation("MeetingChain", fields: [previousMeetingId], references: [id])
+  nextMeetings Meeting[] @relation("MeetingChain")
+
   @@index([heldAt])
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,11 +13,11 @@ model Meeting {
   createdAt DateTime @default(now())
 
   // 議事録メタ情報
-  meetingType String @default(cuid())
+  meetingType String @default(one_time())
   transcriptionQuality String?
   supplementaryMemo String?
   sequenceNumber Int?
-  previousMeetingId String?
+  previousMeetingId String @@index([heldAt])
   estimatedDurationMinutes Int?
   estimationNote String?
 


### PR DESCRIPTION
## 関連Issue
Closes #109

## 概要・目的
* AIが生成する会議分析レポート（MeetingAnalysisReport）をDBに保存できるようにするため、`Meeting` テーブルに議事録メタ情報カラムを追加した
* `meta.meeting_type` による抽出戦略の切り替えや、`meta.previous_meeting_id` による定例会議間の文脈引き継ぎを実現するために自己参照リレーションを追加した
* `handover.estimated_duration_minutes` / `handover.estimation_note` を保存することで、次回会議のルールベース所要時間見積もり結果を永続化できるようにした

## 背景
* AIが会議テキストを複数回のOpenAI API呼び出しで解析し、会議種別・書き起こし品質・所要時間見積もり等を含む `MeetingAnalysisReport` を出力する要件が発生した
* 現状の `Meeting` モデルは `title` / `heldAt` / `createdAt` のみの最小構成であり、解析結果を保存できる状態になっていなかった
* `confidence`（書き起こし品質フラグ）はMVPスコープ外のため今回は追加しない
* 議事録関連の新規テーブル追加・既存テーブルへのカラム追加は別Issueで対応する

## 変更内容
* `apps/api/prisma/schema.prisma` — `Meeting` モデルに以下のカラムを追加

| カラム名 | 型 | NULL | デフォルト | 対応するJSONフィールド |
|---|---|---|---|---|
| `meetingType` | String | NOT NULL | `"one_time"` | `meta.meeting_type` |
| `transcriptionQuality` | String? | NULL可 | なし | `meta.transcription_quality` |
| `supplementaryMemo` | String? | NULL可 | なし | `meta.supplementary_memo` |
| `sequenceNumber` | Int? | NULL可 | なし | `meta.sequence_number` |
| `previousMeetingId` | String? | NULL可 | なし | `meta.previous_meeting_id` |
| `estimatedDurationMinutes` | Int? | NULL可 | なし | `handover.estimated_duration_minutes` |
| `estimationNote` | String? | NULL可 | なし | `handover.estimation_note` |

* `apps/api/prisma/migrations/20260510012213_add_meeting_meta_columns/migration.sql` — 上記に対応するマイグレーションSQL

## 動作確認手順
1. `docker compose up db -d` でDBを起動
2. `make migrate` を実行し、エラーなく完了することを確認
3. `make migrate-status` を実行し、全マイグレーションが `Applied` になっていることを確認

## スクリーンショット
* なし（DBスキーマ変更のみ）

---

> ⚠️ **本番適用時の注意**: `meetingType` は `NOT NULL` だが SQLレベルの `DEFAULT` なし。テーブルにデータがある状態での適用は失敗するため、事前にデータ移行対応が必要。