### PR TITLE
fix(web): Docker dev で Vite が tsconfig 解決に失敗する問題を修正

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,6 +3,10 @@ RUN corepack enable
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/web/package.json ./apps/web/
+# api ワークスペースを devDependency で参照しているため、apps/api/src/types.ts の
+# 内部 import（hono/client など）を Vite が解決できるよう、apps/api 側の
+# node_modules もインストール対象に含める
+COPY apps/api/package.json ./apps/api/
 RUN pnpm install --frozen-lockfile
 WORKDIR /app/apps/web
 EXPOSE 5173

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,6 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" },
-    { "path": "../api" }
+    { "path": "./tsconfig.node.json" }
   ]
 }


### PR DESCRIPTION
## 関連Issue
Closes #112

## 概要・目的
* Docker dev で web コンテナの Vite が起動オーバーレイから抜けられない問題を 2 段で解消する。`apps/web/tsconfig.json` の `references` から `{ "path": "../api" }` を削除し、加えて `apps/web/Dockerfile` で `apps/api/package.json` も COPY して `apps/api/node_modules` がコンテナ内に生成されるようにする。

## 背景
* vite 8 と `@vitejs/plugin-react@6` で変換器が oxc に切り替わり、oxc は `tsconfig.json` の `references` も解決対象に含むようになった。
* `docker-compose.yml` の web サービスは `./apps/api/src:/app/apps/api/src` しかマウントしておらず、コンテナ内に `/app/apps/api/tsconfig.json` が存在しないため `../api` 参照の解決で `Failed to load tsconfig for 'src/main.tsx': Tsconfig not found` が出ていた。
* 上記を直すと続けて `[plugin:vite:import-analysis] Failed to resolve import "hono/client" from "../api/src/types.ts"` が露出した。`apps/api/src/types.ts` は型だけでなく `hcWithType` の runtime 実装を含み、`import { hc } from "hono/client"` をランタイムで持つ。vite はファイル位置基準で `node_modules` を上方向に辿るため、`apps/api/node_modules/hono` を必要とするが、web の Dockerfile は `apps/web/package.json` しか COPY しておらず、`pnpm install` 時点で apps/api ワークスペースの依存が解決されないままだった。
* どちらも「ホストでネイティブ起動する開発者には再現せず Docker 利用者だけが詰まる」状態だった。

## 変更内容
* `apps/web/tsconfig.json` の `references` から `{ "path": "../api" }` を削除（`./tsconfig.app.json` / `./tsconfig.node.json` は残す）。`api/types` の型解決は `apps/web/tsconfig.app.json` の `paths` と `apps/web/vite.config.ts` の alias で維持され、import 側コードと型解決経路は不変。
* `apps/web/Dockerfile` に `COPY apps/api/package.json ./apps/api/` を追加。`pnpm install --frozen-lockfile` で `apps/api/node_modules` が作成され、vite が `apps/api/src/types.ts` の `hono/client` import を解決できるようになる。
* web の `tsc -b` は web 配下の references しか辿らないため、`pnpm --filter web build` / `typecheck` の動作も不変。Turbo / CI も root から `tsc -b` を呼んでいないため影響なし。

## 動作確認手順
1. ブランチを checkout: `git fetch && git checkout fix/issue-112-docker-vite-tsconfig-resolution`
2. ホスト側のスモーク: `pnpm install --frozen-lockfile && pnpm --filter web typecheck && pnpm --filter web build && pnpm --filter web test` がすべて成功すること。
3. web イメージを再ビルドして起動: `docker compose up web --build --renew-anon-volumes -d`。
4. ブラウザで `http://localhost:5173/` を開き、`Tsconfig not found` および `Failed to resolve import "hono/client"` のオーバーレイが出ず、ルートページが描画されることを確認。
5. （任意・コンテナ内検証）`docker compose run --rm --no-deps --entrypoint sh web -c 'ls /app/apps/api/node_modules/hono/dist/client'` で `client.js` が見え、`docker compose run --rm --no-deps --entrypoint sh web -c 'cd /app/apps/web && pnpm exec vite build'` が成功すること。

> **注**: `/app/apps/web/node_modules` は anon volume で管理されており、`--renew-anon-volumes` を付けないと旧イメージの node_modules が引き継がれ、本 PR の Dockerfile 修正が反映されない。これは本 PR の差分とは独立した docker-compose 上の挙動で、依存 bump 後にも同様の注意が必要。

## スクリーンショット
* なし（dev サーバの起動エラーが解消されるのみで UI 変更なし）。


