### PR TITLE
feat(web): 組織一覧ページと組織作成モーダルを追加

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -100,10 +100,20 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
         },
       },
     });
-    const result = orgs.map(({ memberships, ...rest }) => ({
-      ...rest,
-      role: memberships[0]?.role ?? "member",
-    }));
+    // where と include の双方を `userId: user.id` で絞っているため、
+    // 取得した各 organization には必ず 1 件以上 memberships が含まれる。
+    // 取れない場合は DB 整合性が壊れているか、include 句の不一致のいずれかで、
+    // "member" にサイレント・フォールバックすると不正データを隠してしまうため
+    // 例外を投げて顕在化させる。
+    const result = orgs.map(({ memberships, ...rest }) => {
+      const role = memberships[0]?.role;
+      if (!role) {
+        throw new Error(
+          `Membership not found for organization ${rest.id} / user ${user.id}`,
+        );
+      }
+      return { ...rest, role };
+    });
     return c.json(result);
   })
   .post("/", zValidator("json", createSchema), async (c) => {

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -88,11 +88,23 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
   .get("/", async (c) => {
     const user = c.var.user;
+    // 自分の membership の role を 1 件だけ include して取得し、
+    // フロント側で「自分の role」をカード表示するために平坦化して返す。
     const orgs = await prisma.organization.findMany({
       where: { memberships: { some: { userId: user.id } } },
       orderBy: { createdAt: "desc" },
+      include: {
+        memberships: {
+          where: { userId: user.id },
+          select: { role: true },
+        },
+      },
     });
-    return c.json(orgs);
+    const result = orgs.map(({ memberships, ...rest }) => ({
+      ...rest,
+      role: memberships[0]?.role ?? "member",
+    }));
+    return c.json(result);
   })
   .post("/", zValidator("json", createSchema), async (c) => {
     const { name, description } = c.req.valid("json");

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -172,17 +172,49 @@ describe("POST /organizations", () => {
 describe("GET /organizations", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("200 と認証ユーザーが所属する組織一覧を返す", async () => {
-    mockOrgFindMany.mockResolvedValue([sampleOrg]);
+  it("200 と認証ユーザーが所属する組織一覧（自分の role を含む）を返す", async () => {
+    // findMany は include: { memberships } で自分の membership を含めて取得し、
+    // ハンドラ側で role を平坦化して返す。
+    mockOrgFindMany.mockResolvedValue([
+      { ...sampleOrg, memberships: [{ role: "owner" }] },
+    ] as never);
     const res = await app.request("/organizations");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as Array<{ id: string }>;
+    const body = (await res.json()) as Array<{ id: string; role: string }>;
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe("org-1");
+    expect(body[0].role).toBe("owner");
+    // memberships は内部表現として残さず、レスポンスに混入しないこと
+    expect(body[0]).not.toHaveProperty("memberships");
     expect(mockOrgFindMany).toHaveBeenCalledWith({
       where: { memberships: { some: { userId: "user-1" } } },
       orderBy: { createdAt: "desc" },
+      include: {
+        memberships: {
+          where: { userId: "user-1" },
+          select: { role: true },
+        },
+      },
     });
+  });
+
+  it("複数所属でそれぞれの role が含まれる", async () => {
+    mockOrgFindMany.mockResolvedValue([
+      { ...sampleOrg, id: "org-1", memberships: [{ role: "owner" }] },
+      {
+        ...sampleOrg,
+        id: "org-2",
+        name: "別の組織",
+        memberships: [{ role: "member" }],
+      },
+    ] as never);
+    const res = await app.request("/organizations");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string; role: string }>;
+    expect(body.map((o) => [o.id, o.role])).toEqual([
+      ["org-1", "owner"],
+      ["org-2", "member"],
+    ]);
   });
 
   it("所属組織が無い場合は空配列を返す", async () => {

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -9,5 +9,10 @@
       "!node_modules",
       "!src/routeTree.gen.ts"
     ]
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-router": "^1.169.2",
@@ -30,8 +32,6 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
-    "api": "workspace:*",
-    "hono": "^4.7.7",
     "@tailwindcss/vite": "^4.1.6",
     "@tanstack/router-plugin": "^1.114.23",
     "@testing-library/jest-dom": "^6.6.3",
@@ -41,6 +41,8 @@
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
+    "api": "workspace:*",
+    "hono": "^4.7.7",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.1.6",
     "typescript": "^6.0.3",

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,77 @@
+import { cn } from "@/lib/utils";
+import type * as React from "react";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl border py-6 shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "flex flex-col gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] grid auto-rows-min items-start",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+};

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,132 @@
+import { cn } from "@/lib/utils";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon />
+          <span className="sr-only">閉じる</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+import type * as React from "react";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as React from "react";
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 
+const OrganizationsRoute = OrganizationsRouteImport.update({
+  id: '/organizations',
+  path: '/organizations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -26,31 +32,42 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login'
+  fullPaths: '/' | '/login' | '/organizations'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login'
-  id: '__root__' | '/' | '/login'
+  to: '/' | '/login' | '/organizations'
+  id: '__root__' | '/' | '/login' | '/organizations'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  OrganizationsRoute: typeof OrganizationsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/organizations': {
+      id: '/organizations'
+      path: '/organizations'
+      fullPath: '/organizations'
+      preLoaderRoute: typeof OrganizationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
@@ -71,6 +88,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  OrganizationsRoute: OrganizationsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -102,6 +102,12 @@ function CreateOrganizationDialog() {
       }
       // headers は第 2 引数で渡す（第 1 引数に混ぜると無視される）。
       const res = await api.organizations.$post({ json }, authHeaders());
+      // 非 2xx を success として扱うと、API が 400/401/500 を返した場合でも
+      // Dialog が閉じてしまい、ユーザーが成功したと誤認する。res.ok を見て
+      // エラー扱いに落とし、useMutation の onError / isError 経路に流す。
+      if (!res.ok) {
+        throw new Error(`Failed to create organization: ${res.status}`);
+      }
       return res.json();
     },
     onSuccess: () => {

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -128,7 +128,7 @@ function CreateOrganizationDialog() {
       <DialogTrigger asChild>
         <Button>組織を作成</Button>
       </DialogTrigger>
-      <DialogContent aria-label="新しい組織を作成">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>新しい組織を作成</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -100,10 +100,8 @@ function CreateOrganizationDialog() {
       if (data.description && data.description.length > 0) {
         json.description = data.description;
       }
-      const res = await api.organizations.$post({
-        json,
-        ...authHeaders(),
-      });
+      // headers は第 2 引数で渡す（第 1 引数に混ぜると無視される）。
+      const res = await api.organizations.$post({ json }, authHeaders());
       return res.json();
     },
     onSuccess: () => {
@@ -178,7 +176,9 @@ export function OrganizationsPage() {
   } = useQuery<Organization[]>({
     queryKey: ["organizations"],
     queryFn: async () => {
-      const res = await api.organizations.$get(authHeaders());
+      // Hono RPC client は第 2 引数で headers を受け取る。第 1 引数の input に
+      // headers を入れても無視されるため、authHeaders() は必ず第 2 引数へ渡す。
+      const res = await api.organizations.$get(undefined, authHeaders());
       // 認証失敗などで API が { error } を返した場合、配列でないものを
       // そのまま data に格納すると orgs.map() で落ちるため、ここで弾く。
       if (!res.ok) {

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -5,9 +6,24 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { api, authHeaders } from "@/lib/api";
-import { useQuery } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 export const Route = createFileRoute("/organizations")({
   component: OrganizationsPage,
@@ -55,6 +71,105 @@ function OrganizationCard({ org }: { org: Organization }) {
   );
 }
 
+// ===== 作成フォーム =====
+
+const createSchema = z.object({
+  name: z.string().min(1, "組織名は必須です"),
+  description: z.string().optional(),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+
+function CreateOrganizationDialog() {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: { name: "", description: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateFormValues) => {
+      // description は空文字なら API に渡さない（API 側 schema が optional のため）
+      const json: { name: string; description?: string } = { name: data.name };
+      if (data.description && data.description.length > 0) {
+        json.description = data.description;
+      }
+      const res = await api.organizations.$post({
+        json,
+        ...authHeaders(),
+      });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["organizations"] });
+      reset();
+      setOpen(false);
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button>組織を作成</Button>
+      </DialogTrigger>
+      <DialogContent aria-label="新しい組織を作成">
+        <DialogHeader>
+          <DialogTitle>新しい組織を作成</DialogTitle>
+          <DialogDescription>
+            組織名と説明（任意）を入力してください。
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit((data) => mutation.mutate(data))}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="org-name">組織名</Label>
+            <Input
+              id="org-name"
+              placeholder="例: ACME 株式会社"
+              {...register("name")}
+            />
+            {errors.name && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="org-description">説明</Label>
+            <Input
+              id="org-description"
+              placeholder="組織の説明（任意）"
+              {...register("description")}
+            />
+          </div>
+          {mutation.isError && (
+            <p className="text-destructive text-sm">作成に失敗しました</p>
+          )}
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              作成
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function OrganizationsPage() {
   const {
     data: orgs = [],
@@ -73,6 +188,7 @@ export function OrganizationsPage() {
     <main className="container mx-auto p-8 space-y-6">
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">組織一覧</h1>
+        <CreateOrganizationDialog />
       </header>
 
       {isLoading ? (

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -179,6 +179,11 @@ export function OrganizationsPage() {
     queryKey: ["organizations"],
     queryFn: async () => {
       const res = await api.organizations.$get(authHeaders());
+      // 認証失敗などで API が { error } を返した場合、配列でないものを
+      // そのまま data に格納すると orgs.map() で落ちるため、ここで弾く。
+      if (!res.ok) {
+        throw new Error(`Failed to fetch organizations: ${res.status}`);
+      }
       // Hono RPC のレスポンス型は date が string なので as でキャストする
       return (await res.json()) as Organization[];
     },

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -1,0 +1,95 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/organizations")({
+  component: OrganizationsPage,
+});
+
+type OrgRole = "owner" | "admin" | "member";
+
+type Organization = {
+  id: string;
+  name: string;
+  description: string | null;
+  role: OrgRole;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const roleLabels: Record<OrgRole, string> = {
+  owner: "オーナー",
+  admin: "管理者",
+  member: "メンバー",
+};
+
+function RoleBadge({ role }: { role: OrgRole }) {
+  return (
+    <span className="inline-flex items-center rounded-md border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {roleLabels[role]}
+    </span>
+  );
+}
+
+function OrganizationCard({ org }: { org: Organization }) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{org.name}</CardTitle>
+          <RoleBadge role={org.role} />
+        </div>
+        {org.description ? (
+          <CardDescription>{org.description}</CardDescription>
+        ) : null}
+      </CardHeader>
+      <CardContent />
+    </Card>
+  );
+}
+
+export function OrganizationsPage() {
+  const {
+    data: orgs = [],
+    isLoading,
+    isError,
+  } = useQuery<Organization[]>({
+    queryKey: ["organizations"],
+    queryFn: async () => {
+      const res = await api.organizations.$get(authHeaders());
+      // Hono RPC のレスポンス型は date が string なので as でキャストする
+      return (await res.json()) as Organization[];
+    },
+  });
+
+  return (
+    <main className="container mx-auto p-8 space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">組織一覧</h1>
+      </header>
+
+      {isLoading ? (
+        <p>読み込み中...</p>
+      ) : isError ? (
+        <p>取得に失敗しました</p>
+      ) : orgs.length === 0 ? (
+        <p className="text-muted-foreground">所属している組織がありません</p>
+      ) : (
+        <ul aria-label="組織一覧" className="grid gap-4 sm:grid-cols-2">
+          {orgs.map((org) => (
+            <li key={org.id}>
+              <OrganizationCard org={org} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/ui/button";
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
@@ -66,7 +65,6 @@ function OrganizationCard({ org }: { org: Organization }) {
           <CardDescription>{org.description}</CardDescription>
         ) : null}
       </CardHeader>
-      <CardContent />
     </Card>
   );
 }

--- a/apps/web/src/routes/organizations.tsx
+++ b/apps/web/src/routes/organizations.tsx
@@ -20,7 +20,7 @@ import { api, authHeaders } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -81,6 +81,8 @@ type CreateFormValues = z.infer<typeof createSchema>;
 function CreateOrganizationDialog() {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
+  const nameId = useId();
+  const descriptionId = useId();
   const {
     register,
     handleSubmit,
@@ -138,9 +140,9 @@ function CreateOrganizationDialog() {
           className="flex flex-col gap-4"
         >
           <div className="flex flex-col gap-2">
-            <Label htmlFor="org-name">組織名</Label>
+            <Label htmlFor={nameId}>組織名</Label>
             <Input
-              id="org-name"
+              id={nameId}
               placeholder="例: ACME 株式会社"
               {...register("name")}
             />
@@ -151,9 +153,9 @@ function CreateOrganizationDialog() {
             )}
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="org-description">説明</Label>
+            <Label htmlFor={descriptionId}>説明</Label>
             <Input
-              id="org-description"
+              id={descriptionId}
               placeholder="組織の説明（任意）"
               {...register("description")}
             />

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,1 +1,62 @@
 @import "tailwindcss";
+
+/*
+ * shadcn/ui の各コンポーネントが参照する CSS 変数（--background, --primary,
+ * --border など）を定義する。@theme inline でこれらを Tailwind v4 のユーティリティ
+ * クラス（bg-background, text-primary, border 等）から解決可能にする。
+ * 値は shadcn/ui 公式の new-york スタイル（neutral, OKLCH）に揃える。
+ * ダークモード対応時は `.dark` セレクタを追加して値を上書きする。
+ */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+}

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -169,10 +169,10 @@ describe("組織作成モーダル", () => {
     await user.click(within(dialog).getByRole("button", { name: "作成" }));
 
     await waitFor(() => {
+      // 第 1 引数は input ({json}), 第 2 引数は ClientRequestOptions (headers)
       expect(api.organizations.$post).toHaveBeenCalledWith(
-        expect.objectContaining({
-          json: { name: "新しい組織", description: "説明文" },
-        }),
+        { json: { name: "新しい組織", description: "説明文" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
       );
     });
     // ダイアログが閉じる
@@ -208,7 +208,8 @@ describe("組織作成モーダル", () => {
 
     await waitFor(() => {
       expect(api.organizations.$post).toHaveBeenCalledWith(
-        expect.objectContaining({ json: { name: "説明なし組織" } }),
+        { json: { name: "説明なし組織" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
       );
     });
   });

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OrganizationsPage } from "../routes/organizations";
+import { renderWithQuery } from "./test-utils";
+
+// hono/client api モジュールをモック
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      $get: vi.fn(),
+      $post: vi.fn(),
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+// hono/client のレスポンス型が複雑なため、モックの戻り値はヘルパー経由でキャスト
+function mockJson<T>(data: T) {
+  return { json: async () => data } as never;
+}
+
+type Organization = {
+  id: string;
+  name: string;
+  description: string | null;
+  role: "owner" | "admin" | "member";
+  createdAt: string;
+  updatedAt: string;
+};
+
+const mockOrgs: Organization[] = [
+  {
+    id: "org-1",
+    name: "ACME 株式会社",
+    description: "テスト組織",
+    role: "owner",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+  },
+  {
+    id: "org-2",
+    name: "別の組織",
+    description: null,
+    role: "member",
+    createdAt: "2026-05-02T00:00:00.000Z",
+    updatedAt: "2026-05-02T00:00:00.000Z",
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ===== 一覧表示 =====
+
+describe("組織一覧表示", () => {
+  it("自分が所属する組織のカードが name/description/role と共に表示される", async () => {
+    vi.mocked(api.organizations.$get).mockResolvedValue(mockJson(mockOrgs));
+
+    renderWithQuery(<OrganizationsPage />);
+
+    expect(await screen.findByText("ACME 株式会社")).toBeInTheDocument();
+    expect(screen.getByText("テスト組織")).toBeInTheDocument();
+    expect(screen.getByText("別の組織")).toBeInTheDocument();
+    // 日本語ロールラベル
+    expect(screen.getByText("オーナー")).toBeInTheDocument();
+    expect(screen.getByText("メンバー")).toBeInTheDocument();
+  });
+
+  it("組織が無いとき空状態メッセージが表示される", async () => {
+    vi.mocked(api.organizations.$get).mockResolvedValue(mockJson([]));
+
+    renderWithQuery(<OrganizationsPage />);
+
+    expect(
+      await screen.findByText("所属している組織がありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("読み込み中はローディング表示が出る", async () => {
+    vi.mocked(api.organizations.$get).mockImplementation(
+      () => new Promise(() => {}),
+    );
+    renderWithQuery(<OrganizationsPage />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("取得失敗時はエラー表示が出る", async () => {
+    vi.mocked(api.organizations.$get).mockRejectedValue(new Error("network"));
+    renderWithQuery(<OrganizationsPage />);
+    expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -213,4 +213,29 @@ describe("組織作成モーダル", () => {
       );
     });
   });
+
+  it("API が 4xx を返した場合はエラー表示が出てダイアログが閉じない", async () => {
+    // 非 2xx を success として扱うと「作成したつもりが実は失敗」のサイレント
+    // 失敗を生む。エラー表示が出て Dialog が閉じないことを保証する。
+    const user = userEvent.setup();
+    vi.mocked(api.organizations.$post).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "bad request" }),
+    } as never);
+
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    await user.type(within(dialog).getByLabelText("組織名"), "失敗する組織");
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    expect(await screen.findByText("作成に失敗しました")).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "新しい組織を作成" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OrganizationsPage } from "../routes/organizations";
 import { renderWithQuery } from "./test-utils";
 
@@ -91,5 +92,108 @@ describe("組織一覧表示", () => {
     vi.mocked(api.organizations.$get).mockRejectedValue(new Error("network"));
     renderWithQuery(<OrganizationsPage />);
     expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
+  });
+});
+
+// ===== 作成モーダル =====
+
+describe("組織作成モーダル", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations.$get).mockResolvedValue(mockJson([]));
+  });
+
+  it("「組織を作成」ボタンを押すとダイアログが開く", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "新しい組織を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("name が空のとき送信できずバリデーションエラーが出る", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    expect(await screen.findByText("組織名は必須です")).toBeInTheDocument();
+    expect(api.organizations.$post).not.toHaveBeenCalled();
+  });
+
+  it("正常送信で $post が呼ばれ、ダイアログが閉じて一覧が再取得される", async () => {
+    const user = userEvent.setup();
+    const created: Organization = {
+      id: "org-3",
+      name: "新しい組織",
+      description: "説明文",
+      role: "owner",
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+    };
+    vi.mocked(api.organizations.$post).mockResolvedValue(mockJson(created));
+    vi.mocked(api.organizations.$get)
+      .mockResolvedValueOnce(mockJson([]))
+      .mockResolvedValueOnce(mockJson([created]));
+
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    await user.type(within(dialog).getByLabelText("組織名"), "新しい組織");
+    await user.type(within(dialog).getByLabelText("説明"), "説明文");
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    await waitFor(() => {
+      expect(api.organizations.$post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          json: { name: "新しい組織", description: "説明文" },
+        }),
+      );
+    });
+    // ダイアログが閉じる
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "新しい組織を作成" }),
+      ).not.toBeInTheDocument();
+    });
+    // 一覧が更新され、新しい組織が表示される
+    expect(await screen.findByText("新しい組織")).toBeInTheDocument();
+  });
+
+  it("description 未入力でも送信可能（API には description を渡さない）", async () => {
+    const user = userEvent.setup();
+    const created: Organization = {
+      id: "org-4",
+      name: "説明なし組織",
+      description: null,
+      role: "owner",
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+    };
+    vi.mocked(api.organizations.$post).mockResolvedValue(mockJson(created));
+
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    await user.type(within(dialog).getByLabelText("組織名"), "説明なし組織");
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    await waitFor(() => {
+      expect(api.organizations.$post).toHaveBeenCalledWith(
+        expect.objectContaining({ json: { name: "説明なし組織" } }),
+      );
+    });
   });
 });

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -17,9 +17,10 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-// hono/client のレスポンス型が複雑なため、モックの戻り値はヘルパー経由でキャスト
+// hono/client のレスポンス型が複雑なため、モックの戻り値はヘルパー経由でキャスト。
+// queryFn 側で res.ok チェックを行うため ok: true / status: 200 も埋める。
 function mockJson<T>(data: T) {
-  return { json: async () => data } as never;
+  return { ok: true, status: 200, json: async () => data } as never;
 }
 
 type Organization = {
@@ -91,6 +92,21 @@ describe("組織一覧表示", () => {
   it("取得失敗時はエラー表示が出る", async () => {
     vi.mocked(api.organizations.$get).mockRejectedValue(new Error("network"));
     renderWithQuery(<OrganizationsPage />);
+    expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
+  });
+
+  it("API が 4xx を返した場合（res.ok=false）もエラー表示でフォールバックする", async () => {
+    // 認証失敗などで API が配列でない { error } を返すケース。
+    // queryFn 側で弾かないと orgs.map() が落ちるため、UI クラッシュではなく
+    // エラー表示にフォールバックすることを保証する。
+    vi.mocked(api.organizations.$get).mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "認証が必要です" }),
+    } as never);
+
+    renderWithQuery(<OrganizationsPage />);
+
     expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-label':
+        specifier: ^2.1.8
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
@@ -754,8 +760,126 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.8':
+    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -798,6 +922,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
@@ -809,6 +942,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1393,6 +1535,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1571,6 +1717,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -1709,6 +1858,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
@@ -2220,6 +2373,36 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -2460,6 +2643,26 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -3224,9 +3427,112 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3258,6 +3564,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
@@ -3269,6 +3581,13 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3761,6 +4080,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -3947,6 +4270,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   diff@8.0.4: {}
 
   dom-accessibility-api@0.5.16: {}
@@ -4091,6 +4416,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-port-please@3.2.0: {}
 
@@ -4532,6 +4859,33 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.5: {}
 
   readdirp@3.6.0:
@@ -4777,6 +5131,21 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## 関連Issue
Closes #87

## 概要・目的
* `/organizations` ルートに、自分が所属する組織のカード一覧と組織作成 Dialog を追加した。
* PR #95 で実装した組織 API を初めて Web から叩く動線を入れる。

## 背景
* PR #95（main にマージ済み）で組織 CRUD API（`GET/POST/PATCH/DELETE /organizations` ほか）を実装したが、それを利用する UI が無く、Web からの組織管理動線が無かった。
* Issue #87 のスコープは「組織一覧ページ」と「組織作成モーダル」までで、組織詳細・招待 UI は別 Issue で扱う。
* 当初は PR #95 のブランチに base をスタックさせる想定だったが、PR #95 が main にマージされたため、`origin/main` にリベース済み。

## 変更内容
* `GET /organizations` のレスポンスに自分の role（`owner`/`admin`/`member`）を含めるよう拡張。`prisma.organization.findMany` に `include: { memberships: { where: { userId } } }` を加え、ハンドラ側で平坦化する。`memberships` 配列はレスポンスから除外。
* shadcn/ui 互換の `Dialog`/`Input`/`Label`/`Card` を `apps/web/src/components/ui/` に追加。依存として `@radix-ui/react-dialog` と `@radix-ui/react-label` を導入（既存 `button.tsx` と同じ `data-slot` + `cn()` の方針）。
* `/organizations` ルート（`apps/web/src/routes/organizations.tsx`）を新設。TanStack Query で一覧取得、`react-hook-form + zod` で作成フォームをバリデーション、`useMutation` 成功時に `invalidateQueries(["organizations"])` で再取得する。
* role は日本語ラベル（オーナー/管理者/メンバー）でバッジ風に表示。
* 空状態（所属組織なし）・ローディング・エラーの 3 状態にそれぞれメッセージを出す。
* description は空文字のまま送信せず、API には key ごと渡さない（API 側 schema が `optional` のため）。
* テスト: API 側で role を含むレスポンス検証を 2 ケース追加。Web 側で一覧表示（4 ケース）と作成モーダル（4 ケース）の計 8 ケースを追加。

## 動作確認手順
1. このブランチを checkout し、`make install` で依存解決（`@radix-ui/react-dialog` / `@radix-ui/react-label` を追加しているため）。
2. `make test` で全パッケージのテストを実行し、API 81 件 / Web 58 件（`organizations.test.tsx` 含む）が GREEN になることを確認。
3. 既に Docker dev を起動済みの場合は `make dev-fresh` で起動する（anon volume を作り直して新規依存をコンテナに反映させるため）。未起動の場合は `make dev-build` で起動。
4. 初回または `make dev-reset` 後は `make migrate` で DB を準備。
5. FakeAuth でログイン後、ブラウザで `/organizations` にアクセス。所属組織が無いと「所属している組織がありません」が表示される。
6. 「組織を作成」を押下し、Dialog で組織名（必須）と説明（任意）を入力 → 作成。Dialog が閉じてカードに新組織が現れる。
7. 組織名を空のまま送信するとバリデーションエラー「組織名は必須です」が出ることを確認。

## スクリーンショット
<img width="812" height="730" alt="image" src="https://github.com/user-attachments/assets/53199063-27ad-40c8-bdc5-43eda627ad1b" />
<img width="847" height="642" alt="image" src="https://github.com/user-attachments/assets/5fc50c73-b126-4df7-9190-734af5e32f50" />
