### PR TITLE
[DB] 議事録解析結果を保存するための関連テーブル追加・enum定義

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25.6.0",
     "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^4.1.5",
+    "dotenv": "^17.4.2",
     "prisma": "^7.8.0",
     "tsx": "^4.19.3",
     "typescript": "^6.0.3",

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from "prisma/config";
+import { config } from "dotenv";
+
+// .env ファイルをロードして環境変数を設定
+config();
 
 export default defineConfig({
   datasource: {

--- a/apps/api/prisma/migrations/20260512011504_add_meeting_extraction_models/migration.sql
+++ b/apps/api/prisma/migrations/20260512011504_add_meeting_extraction_models/migration.sql
@@ -1,0 +1,329 @@
+-- CreateEnum
+CREATE TYPE "DecisionItemStatus" AS ENUM ('draft', 'reviewing', 'open', 'decided', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "DecisionState" AS ENUM ('confirmed', 'tentative', 'open');
+
+-- CreateEnum
+CREATE TYPE "DecisionReason" AS ENUM ('no_consensus', 'information_lack', 'intentional_defer', 'not_discussed');
+
+-- CreateEnum
+CREATE TYPE "TaskStatus" AS ENUM ('draft', 'reviewing', 'todo', 'in_progress', 'done', 'rejected');
+
+-- CreateEnum
+CREATE TYPE "TaskPriority" AS ENUM ('required', 'optional');
+
+-- CreateEnum
+CREATE TYPE "AmbiguousInfoStatus" AS ENUM ('draft', 'reviewing', 'resolved', 'rejected');
+
+-- CreateEnum
+CREATE TYPE "AmbiguityType" AS ENUM ('missing_speaker', 'transcription_error_low', 'transcription_error_high', 'no_assignee', 'no_deadline_mentioned', 'no_deadline_absolute', 'unclear_decision', 'insufficient_basis', 'unclear_scope');
+
+-- CreateEnum
+CREATE TYPE "AmbiguitySeverity" AS ENUM ('high', 'medium', 'low');
+
+-- CreateEnum
+CREATE TYPE "ResolutionType" AS ENUM ('task', 'decision_item', 'discarded');
+
+-- CreateEnum
+CREATE TYPE "ResolutionStatus" AS ENUM ('resolved', 'unresolved', 'unknown');
+
+-- CreateEnum
+CREATE TYPE "EstimationBreakdownType" AS ENUM ('required_task_check', 'open_issue_new', 'open_issue_recurring', 'overdue_task', 'new_topic', 'tentative_reconfirm', 'buffer');
+
+-- CreateTable
+CREATE TABLE "MeetingSpeaker" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "userId" TEXT,
+    "name" TEXT,
+    "resolutionStatus" "ResolutionStatus" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MeetingSpeaker_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MeetingEstimationBreakdown" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "type" "EstimationBreakdownType" NOT NULL,
+    "count" INTEGER NOT NULL,
+    "minutes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MeetingEstimationBreakdown_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RagDocument" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "themeKeywords" JSONB NOT NULL,
+    "confirmedDecisionTexts" JSONB NOT NULL,
+    "openIssueTexts" JSONB NOT NULL,
+    "participantNames" JSONB NOT NULL,
+    "indexedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RagDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedPastMeeting" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "relatedMeetingId" TEXT NOT NULL,
+    "relevanceSummary" TEXT NOT NULL,
+    "recurringFlag" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RelatedPastMeeting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DecisionItem" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "sourceQuote" TEXT,
+    "sourceContext" TEXT,
+    "status" "DecisionItemStatus" NOT NULL,
+    "decisionState" "DecisionState",
+    "reason" "DecisionReason",
+    "blockingItemId" TEXT,
+    "recurrenceCount" INTEGER,
+    "ambiguityFlags" JSONB,
+    "decisionDeadline" TIMESTAMP(3),
+    "plannedMeetingId" TEXT,
+    "decidedAt" TIMESTAMP(3),
+    "decidedBy" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DecisionItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DecisionItemAssignee" (
+    "id" TEXT NOT NULL,
+    "decisionItemId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "DecisionItemAssignee_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Task" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "decisionItemId" TEXT,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "sourceQuote" TEXT,
+    "sourceContext" TEXT,
+    "status" "TaskStatus" NOT NULL,
+    "priority" "TaskPriority",
+    "dueDateRaw" TEXT,
+    "dueDateEstimated" BOOLEAN,
+    "assigneeRaw" TEXT,
+    "blockingItemId" TEXT,
+    "carriedOverCount" INTEGER,
+    "ambiguityFlags" JSONB,
+    "dueDate" TIMESTAMP(3),
+    "startDate" TIMESTAMP(3),
+    "followUpDate" TIMESTAMP(3),
+    "version" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Task_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TaskAssignee" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "TaskAssignee_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AmbiguousInfo" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "sourceQuote" TEXT,
+    "sourceContext" TEXT,
+    "status" "AmbiguousInfoStatus" NOT NULL,
+    "ambiguityType" "AmbiguityType",
+    "severity" "AmbiguitySeverity",
+    "inferenceBasis" TEXT,
+    "dueDateRaw" TEXT,
+    "dueDateEstimated" BOOLEAN,
+    "affectedItemIds" JSONB,
+    "resolutionType" "ResolutionType",
+    "resolvedToTaskId" TEXT,
+    "resolvedToDecisionItemId" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AmbiguousInfo_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL,
+    "resourceId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "beforeValue" JSONB,
+    "afterValue" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ReadLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL,
+    "resourceId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReadLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MeetingSpeaker_meetingId_idx" ON "MeetingSpeaker"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "MeetingEstimationBreakdown_meetingId_idx" ON "MeetingEstimationBreakdown"("meetingId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RagDocument_meetingId_key" ON "RagDocument"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "RelatedPastMeeting_meetingId_idx" ON "RelatedPastMeeting"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "RelatedPastMeeting_relatedMeetingId_idx" ON "RelatedPastMeeting"("relatedMeetingId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedPastMeeting_meetingId_relatedMeetingId_key" ON "RelatedPastMeeting"("meetingId", "relatedMeetingId");
+
+-- CreateIndex
+CREATE INDEX "DecisionItem_meetingId_idx" ON "DecisionItem"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "DecisionItem_status_idx" ON "DecisionItem"("status");
+
+-- CreateIndex
+CREATE INDEX "DecisionItemAssignee_decisionItemId_idx" ON "DecisionItemAssignee"("decisionItemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DecisionItemAssignee_decisionItemId_userId_key" ON "DecisionItemAssignee"("decisionItemId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Task_meetingId_idx" ON "Task"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "Task_decisionItemId_idx" ON "Task"("decisionItemId");
+
+-- CreateIndex
+CREATE INDEX "Task_dueDate_idx" ON "Task"("dueDate");
+
+-- CreateIndex
+CREATE INDEX "Task_startDate_idx" ON "Task"("startDate");
+
+-- CreateIndex
+CREATE INDEX "TaskAssignee_taskId_idx" ON "TaskAssignee"("taskId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskAssignee_taskId_userId_key" ON "TaskAssignee"("taskId", "userId");
+
+-- CreateIndex
+CREATE INDEX "AmbiguousInfo_meetingId_idx" ON "AmbiguousInfo"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "AmbiguousInfo_status_idx" ON "AmbiguousInfo"("status");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_resourceType_resourceId_idx" ON "AuditLog"("resourceType", "resourceId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_actorId_idx" ON "AuditLog"("actorId");
+
+-- CreateIndex
+CREATE INDEX "ReadLog_userId_resourceType_resourceId_idx" ON "ReadLog"("userId", "resourceType", "resourceId");
+
+-- AddForeignKey
+ALTER TABLE "MeetingSpeaker" ADD CONSTRAINT "MeetingSpeaker_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingSpeaker" ADD CONSTRAINT "MeetingSpeaker_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingEstimationBreakdown" ADD CONSTRAINT "MeetingEstimationBreakdown_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RagDocument" ADD CONSTRAINT "RagDocument_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RelatedPastMeeting" ADD CONSTRAINT "RelatedPastMeeting_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RelatedPastMeeting" ADD CONSTRAINT "RelatedPastMeeting_relatedMeetingId_fkey" FOREIGN KEY ("relatedMeetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DecisionItem" ADD CONSTRAINT "DecisionItem_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DecisionItem" ADD CONSTRAINT "DecisionItem_plannedMeetingId_fkey" FOREIGN KEY ("plannedMeetingId") REFERENCES "Meeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DecisionItem" ADD CONSTRAINT "DecisionItem_decidedBy_fkey" FOREIGN KEY ("decidedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DecisionItemAssignee" ADD CONSTRAINT "DecisionItemAssignee_decisionItemId_fkey" FOREIGN KEY ("decisionItemId") REFERENCES "DecisionItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DecisionItemAssignee" ADD CONSTRAINT "DecisionItemAssignee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_decisionItemId_fkey" FOREIGN KEY ("decisionItemId") REFERENCES "DecisionItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskAssignee" ADD CONSTRAINT "TaskAssignee_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskAssignee" ADD CONSTRAINT "TaskAssignee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AmbiguousInfo" ADD CONSTRAINT "AmbiguousInfo_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AmbiguousInfo" ADD CONSTRAINT "AmbiguousInfo_resolvedToTaskId_fkey" FOREIGN KEY ("resolvedToTaskId") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AmbiguousInfo" ADD CONSTRAINT "AmbiguousInfo_resolvedToDecisionItemId_fkey" FOREIGN KEY ("resolvedToDecisionItemId") REFERENCES "DecisionItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReadLog" ADD CONSTRAINT "ReadLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260513114921_add_related_past_meeting_check_constraint/migration.sql
+++ b/apps/api/prisma/migrations/20260513114921_add_related_past_meeting_check_constraint/migration.sql
@@ -1,0 +1,10 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingSpeaker_meetingId_userId_key" ON "MeetingSpeaker"("meetingId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Task_status_idx" ON "Task"("status");
+
+-- check制約を追加して、RelatedPastMeetingが自己参照を許さないようにする
+ALTER TABLE "RelatedPastMeeting"
+ADD CONSTRAINT "RelatedPastMeeting_no_self_reference"
+CHECK ("meetingId" <> "relatedMeetingId");

--- a/apps/api/prisma/migrations/20260513115921_add_meeting_estimation_breakdown_unique/migration.sql
+++ b/apps/api/prisma/migrations/20260513115921_add_meeting_estimation_breakdown_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[meetingId,type]` on the table `MeetingEstimationBreakdown` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingEstimationBreakdown_meetingId_type_key" ON "MeetingEstimationBreakdown"("meetingId", "type");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -267,6 +267,7 @@ model MeetingSpeaker {
   user    User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([meetingId])
+  @@unique([meetingId, userId])
 }
 
 // 次回会議の所要時間見積もり内訳。meetings.estimatedDurationMinutesの算出根拠を保持する。

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -325,9 +325,9 @@ model DecisionItem {
   body             String?
   sourceQuote      String?
   sourceContext    String?
-  status           DecisionItemStatus   // draft / reviewing / open / decided / cancelled
-  decisionState    DecisionState?  // confirmed / tentative / open
-  reason           DecisionReason?  // no_consensus / information_lack / intentional_defer / not_discussed
+  status           DecisionItemStatus
+  decisionState    DecisionState?
+  reason           DecisionReason?
   blockingItemId   String?
   recurrenceCount  Int?
   ambiguityFlags   Json?
@@ -419,14 +419,14 @@ model AmbiguousInfo {
   body                       String
   sourceQuote                String?
   sourceContext              String?
-  status                     AmbiguousInfoStatus    // draft / reviewing / resolved / rejected
-  ambiguityType              AmbiguityType?   // missing_speaker / transcription_error_low / no_assignee / unclear_decision など
-  severity                   AmbiguitySeverity?   // high / medium / low
+  status                     AmbiguousInfoStatus
+  ambiguityType              AmbiguityType?
+  severity                   AmbiguitySeverity?
   inferenceBasis             String?
   dueDateRaw                 String?
   dueDateEstimated           Boolean?
   affectedItemIds            Json?
-  resolutionType             ResolutionType?   // null = 未解消 / task / decision_item / discarded
+  resolutionType             ResolutionType?
   resolvedToTaskId           String?
   resolvedToDecisionItemId   String?
   version                    Int       @default(0)

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -259,7 +259,7 @@ model MeetingSpeaker {
   meetingId        String
   userId           String?
   name             String?
-  resolutionStatus ResolutionStatus   // resolved / unresolved / unknown
+  resolutionStatus ResolutionStatus
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
@@ -273,7 +273,7 @@ model MeetingSpeaker {
 model MeetingEstimationBreakdown {
   id        String   @id @default(cuid())
   meetingId String
-  type      EstimationBreakdownType   // required_task_check / open_issue_new / open_issue_recurring / overdue_task / new_topic / tentative_reconfirm / buffer
+  type      EstimationBreakdownType
   count     Int
   minutes   Int
   createdAt DateTime @default(now())
@@ -372,8 +372,8 @@ model Task {
   body             String?
   sourceQuote      String?
   sourceContext    String?
-  status           TaskStatus   // draft / reviewing / todo / in_progress / done / rejected
-  priority         TaskPriority?   // required / optional
+  status           TaskStatus
+  priority         TaskPriority?
   dueDateRaw       String?
   dueDateEstimated Boolean?
   assigneeRaw      String?
@@ -396,6 +396,7 @@ model Task {
   @@index([decisionItemId])
   @@index([dueDate])
   @@index([startDate])
+  @@index([status])
 }
 
 // タスクの担当者。複数担当者に対応するための中間テーブル。

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -25,6 +25,17 @@ model Meeting {
   previousMeeting Meeting? @relation("MeetingChain", fields: [previousMeetingId], references: [id])
   nextMeetings Meeting[] @relation("MeetingChain")
 
+  // リレーション
+  speakers             MeetingSpeaker[]
+  estimationBreakdowns MeetingEstimationBreakdown[]
+  ragDocument          RagDocument?
+  currentMeetingRefs   RelatedPastMeeting[] @relation("CurrentMeeting")
+  relatedMeetingRefs   RelatedPastMeeting[] @relation("RelatedMeeting")
+  decisionItems        DecisionItem[]
+  decisionItemsPlanned DecisionItem[]       @relation("PlannedMeeting")
+  tasks                Task[]
+  ambiguousInfos       AmbiguousInfo[]
+
   // インデックス
   @@index([previousMeetingId])
   @@index([heldAt])
@@ -43,6 +54,107 @@ model User {
   memberships     OrganizationMembership[]
   invitationsSent OrganizationInvitation[] @relation("InvitedBy")
   meetingMembers  MeetingMember[]
+
+  // 会議の話者情報。話者名とDBユーザーの紐付け状態を管理する。ユーザーが削除された場合も履歴保持のためレコードは残すが、userIdはnullにする。
+  meetingSpeakers      MeetingSpeaker[]
+  decisionItemsDecided DecisionItem[]
+  decisionItemAssignees DecisionItemAssignee[]
+  taskAssignees        TaskAssignee[]
+  auditLogs            AuditLog[]
+  readLogs             ReadLog[]
+}
+
+// 決定事項のステータス
+enum DecisionItemStatus {
+  draft
+  reviewing
+  open
+  decided
+  cancelled
+}
+
+// 決定事項の確定状態
+enum DecisionState {
+  confirmed
+  tentative
+  open
+}
+
+// 未決の理由
+enum DecisionReason {
+  no_consensus
+  information_lack
+  intentional_defer
+  not_discussed
+}
+
+// タスクのステータス
+enum TaskStatus {
+  draft
+  reviewing
+  todo
+  in_progress
+  done
+  rejected
+}
+
+// タスクの必須度
+enum TaskPriority {
+  required
+  optional
+}
+
+// 曖昧情報のステータス
+enum AmbiguousInfoStatus {
+  draft
+  reviewing
+  resolved
+  rejected
+}
+
+// 曖昧情報の種別
+enum AmbiguityType {
+  missing_speaker
+  transcription_error_low
+  transcription_error_high
+  no_assignee
+  no_deadline_mentioned
+  no_deadline_absolute
+  unclear_decision
+  insufficient_basis
+  unclear_scope
+}
+
+// 曖昧情報の深刻度
+enum AmbiguitySeverity {
+  high
+  medium
+  low
+}
+
+// 曖昧情報の解消種別
+enum ResolutionType {
+  task
+  decision_item
+  discarded
+}
+
+// 話者の解決状態
+enum ResolutionStatus {
+  resolved
+  unresolved
+  unknown
+}
+
+// 所要時間見積もりの種別
+enum EstimationBreakdownType {
+  required_task_check
+  open_issue_new
+  open_issue_recurring
+  overdue_task
+  new_topic
+  tentative_reconfirm
+  buffer
 }
 
 // 組織内メンバー権限。owner は組織削除可、admin は招待・編集可、member は閲覧中心。
@@ -139,4 +251,222 @@ model MeetingMember {
 
   @@id([recurringMeetingId, userId])
   @@index([userId])
+}
+
+// 会議ごとの話者情報。書き起こし上の呼称とDBユーザーの紐付け状態を管理する。
+model MeetingSpeaker {
+  id               String   @id @default(cuid())
+  meetingId        String
+  userId           String?
+  name             String?
+  resolutionStatus ResolutionStatus   // resolved / unresolved / unknown
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  meeting Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  user    User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([meetingId])
+}
+
+// 次回会議の所要時間見積もり内訳。meetings.estimatedDurationMinutesの算出根拠を保持する。
+model MeetingEstimationBreakdown {
+  id        String   @id @default(cuid())
+  meetingId String
+  type      EstimationBreakdownType   // required_task_check / open_issue_new / open_issue_recurring / overdue_task / new_topic / tentative_reconfirm / buffer
+  count     Int
+  minutes   Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  meeting Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+
+  @@index([meetingId])
+}
+
+// AI Searchに登録するRAGインデックスドキュメント。1会議=1ドキュメント。
+model RagDocument {
+  id                     String    @id @default(cuid())
+  meetingId              String    @unique
+  themeKeywords          Json
+  confirmedDecisionTexts Json
+  openIssueTexts         Json
+  participantNames       Json
+  indexedAt              DateTime?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  meeting Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+}
+
+// RAG検索で見つかった関連過去会議。recurring_flagで再議論検出に使用する。
+model RelatedPastMeeting {
+  id                String   @id @default(cuid())
+  meetingId         String
+  relatedMeetingId  String
+  relevanceSummary  String
+  recurringFlag     Boolean  @default(false)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  meeting        Meeting @relation("CurrentMeeting", fields: [meetingId], references: [id], onDelete: Cascade)
+  relatedMeeting Meeting @relation("RelatedMeeting", fields: [relatedMeetingId], references: [id], onDelete: Cascade)
+
+  @@unique([meetingId, relatedMeetingId])
+  @@index([meetingId])
+  @@index([relatedMeetingId])
+}
+
+// 会議から抽出された決定事項・未決事項。
+model DecisionItem {
+  id               String   @id @default(cuid())
+  meetingId        String
+  title            String
+  body             String?
+  sourceQuote      String?
+  sourceContext    String?
+  status           DecisionItemStatus   // draft / reviewing / open / decided / cancelled
+  decisionState    DecisionState?  // confirmed / tentative / open
+  reason           DecisionReason?  // no_consensus / information_lack / intentional_defer / not_discussed
+  blockingItemId   String?
+  recurrenceCount  Int?
+  ambiguityFlags   Json?
+  decisionDeadline DateTime?
+  plannedMeetingId String?
+  decidedAt        DateTime?
+  decidedBy        String?
+  version          Int      @default(0)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  meeting        Meeting  @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  plannedMeeting Meeting? @relation("PlannedMeeting", fields: [plannedMeetingId], references: [id], onDelete: SetNull)
+  decidedByUser  User?    @relation(fields: [decidedBy], references: [id], onDelete: SetNull)
+  assignees      DecisionItemAssignee[]
+  tasks          Task[]
+  ambiguousInfos AmbiguousInfo[]
+
+  @@index([meetingId])
+  @@index([status])
+}
+
+// 決定事項・未決事項の担当者。複数担当者に対応するための中間テーブル。
+model DecisionItemAssignee {
+  id             String @id @default(cuid())
+  decisionItemId String
+  userId         String
+
+  decisionItem DecisionItem @relation(fields: [decisionItemId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([decisionItemId, userId])
+  @@index([decisionItemId])
+}
+
+// 会議から抽出されたタスク。
+model Task {
+  id               String    @id @default(cuid())
+  meetingId        String
+  decisionItemId   String?
+  title            String
+  body             String?
+  sourceQuote      String?
+  sourceContext    String?
+  status           TaskStatus   // draft / reviewing / todo / in_progress / done / rejected
+  priority         TaskPriority?   // required / optional
+  dueDateRaw       String?
+  dueDateEstimated Boolean?
+  assigneeRaw      String?
+  blockingItemId   String?
+  carriedOverCount Int?
+  ambiguityFlags   Json?
+  dueDate          DateTime?
+  startDate        DateTime?
+  followUpDate     DateTime?
+  version          Int       @default(0)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  meeting      Meeting       @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  decisionItem DecisionItem? @relation(fields: [decisionItemId], references: [id], onDelete: SetNull)
+  assignees    TaskAssignee[]
+  ambiguousInfos AmbiguousInfo[]
+
+  @@index([meetingId])
+  @@index([decisionItemId])
+  @@index([dueDate])
+  @@index([startDate])
+}
+
+// タスクの担当者。複数担当者に対応するための中間テーブル。
+model TaskAssignee {
+  id      String @id @default(cuid())
+  taskId  String
+  userId  String
+
+  task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, userId])
+  @@index([taskId])
+}
+
+// 会議中に発生した曖昧な情報。
+model AmbiguousInfo {
+  id                         String    @id @default(cuid())
+  meetingId                  String
+  body                       String
+  sourceQuote                String?
+  sourceContext              String?
+  status                     AmbiguousInfoStatus    // draft / reviewing / resolved / rejected
+  ambiguityType              AmbiguityType?   // missing_speaker / transcription_error_low / no_assignee / unclear_decision など
+  severity                   AmbiguitySeverity?   // high / medium / low
+  inferenceBasis             String?
+  dueDateRaw                 String?
+  dueDateEstimated           Boolean?
+  affectedItemIds            Json?
+  resolutionType             ResolutionType?   // null = 未解消 / task / decision_item / discarded
+  resolvedToTaskId           String?
+  resolvedToDecisionItemId   String?
+  version                    Int       @default(0)
+  createdAt                  DateTime  @default(now())
+  updatedAt                  DateTime  @updatedAt
+
+  meeting              Meeting       @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  resolvedToTask       Task?         @relation(fields: [resolvedToTaskId], references: [id], onDelete: SetNull)
+  resolvedToDecision   DecisionItem? @relation(fields: [resolvedToDecisionItemId], references: [id], onDelete: SetNull)
+
+  @@index([meetingId])
+  @@index([status])
+}
+
+// 各リソースへの操作履歴。追記専用の不変ログ。
+model AuditLog {
+  id           String   @id @default(cuid())
+  actorId      String
+  resourceType String   // task / decision_item / ambiguous_info など
+  resourceId   String
+  action       String   // create / update / delete
+  beforeValue  Json?
+  afterValue   Json?
+  createdAt    DateTime @default(now())
+
+  actor User @relation(fields: [actorId], references: [id], onDelete: Restrict)
+
+  @@index([resourceType, resourceId])
+  @@index([actorId])
+}
+
+// ユーザーによるリソースの既読履歴。追記専用の不変ログ。
+model ReadLog {
+  id           String   @id @default(cuid())
+  userId       String
+  resourceType String   // task / decision_item / ambiguous_info など
+  resourceId   String
+  readAt       DateTime @default(now())
+  createdAt    DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, resourceType, resourceId])
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -283,6 +283,7 @@ model MeetingEstimationBreakdown {
   meeting Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
 
   @@index([meetingId])
+  @@unique([meetingId, type])
 }
 
 // AI Searchに登録するRAGインデックスドキュメント。1会議=1ドキュメント。

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -1,329 +1,299 @@
-Table teams {
-  Note: 'チーム。複数の定例会議を束ねる単位。将来的にOrganizationを上位に追加できるよう team_id 経由で参照する設計にしている'
-  id         uuid [pk]
-  name       varchar
-  created_by uuid [ref: > users.id]
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
-}
-
-Table team_members {
-  Note: 'チームのメンバー管理。role により閲覧・編集・管理の権限を制御する'
-  id         uuid [pk]
-  team_id    uuid [ref: > teams.id]
-  user_id    uuid [ref: > users.id]
-  role       varchar [note: 'owner / member / viewer']
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+Table meetings {
+  Note: '個別の会議。定例会議から生成される場合もあれば、単発で作成される場合もある'
+  id                       varchar [pk]
+  title                    varchar
+  heldAt                   timestamp
+  meetingType              varchar [default: 'one_time', note: 'recurring_meeting / one_time / hearing / kickoff']
+  transcriptionQuality     varchar [note: 'full / partial / poor']
+  supplementaryMemo        text
+  sequenceNumber           int
+  previousMeetingId        varchar [ref: > meetings.id, note: '自己参照FK。直前の会議ID']
+  estimatedDurationMinutes int
+  estimationNote           text
+  createdAt                timestamp
 
   indexes {
-    (team_id, user_id) [unique]
+    previousMeetingId
+    heldAt
   }
 }
 
 Table users {
   Note: 'システムのユーザー。認証はEntra IDに移譲し、外部IDとプロバイダー情報を保持する'
-  id          uuid [pk]
-  external_id varchar [unique, note: 'Entra IDのユーザーID']
-  provider    varchar [note: 'microsoft など']
-  name        varchar
+  id          varchar [pk]
+  externalId  varchar [unique, note: 'Entra IDのユーザーID']
   email       varchar [unique]
-  created_at  timestamp
-  updated_at  timestamp
-  deleted_at  timestamp
+  name        varchar
+  displayName varchar
+  createdAt   timestamp
+  updatedAt   timestamp
 }
 
-Table user_roles {
-  Note: 'ユーザーのロール。team_idがNULLの場合はグローバルロール、値がある場合はチームスコープのロールとして機能する'
-  id         uuid [pk]
-  user_id    uuid [ref: > users.id]
-  team_id    uuid [ref: > teams.id, note: 'NULLの場合はグローバルロール']
-  role       varchar [note: 'admin / member / guest など']
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+Table organizations {
+  Note: '組織。所属メンバーと配下定例の親エンティティ'
+  id          varchar [pk]
+  name        varchar
+  description text
+  createdAt   timestamp
+  updatedAt   timestamp
+}
+
+Table organization_memberships {
+  Note: '組織への所属。userId × organizationId を複合主キーとする'
+  userId         varchar [ref: > users.id]
+  organizationId varchar [ref: > organizations.id]
+  role           varchar [note: 'owner / admin / member']
+  joinedAt       timestamp
 
   indexes {
-    (user_id, team_id, role) [unique]
+    (userId, organizationId) [pk]
+    organizationId
+  }
+}
+
+Table organization_invitations {
+  Note: '組織への招待。同一組織への同一メールアドレスの同一statusの招待は重複させない'
+  id             varchar [pk]
+  organizationId varchar [ref: > organizations.id]
+  email          varchar
+  invitedBy      varchar [ref: > users.id]
+  role           varchar [default: 'member', note: 'owner / admin / member']
+  expiresAt      timestamp
+  status         varchar [default: 'pending', note: 'pending / accepted / expired']
+  createdAt      timestamp
+
+  indexes {
+    (organizationId, email, status) [unique]
+    email
   }
 }
 
 Table recurring_meetings {
-  Note: '定例会議の定義。cron形式のスケジュールを持ち、個別のmeetingを繰り返し生成する元になる。チームに複数の定例を持てる'
-  id            uuid [pk]
-  team_id       uuid [ref: > teams.id]
-  title         varchar
-  description   text
-  schedule_cron     varchar [note: '例: 0 10 * * 2 = 毎週火曜10時']
-  agenda_lead_days  int [note: 'アジェンダを何日前に自動生成するか。デフォルト3']
-  created_at        timestamp
-  updated_at    timestamp
-  deleted_at    timestamp
-}
-
-Table recurring_meeting_members {
-  Note: '定例会議のデフォルトメンバー。roleにより閲覧・編集・管理を制御し、この一覧をもとにmeeting_attendeesが自動生成される'
-  id                   uuid [pk]
-  recurring_meeting_id uuid [ref: > recurring_meetings.id]
-  user_id              uuid [ref: > users.id]
-  role                 varchar [note: 'owner / member / viewer']
-  created_at           timestamp
-  updated_at           timestamp
-  deleted_at           timestamp
+  Note: '定例会議。組織配下の継続的なミーティング枠'
+  id             varchar [pk]
+  organizationId varchar [ref: > organizations.id]
+  name           varchar
+  description    text
+  scheduleCron   varchar
+  createdAt      timestamp
+  updatedAt      timestamp
 
   indexes {
-    (recurring_meeting_id, user_id) [unique]
+    organizationId
   }
 }
 
-Table meetings {
-  Note: '個別の会議。定例会議から生成される場合もあれば、単発で作成される場合もある。文字起こし本文を直接保持する'
-  id                   uuid [pk]
-  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は単発の会議']
-  title                varchar
-  scheduled_at         timestamp
-  status               varchar [note: 'scheduled / done / canceled']
-  processing_status    varchar [note: 'pending / analyzing / review_waiting / completed / failed']
-  processing_error     text [note: 'processing_status = failed のときのエラー詳細。NULLの場合は正常']
-  summary              text [note: 'AIが生成した会議要約。NULLの場合は未生成']
-  transcription        text [note: '文字起こし本文']
-  created_at           timestamp
-  updated_at           timestamp
-  deleted_at           timestamp
+Table meeting_members {
+  Note: '定例ごとのメンバー。recurringMeetingId × userId を複合主キーとする'
+  recurringMeetingId varchar [ref: > recurring_meetings.id]
+  userId             varchar [ref: > users.id]
+  role               varchar [note: 'owner / member']
+  joinedAt           timestamp
 
   indexes {
-    recurring_meeting_id
-    scheduled_at
+    (recurringMeetingId, userId) [pk]
+    userId
   }
 }
 
-Table meeting_attendees {
-  Note: '会議ごとの参加者。AIによる提案・人間による招待から始まり、承認/辞退/参加/欠席へと状態遷移する'
-  id         uuid [pk]
-  meeting_id uuid [ref: > meetings.id]
-  user_id    uuid [ref: > users.id]
-  status     varchar [note: 'proposed / invited / accepted / declined / attended / absent']
-  is_default boolean [note: 'true = 定例メンバー / false = 今回だけの参加']
-  invited_by uuid [ref: > users.id, note: 'NULLの場合はAIによる提案']
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+Table meeting_speakers {
+  Note: '会議ごとの話者情報。書き起こし上の呼称とDBユーザーの紐付け状態を管理する'
+  id               varchar [pk]
+  meetingId        varchar [ref: > meetings.id]
+  userId           varchar [ref: > users.id, note: 'NULLの場合は未解決']
+  name             varchar [note: '書き起こし上の呼称。不明の場合はNULL']
+  resolutionStatus varchar [note: 'resolved / unresolved / unknown']
+  createdAt        timestamp
+  updatedAt        timestamp
 
   indexes {
-    (meeting_id, user_id) [unique]
+    meetingId
   }
 }
 
-Table topic_requests {
-  Note: '人間が会議に対して入力する議題リクエスト。AIによるagenda_items生成のインプットになる。meeting_idとrecurring_meeting_idのどちらか一方が必須'
-  id                   uuid [pk]
-  meeting_id           uuid [ref: > meetings.id, note: 'NULLの場合はrecurring_meeting向けリクエスト']
-  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は特定会議向けリクエスト']
-  requested_by         uuid [ref: > users.id]
-  title                varchar
-  body                 text
-  created_at           timestamp
-  updated_at           timestamp
-  deleted_at           timestamp
+Table meeting_estimation_breakdowns {
+  Note: '次回会議の所要時間見積もり内訳。meetings.estimatedDurationMinutesの算出根拠を保持する'
+  id        varchar [pk]
+  meetingId varchar [ref: > meetings.id]
+  type      varchar [note: 'required_task_check / open_issue_new / open_issue_recurring / overdue_task / new_topic / tentative_reconfirm / buffer']
+  count     int
+  minutes   int
+  createdAt timestamp
+  updatedAt timestamp
 
   indexes {
-    meeting_id
-    recurring_meeting_id
+    meetingId
   }
 }
 
-Table agenda_generation_batches {
-  Note: 'アジェンダの生成バッチ。再生成のたびに1レコード追加され、最新バッチ（created_at最大）が現在のアジェンダとなる。過去バッチを参照することで履歴閲覧・復元が可能'
-  id                   uuid [pk]
-  meeting_id           uuid [ref: > meetings.id, note: 'NULLの場合はrecurring_meeting向けバッチ']
-  recurring_meeting_id uuid [ref: > recurring_meetings.id, note: 'NULLの場合は特定会議向けバッチ']
-  generated_by         varchar [note: 'ai / human']
-  created_by           uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
-  created_at           timestamp
-
-  indexes {
-    meeting_id
-    recurring_meeting_id
-  }
+Table rag_documents {
+  Note: 'AI Searchに登録するRAGインデックスドキュメント。1会議=1ドキュメント'
+  id                     varchar [pk]
+  meetingId              varchar [unique, ref: > meetings.id]
+  themeKeywords          json
+  confirmedDecisionTexts json
+  openIssueTexts         json
+  participantNames       json
+  indexedAt              timestamp [note: 'AI Searchへの登録日時。NULLの場合は未登録']
+  createdAt              timestamp
+  updatedAt              timestamp
 }
 
-Table agenda_items {
-  Note: 'AIまたは人間が作成するアジェンダ。generation_batch_idで生成バッチと紐づき、会議をまたいで持ち越しが可能'
-  id                      uuid [pk]
-  generation_batch_id     uuid [ref: > agenda_generation_batches.id, note: 'NULLの場合はバッチに属さない手動作成']
-  title                   varchar
-  body                    text
-  source_type             varchar [note: 'ai / human / carried_over']
-  status                  varchar [note: 'pending / approved / rejected']
-  topic_request_id        uuid [ref: > topic_requests.id, note: 'NULLの場合はtopic_requestに基づかない生成']
-  origin_meeting_id       uuid [ref: > meetings.id, note: '持ち越し元の会議ID。持ち越しでない場合はNULL']
-  created_by              uuid [ref: > users.id, note: 'NULLの場合はAIが生成']
-  modified_by             uuid [ref: > users.id, note: 'NULLの場合は修正なし']
-  created_at              timestamp
-  updated_at              timestamp
-  deleted_at              timestamp
+Table related_past_meetings {
+  Note: 'RAG検索で見つかった関連過去会議。recurring_flagで再議論検出に使用する'
+  id               varchar [pk]
+  meetingId        varchar [ref: > meetings.id, note: '現在の会議']
+  relatedMeetingId varchar [ref: > meetings.id, note: '関連する過去会議']
+  relevanceSummary text
+  recurringFlag    boolean [default: false, note: '同一定例グループで2回以上類似トピックが検出された場合はtrue']
+  createdAt        timestamp
+  updatedAt        timestamp
 
   indexes {
-    generation_batch_id
-  }
-}
-
-Table meeting_agenda_items {
-  Note: 'agenda_itemsとmeetingsの中間テーブル。order_indexで表示順を管理する'
-  id             uuid [pk]
-  meeting_id     uuid [ref: > meetings.id]
-  agenda_item_id uuid [ref: > agenda_items.id]
-  order_index    int
-  created_at     timestamp
-  updated_at     timestamp
-  deleted_at     timestamp
-
-  indexes {
-    (meeting_id, agenda_item_id) [unique]
-  }
-}
-
-Table meeting_materials {
-  Note: '会議に添付された資料ファイル。ファイル本体はストレージに保存し、URLのみDBで管理する'
-  id          uuid [pk]
-  meeting_id  uuid [ref: > meetings.id]
-  uploaded_by uuid [ref: > users.id]
-  file_name   varchar
-  file_url    varchar
-  created_at  timestamp
-  updated_at  timestamp
-  deleted_at  timestamp
-
-  indexes {
-    meeting_id
+    (meetingId, relatedMeetingId) [unique]
+    meetingId
+    relatedMeetingId
   }
 }
 
 Table decision_items {
-  Note: '会議から抽出された決定事項・未決事項。open（未決）⇔ decided（決定）のサイクルを持ち、再開も表現できる。決定期限・予定会議を持つことで未決事項の追跡も可能'
-  id                   uuid [pk]
-  meeting_id           uuid [ref: > meetings.id, note: '発生元の会議']
-  title                varchar
-  body                 text
-  source_quote         text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
-  source_context       text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
-  status               varchar [note: 'draft / reviewing / open / decided / cancelled']
-  decision_deadline    timestamp [note: 'いつまでに決めるか。status = open のときに使用']
-  planned_meeting_id   uuid [ref: > meetings.id, note: 'どの会議で議題に上げるか。status = open のときに使用']
-  decided_at           timestamp [note: 'status = decided になった日時']
-  decided_by           uuid [ref: > users.id, note: '最後に decided に変更したユーザー']
-  version              int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
-  created_at           timestamp
-  updated_at           timestamp
-  deleted_at           timestamp
+  Note: '会議から抽出された決定事項・未決事項'
+  id               varchar [pk]
+  meetingId        varchar [ref: > meetings.id]
+  title            varchar
+  body             text
+  sourceQuote      text    [note: 'AIが根拠とした発話1文']
+  sourceContext    text    [note: '根拠周辺の文脈']
+  status           varchar [note: 'draft / reviewing / open / decided / cancelled']
+  decisionState    varchar [note: 'confirmed / tentative / open']
+  reason           varchar [note: 'no_consensus / information_lack / intentional_defer / not_discussed']
+  blockingItemId   varchar [note: 'ブロッキング対象のアイテムID']
+  recurrenceCount  int
+  ambiguityFlags   json
+  decisionDeadline timestamp
+  plannedMeetingId varchar [ref: > meetings.id, note: 'どの会議で議題に上げるか']
+  decidedAt        timestamp
+  decidedBy        varchar [ref: > users.id]
+  version          int     [default: 0, note: '楽観的ロック用バージョン番号']
+  createdAt        timestamp
+  updatedAt        timestamp
 
   indexes {
-    meeting_id
+    meetingId
     status
   }
 }
 
 Table decision_item_assignees {
-  Note: '決定事項・未決事項の担当者。1つのdecision_itemに複数の担当者を紐づけられるよう中間テーブルとして管理する'
-  id                 uuid [pk]
-  decision_item_id   uuid [ref: > decision_items.id]
-  user_id            uuid [ref: > users.id]
-  created_at         timestamp
-  updated_at         timestamp
-  deleted_at         timestamp
+  Note: '決定事項・未決事項の担当者。複数担当者に対応するための中間テーブル'
+  id             varchar [pk]
+  decisionItemId varchar [ref: > decision_items.id]
+  userId         varchar [ref: > users.id]
 
   indexes {
-    (decision_item_id, user_id) [unique]
+    (decisionItemId, userId) [unique]
+    decisionItemId
   }
 }
 
 Table tasks {
-  Note: '会議から抽出されたタスク。decision_itemに紐づく場合と、紐づかない独立したタスクの両方を表現できる'
-  id                 uuid [pk]
-  meeting_id         uuid [ref: > meetings.id]
-  decision_item_id   uuid [ref: > decision_items.id, note: 'NULLの場合はdecision_itemに紐づかない独立したタスク']
-  title          varchar
-  body           text
-  source_quote   text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
-  source_context text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
-  status         varchar [note: 'draft / reviewing / todo / in_progress / done / rejected']
-  due_date       timestamp [note: '完了期限']
-  start_date     timestamp [note: '着手予定日。NULLの場合は未設定']
-  follow_up_date timestamp [note: '再検討日。期限が決められない場合にいつ期限を決め直すかを記録']
-  version        int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
-  created_at     timestamp
-  updated_at     timestamp
-  deleted_at     timestamp
+  Note: '会議から抽出されたタスク'
+  id               varchar  [pk]
+  meetingId        varchar  [ref: > meetings.id]
+  decisionItemId   varchar  [ref: > decision_items.id, note: 'NULLの場合は独立したタスク']
+  title            varchar
+  body             text
+  sourceQuote      text     [note: 'AIが根拠とした発話1文']
+  sourceContext    text     [note: '根拠周辺の文脈']
+  status           varchar  [note: 'draft / reviewing / todo / in_progress / done / rejected']
+  priority         varchar  [note: 'required / optional']
+  dueDateRaw       varchar  [note: '書き起こし上の期限表現をそのまま記録']
+  dueDateEstimated boolean  [note: 'due_dateが推定値の場合はtrue']
+  assigneeRaw      varchar  [note: '書き起こし上の担当者呼称']
+  blockingItemId   varchar  [note: 'ブロッキング対象のアイテムID']
+  carriedOverCount int      [note: '累計持ち越し回数']
+  ambiguityFlags   json
+  dueDate          timestamp
+  startDate        timestamp
+  followUpDate     timestamp
+  version          int      [default: 0, note: '楽観的ロック用バージョン番号']
+  createdAt        timestamp
+  updatedAt        timestamp
 
   indexes {
-    meeting_id
-    decision_item_id
-    due_date
-    start_date
+    meetingId
+    decisionItemId
+    dueDate
+    startDate
   }
 }
 
 Table task_assignees {
-  Note: 'タスクの担当者。1つのタスクに複数の担当者を紐づけられるよう中間テーブルとして管理する'
-  id         uuid [pk]
-  task_id    uuid [ref: > tasks.id]
-  user_id    uuid [ref: > users.id]
-  created_at timestamp
-  updated_at timestamp
-  deleted_at timestamp
+  Note: 'タスクの担当者。複数担当者に対応するための中間テーブル'
+  id     varchar [pk]
+  taskId varchar [ref: > tasks.id]
+  userId varchar [ref: > users.id]
 
   indexes {
-    (task_id, user_id) [unique]
+    (taskId, userId) [unique]
+    taskId
   }
 }
 
-Table ambiguous_info {
-  Note: '会議中に発生した曖昧な情報。resolution_typeによってタスク・決定事項未決事項への解消、または対応不要の棄却を管理する'
-  id                           uuid [pk]
-  meeting_id                   uuid [ref: > meetings.id]
-  body                         text
-  source_quote                 text [note: 'AIが根拠とした発話1文。レビュー画面のデフォルト表示に使用']
-  source_context               text [note: '根拠周辺の文脈。展開表示用。NULLの場合は未取得']
-  status                       varchar [note: 'draft / reviewing / resolved / rejected']
-  resolution_type              varchar [note: 'null = 未解消 / task / decision_item / discarded']
-  resolved_to_task_id          uuid [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
-  resolved_to_decision_item_id uuid [ref: > decision_items.id, note: 'resolution_type = decision_item のときのみ値が入る']
-  version                      int [not null, default: 0, note: '楽観的ロック用バージョン番号。更新のたびにインクリメント']
-  created_at           timestamp
-  updated_at           timestamp
-  deleted_at           timestamp
+Table ambiguous_infos {
+  Note: '会議中に発生した曖昧な情報'
+  id                       varchar  [pk]
+  meetingId                varchar  [ref: > meetings.id]
+  body                     text
+  sourceQuote              text     [note: 'AIが根拠とした発話1文']
+  sourceContext            text     [note: '根拠周辺の文脈']
+  status                   varchar  [note: 'draft / reviewing / resolved / rejected']
+  ambiguityType            varchar  [note: 'missing_speaker / transcription_error_low / transcription_error_high / no_assignee / no_deadline_mentioned / no_deadline_absolute / unclear_decision / insufficient_basis / unclear_scope']
+  severity                 varchar  [note: 'high / medium / low']
+  inferenceBasis           text     [note: 'missing_speakerの場合の推定根拠']
+  dueDateRaw               varchar  [note: 'no_deadline_absoluteの場合の期限表現']
+  dueDateEstimated         boolean  [note: 'AIが推定した場合はtrue']
+  affectedItemIds          json     [note: '解消時に変更を反映すべきタスクID・未決事項IDの配列']
+  resolutionType           varchar  [note: 'null = 未解消 / task / decision_item / discarded']
+  resolvedToTaskId         varchar  [ref: > tasks.id, note: 'resolution_type = task のときのみ値が入る']
+  resolvedToDecisionItemId varchar  [ref: > decision_items.id, note: 'resolution_type = decision_item のときのみ値が入る']
+  version                  int      [default: 0, note: '楽観的ロック用バージョン番号']
+  createdAt                timestamp
+  updatedAt                timestamp
 
   indexes {
-    meeting_id
+    meetingId
     status
   }
 }
 
 Table audit_logs {
-  Note: '各リソースへの操作履歴。変更前後の値をJSONで保持する追記専用の不変ログ'
-  id            uuid [pk]
-  actor_id      uuid [ref: > users.id]
-  resource_type varchar [note: 'task / decision_item / ambiguous_info など']
-  resource_id   uuid
-  action        varchar [note: 'create / update / delete']
-  before_value  json
-  after_value   json
-  created_at    timestamp
+  Note: '各リソースへの操作履歴。追記専用の不変ログ'
+  id           varchar [pk]
+  actorId      varchar [ref: > users.id]
+  resourceType varchar [note: 'task / decision_item / ambiguous_info など']
+  resourceId   varchar
+  action       varchar [note: 'create / update / delete']
+  beforeValue  json
+  afterValue   json
+  createdAt    timestamp
 
   indexes {
-    (resource_type, resource_id)
-    actor_id
+    (resourceType, resourceId)
+    actorId
   }
 }
 
 Table read_logs {
-  Note: 'ユーザーによるリソースの既読履歴。未読バッジ表示などの既読管理に使用する追記専用の不変ログ'
-  id            uuid [pk]
-  user_id       uuid [ref: > users.id]
-  resource_type varchar [note: 'task / decision_item / ambiguous_info など']
-  resource_id   uuid
-  read_at       timestamp
-  created_at    timestamp
+  Note: 'ユーザーによるリソースの既読履歴。追記専用の不変ログ'
+  id           varchar [pk]
+  userId       varchar [ref: > users.id]
+  resourceType varchar [note: 'task / decision_item / ambiguous_info など']
+  resourceId   varchar
+  readAt       timestamp
+  createdAt    timestamp
+
+  indexes {
+    (userId, resourceType, resourceId)
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.4))
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)


### PR DESCRIPTION
## 関連Issue
Closes #111 

## 概要・目的
* AIが生成する会議分析レポート（MeetingAnalysisReport）の解析結果をDBに保存できるようにするため、議事録解析結果に対応する新規テーブルの追加および既存テーブルへのカラム追加を行った
* 話者の解決状態・RAGインデックス・関連過去会議・所要時間見積もり内訳を管理するための新規テーブルを4つ追加した
* `DecisionItem` / `Task` / `AmbiguousInfo` にJSONスキーマ対応カラムを追加し、ステータス系カラムをすべてenum型で定義した

## 背景
* Issue A（#109）で `meetings` テーブルへのメタ情報カラム追加を行ったが、`MeetingAnalysisReport` の各セクション（`decisions` / `tasks` / `ambiguities` / `handover` / `rag_document`）に対応するDB構造がまだ不足していた
* ステータス系カラムをenum型で定義することで、不正な値をDB・Prismaレベルで防げるようにした
* `confidence`（書き起こし品質フラグ）はMVPスコープ外のため今回は追加しない

## 変更内容

### 新規追加テーブル（4テーブル）

| テーブル名 | 役割 | 対応するJSONフィールド |
|---|---|---|
| `MeetingSpeaker` | 話者ごとの解決状態（`resolved` / `unresolved` / `unknown`）を管理 | `meta.speakers` |
| `MeetingEstimationBreakdown` | 次回会議の所要時間見積もり内訳を管理 | `handover.estimation_breakdown` |
| `RagDocument` | Azure AI Searchに登録するRAGインデックスドキュメントを管理 | `rag_document` |
| `RelatedPastMeeting` | RAG検索で見つかった関連過去会議を管理 | `related_past_meetings` |

### 新規追加enum（7種）

| enum名 | 値 |
|---|---|
| `DecisionItemStatus` | `draft` / `reviewing` / `open` / `decided` / `cancelled` |
| `DecisionState` | `confirmed` / `tentative` / `open` |
| `DecisionReason` | `no_consensus` / `information_lack` / `intentional_defer` / `not_discussed` |
| `TaskStatus` | `draft` / `reviewing` / `todo` / `in_progress` / `done` / `rejected` |
| `TaskPriority` | `required` / `optional` |
| `AmbiguousInfoStatus` | `draft` / `reviewing` / `resolved` / `rejected` |
| `AmbiguityType` | `missing_speaker` / `transcription_error_low` / `transcription_error_high` / `no_assignee` / `no_deadline_mentioned` / `no_deadline_absolute` / `unclear_decision` / `insufficient_basis` / `unclear_scope` |
| `AmbiguitySeverity` | `high` / `medium` / `low` |
| `ResolutionType` | `task` / `decision_item` / `discarded` |
| `ResolutionStatus` | `resolved` / `unresolved` / `unknown` |
| `EstimationBreakdownType` | `required_task_check` / `open_issue_new` / `open_issue_recurring` / `overdue_task` / `new_topic` / `tentative_reconfirm` / `buffer` |

### 新規追加モデル（5モデル）

* `DecisionItem`：決定事項・未決事項。`decisionState` / `reason` / `blockingItemId` / `recurrenceCount` / `ambiguityFlags` を含む
* `DecisionItemAssignee`：決定事項の担当者（中間テーブル）
* `Task`：タスク。`priority` / `dueDateRaw` / `dueDateEstimated` / `assigneeRaw` / `blockingItemId` / `carriedOverCount` / `ambiguityFlags` を含む
* `TaskAssignee`：タスクの担当者（中間テーブル）
* `AmbiguousInfo`：曖昧情報。`ambiguityType` / `severity` / `inferenceBasis` / `dueDateRaw` / `dueDateEstimated` / `affectedItemIds` / `resolutionType` を含む

### 追記専用ログテーブル（2テーブル）

* `AuditLog`：各リソースへの操作履歴
* `ReadLog`：ユーザーによるリソースの既読履歴

### マイグレーション

* `apps/api/prisma/migrations/xxxxxxxxxx_add_meeting_analysis_tables/migration.sql`

## 動作確認手順
1. `docker compose up db -d` でDBを起動
2. `make migrate` を実行し、エラーなく完了することを確認
3. `make migrate-status` を実行し、全マイグレーションが `Applied` になっていることを確認

## スクリーンショット
* なし（DBスキーマ変更のみ）