### PR TITLE
feat: Makefile に refresh / logs / ps / help ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev dev-build dev-fresh dev-reset dev-native fake-auth-keys docker-clean lint test format migrate migrate-status db-shell
+.PHONY: help install dev dev-build dev-fresh dev-reset dev-native fake-auth-keys docker-clean lint test format migrate migrate-status db-shell refresh
 
 help: ## 利用可能な make ターゲット一覧を表示する
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -22,6 +22,15 @@ dev-reset: ## 全 volume（DB 含む）をリセットして起動する（起�
 
 docker-clean: ## コンテナと全 volume を削除する（起動はしない）
 	docker compose down -v --remove-orphans
+
+refresh: ## 単一サービスを anon volume ごと再生成する（SVC=<service> を指定）
+	@if [ -z "$(SVC)" ]; then \
+		echo "Usage: make refresh SVC=<service>" >&2; \
+		echo "  例: make refresh SVC=web" >&2; \
+		exit 1; \
+	fi
+	docker compose rm -fsv $(SVC)
+	docker compose up -d --build $(SVC)
 
 dev-native: ## インフラ（db / servicebus / fake-auth）のみ Docker で起動し、アプリは overmind で起動する
 	docker compose up -d db servicebus-db servicebus fake-auth

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,53 @@
-.PHONY: install dev dev-build dev-fresh dev-reset dev-native docker-clean lint test format migrate migrate-status db-shell
+.PHONY: help install dev dev-build dev-fresh dev-reset dev-native fake-auth-keys docker-clean lint test format migrate migrate-status db-shell
 
-install:
+help: ## 利用可能な make ターゲット一覧を表示する
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## pnpm install と uv sync で依存関係をインストールする
 	pnpm install
 	cd services/ai && uv sync
 
-# 全サービスを Docker Compose で起動する（イメージ再ビルドなし）
-dev:
+dev: ## 全サービスを Docker Compose で起動する（イメージ再ビルドなし）
 	docker compose up
 
-# イメージを再ビルドしてから起動する（package.json / Dockerfile 変更後）
-dev-build:
+dev-build: ## イメージを再ビルドしてから起動する（package.json / Dockerfile 変更後）
 	docker compose up --build
 
-# node_modules の anonymous volume のみリセットして起動する（DB データは維持）
-dev-fresh:
+dev-fresh: ## node_modules の anonymous volume のみリセットして起動する（DB データは維持）
 	docker compose up --build --renew-anon-volumes
 
-# 全 volume（DB 含む）をリセットして起動する（起動後に make migrate が必要）
-dev-reset:
+dev-reset: ## 全 volume（DB 含む）をリセットして起動する（起動後に make migrate が必要）
 	docker compose down -v
 	docker compose up --build
 
-# コンテナと全 volume を削除する
-docker-clean:
+docker-clean: ## コンテナと全 volume を削除する（起動はしない）
 	docker compose down -v --remove-orphans
 
-# インフラ（db / servicebus / fake-auth）のみ Docker で起動し、アプリは overmind（Procfile）で起動する
-dev-native:
+dev-native: ## インフラ（db / servicebus / fake-auth）のみ Docker で起動し、アプリは overmind で起動する
 	docker compose up -d db servicebus-db servicebus fake-auth
 	overmind start
 
-# fake-authのRSA鍵ペアを生成（初回のみ）
-fake-auth-keys:
+fake-auth-keys: ## fake-auth の RSA 鍵ペアを生成する（初回のみ）
 	cd services/fake-auth && pnpm install && pnpm generate-keys
 
-lint:
+lint: ## Biome (TS) + Ruff (Python) で lint を実行する
 	pnpm turbo run lint
 	cd services/ai && uv run ruff check .
 
-test:
+test: ## Vitest + pytest を実行する
 	pnpm turbo run test
 	cd services/ai && uv run pytest || [ $$? -eq 5 ]
 
-format:
+format: ## Biome + Ruff の自動修正を実行する
 	pnpm turbo run format
 	cd services/ai && uv run ruff format .
 
-migrate:
+migrate: ## prisma migrate dev を実行する（NAME=xxx でマイグレーション名指定可）
 	@if [ -f apps/api/.env ]; then set -a; . apps/api/.env; set +a; fi; pnpm --filter api exec prisma migrate dev --name $(if $(NAME),$(NAME),migration)
 
-# マイグレーションの適用状況を確認する
-migrate-status:
+migrate-status: ## マイグレーションの適用状況を確認する
 	@if [ -f apps/api/.env ]; then set -a; . apps/api/.env; set +a; fi; pnpm --filter api exec prisma migrate status
 
-# psql でDBに直接接続する
-db-shell:
+db-shell: ## psql で decision_loop DB に直接接続する
 	@if [ -f apps/api/.env ]; then set -a; . apps/api/.env; set +a; fi; \
 	  psql "$${DATABASE_URL}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev dev-build dev-fresh dev-reset dev-native fake-auth-keys docker-clean lint test format migrate migrate-status db-shell refresh
+.PHONY: help install dev dev-build dev-fresh dev-reset dev-native fake-auth-keys docker-clean lint test format migrate migrate-status db-shell refresh logs ps
 
 help: ## 利用可能な make ターゲット一覧を表示する
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -31,6 +31,12 @@ refresh: ## 単一サービスを anon volume ごと再生成する（SVC=<servi
 	fi
 	docker compose rm -fsv $(SVC)
 	docker compose up -d --build $(SVC)
+
+logs: ## docker compose logs -f を実行する（SVC=<service> で個別指定可）
+	docker compose logs -f $(SVC)
+
+ps: ## docker compose ps を実行する
+	docker compose ps
 
 dev-native: ## インフラ（db / servicebus / fake-auth）のみ Docker で起動し、アプリは overmind で起動する
 	docker compose up -d db servicebus-db servicebus fake-auth

--- a/README.md
+++ b/README.md
@@ -107,10 +107,20 @@ docker compose exec api wget -qO- http://fake-auth:3007/.well-known/jwks.json
 | `make dev` | 通常起動（イメージ再ビルドなし） | 維持 |
 | `make dev-build` | `package.json` / `Dockerfile` 変更後の再ビルド起動 | 維持 |
 | `make dev-fresh` | `node_modules` が壊れたときのリセット起動 | **維持** |
+| `make refresh SVC=<service>` | 単一サービスを anon volume ごと再生成（pnpm 依存追加時など） | 維持 |
 | `make dev-reset` | DB 含む全 volume をリセットして起動 | **消える** |
 | `make docker-clean` | コンテナと全 volume を削除（起動しない） | **消える** |
 
 > `make dev-reset` / `make docker-clean` 後は `make migrate` で DB を再構築してください。
+
+### コンテナ運用補助
+
+| コマンド | 用途 |
+|---------|------|
+| `make ps` | `docker compose ps` でコンテナ状態を確認する |
+| `make logs` | 全サービスのログを follow する |
+| `make logs SVC=<service>` | 個別サービスのログを follow する |
+| `make help` | 利用可能な make ターゲット一覧を表示する |
 
 ## Development
 


### PR DESCRIPTION
## 関連Issue
Closes #118

## 概要・目的
* 単一サービスを再生成する `make refresh SVC=<service>`、コンテナ運用補助の `make logs` / `make ps`、ターゲット一覧表示の `make help` を Makefile に追加した。
* pnpm 依存追加時に anonymous volume が残って Vite が解決に失敗する問題を、`dev-fresh` で全サービスを巻き込まずに 1 コマンドで復旧できるようにする。

## 背景
* PR #115 で `@radix-ui/react-dialog` を追加した際、Docker dev コンテナの `/app/apps/web/node_modules` の anon volume が古いまま残り、Vite が `Failed to resolve import` で起動しなくなる事象が発生した。
* 既存の `make dev-fresh` は `--renew-anon-volumes` で全サービスを再生成するため、1 サービスのみ復旧したい場面ではビルド時間が無駄に伸びる。
* ログ確認・コンテナ状態確認は素の `docker compose logs` / `docker compose ps` で行っており、Makefile に help が無いため利用可能なターゲットを目視で確認するしかなかった。

## 変更内容
* `Makefile`: `refresh` / `logs` / `ps` / `help` の 4 ターゲットを追加。
  * `refresh`: `docker compose rm -fsv $(SVC) && docker compose up -d --build $(SVC)`。`SVC` 未指定時は使い方を stderr に出して非 0 終了。
  * `logs`: `docker compose logs -f $(SVC)`。`SVC` 未指定なら全サービスを follow。
  * `ps`: `docker compose ps`。
  * `help`: 各ターゲット行のインライン `## description` コメントを awk で抽出して整列表示。
* `Makefile`: 既存ターゲットの説明コメントを `## ` インライン形式に統一（コマンド本体は不変）。
* `README.md`: 「Docker 起動コマンドの使い分け」表に `make refresh` を追記し、「コンテナ運用補助」セクションを新設して `ps` / `logs` / `help` を記載（CLAUDE.md Principle 9 の Documentation Sync 準拠）。

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-118-add-makefile-devx-targets`
2. `make help` を実行し、追加した 4 ターゲットを含むターゲット一覧が縦揃えで表示されることを確認する。
3. `make refresh` を引数なしで実行し、使い方が表示され `Error 1` で停止することを確認する。
4. `make -n refresh SVC=web` で `docker compose rm -fsv web` と `docker compose up -d --build web` が出力されることを確認する。
5. `make -n logs` / `make -n logs SVC=api` / `make -n ps` で期待コマンドが出力されることを確認する。
6. 既存ターゲットへの影響がないことを `make -n dev` / `make -n dev-fresh` で確認する。

## スクリーンショット
* 該当なし（CLI のみの変更）