### PR TITLE
feat(api): GET /organizations/:id に自分の role と定例一覧を含める

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -144,11 +144,20 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const guard = await requireMembership(c, id);
     if (!guard.ok) return guard.res;
 
-    const org = await prisma.organization.findUnique({ where: { id } });
+    // 自分の role はガードで確定済みのものを流用し、追加クエリを避ける。
+    // 定例一覧は組織詳細画面の簡易表示用に併せて返す（並び順は作成日時降順）。
+    const org = await prisma.organization.findUnique({
+      where: { id },
+      include: {
+        recurringMeetings: {
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    });
     if (!org) {
       return c.json({ error: "組織が見つかりません" }, 404);
     }
-    return c.json(org);
+    return c.json({ ...org, role: guard.membership.role });
   })
   .patch("/:id", zValidator("json", updateSchema), async (c) => {
     const id = c.req.param("id");

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -229,28 +229,104 @@ describe("GET /organizations", () => {
 describe("GET /organizations/:id", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("認証ユーザーが所属していれば 200 で組織を返す", async () => {
+  const sampleRecurringMeetings = [
+    {
+      id: "meet-2",
+      organizationId: "org-1",
+      name: "週次定例",
+      description: null,
+      scheduleCron: "0 10 * * 1",
+      createdAt: new Date("2026-05-03T00:00:00Z"),
+      updatedAt: new Date("2026-05-03T00:00:00Z"),
+    },
+    {
+      id: "meet-1",
+      organizationId: "org-1",
+      name: "月次レビュー",
+      description: "月初に実施",
+      scheduleCron: "0 9 1 * *",
+      createdAt: new Date("2026-05-01T00:00:00Z"),
+      updatedAt: new Date("2026-05-01T00:00:00Z"),
+    },
+  ];
+
+  it("認証ユーザーが所属していれば 200 で組織と自分の role・定例一覧を返す", async () => {
     mockMembershipFindUnique.mockResolvedValue({
       userId: "user-1",
       organizationId: "org-1",
-      role: "member",
+      role: "owner",
       joinedAt: new Date("2026-05-01T00:00:00Z"),
     });
-    mockOrgFindUnique.mockResolvedValue(sampleOrg);
+    mockOrgFindUnique.mockResolvedValue({
+      ...sampleOrg,
+      recurringMeetings: sampleRecurringMeetings,
+    } as never);
 
     const res = await app.request("/organizations/org-1");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { id: string };
+    const body = (await res.json()) as {
+      id: string;
+      role: string;
+      recurringMeetings: Array<{ id: string; createdAt: string }>;
+    };
     expect(body.id).toBe("org-1");
+    expect(body.role).toBe("owner");
+    expect(body.recurringMeetings).toHaveLength(2);
+    expect(body.recurringMeetings[0].id).toBe("meet-2");
+    expect(body.recurringMeetings[1].id).toBe("meet-1");
 
     expect(mockMembershipFindUnique).toHaveBeenCalledWith({
       where: {
         userId_organizationId: { userId: "user-1", organizationId: "org-1" },
       },
     });
+    // recurringMeetings を include で取得し、createdAt desc で並べる。
     expect(mockOrgFindUnique).toHaveBeenCalledWith({
       where: { id: "org-1" },
+      include: {
+        recurringMeetings: {
+          orderBy: { createdAt: "desc" },
+        },
+      },
     });
+  });
+
+  it("member ロールでも自分の role が反映されて返る", async () => {
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    });
+    mockOrgFindUnique.mockResolvedValue({
+      ...sampleOrg,
+      recurringMeetings: [],
+    } as never);
+
+    const res = await app.request("/organizations/org-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { role: string };
+    expect(body.role).toBe("member");
+  });
+
+  it("定例が 0 件なら recurringMeetings は空配列で返る", async () => {
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "admin",
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    });
+    mockOrgFindUnique.mockResolvedValue({
+      ...sampleOrg,
+      recurringMeetings: [],
+    } as never);
+
+    const res = await app.request("/organizations/org-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      recurringMeetings: unknown[];
+    };
+    expect(body.recurringMeetings).toEqual([]);
   });
 
   it("認証ユーザーが所属していない場合は 404 を返す", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #126

## 概要・目的
* 組織詳細画面 (#88) の実装に必要となる、自分の role と組織配下の定例一覧を `GET /organizations/:id` のレスポンスで返せるようにする

## 背景
* 組織一覧 API は自分の role を平坦化して返しているが、詳細 API は素の Organization のみで role を含まなかった
* フロント側で owner/admin 判定を行うため、詳細レスポンスにも role が必要
* 組織配下の定例一覧を簡易表示する仕様 (#88) があるが、定例取得用エンドポイントは未整備のため、詳細レスポンスに併せて含める

## 変更内容
* `GET /organizations/:id`
  * レスポンスに `role: "owner" | "admin" | "member"` を含める（`requireMembership` で確定済みの `membership.role` を流用）
  * レスポンスに `recurringMeetings` 配列を含める（`findUnique` の `include` で取得、`createdAt` 降順で並べる）
* `test/organizations.test.ts`
  * 既存の GET /:id 成功系テストを role / recurringMeetings 検証に拡張
  * member ロール反映を確認するテストを追加
  * 定例 0 件の組織で空配列が返ることを確認するテストを追加

## 動作確認手順
1. `make install`（依存変更なしのため初回のみ）
2. `make lint` で lint エラーが出ないこと
3. `make test` で Vitest が `apps/api` の 83 件を含めてすべて GREEN になること
4. `make dev` でローカル環境を起動し、`make migrate` を一度実行しておく
5. fake-auth で取得したトークンを使って `GET http://localhost:8787/organizations/:id` を呼び出し、レスポンスに `role` と `recurringMeetings` が含まれることを確認

## スクリーンショット
* API レスポンス例:
  ```json
  {
    "id": "org-1",
    "name": "ACME 株式会社",
    "description": "テスト組織",
    "createdAt": "2026-05-01T00:00:00.000Z",
    "updatedAt": "2026-05-01T00:00:00.000Z",
    "role": "owner",
    "recurringMeetings": [
      {
        "id": "meet-2",
        "organizationId": "org-1",
        "name": "週次定例",
        "description": null,
        "scheduleCron": "0 10 * * 1",
        "createdAt": "2026-05-03T00:00:00.000Z",
        "updatedAt": "2026-05-03T00:00:00.000Z"
      }
    ]
  }
  ```

