### PR TITLE
feat(api): 組織メンバー一覧 API (GET /organizations/:id/members) を追加

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -159,6 +159,39 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     }
     return c.json({ ...org, role: guard.membership.role });
   })
+  .get("/:id/members", async (c) => {
+    const id = c.req.param("id");
+
+    const guard = await requireMembership(c, id);
+    if (!guard.ok) return guard.res;
+
+    // OrgRole enum を DB 側で owner→admin→member 順に並べる手段がないため
+    // findMany では並べず、レスポンス整形時にメモリ内ソートする。
+    const memberships = await prisma.organizationMembership.findMany({
+      where: { organizationId: id },
+      include: { user: true },
+    });
+
+    const roleOrder: Record<OrgRole, number> = {
+      owner: 0,
+      admin: 1,
+      member: 2,
+    };
+    const sorted = [...memberships].sort((a, b) => {
+      if (a.role !== b.role) return roleOrder[a.role] - roleOrder[b.role];
+      return a.joinedAt.getTime() - b.joinedAt.getTime();
+    });
+
+    const result = sorted.map((m) => ({
+      userId: m.userId,
+      name: m.user.name,
+      displayName: m.user.displayName,
+      email: m.user.email,
+      role: m.role,
+      joinedAt: m.joinedAt,
+    }));
+    return c.json(result);
+  })
   .patch("/:id", zValidator("json", updateSchema), async (c) => {
     const id = c.req.param("id");
     const data = c.req.valid("json");

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -13,6 +13,7 @@ vi.mock("../src/lib/prisma.js", () => ({
     organizationMembership: {
       findUnique: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
     },
     organizationInvitation: {
@@ -71,6 +72,9 @@ const mockMembershipFindUnique = vi.mocked(
 );
 const mockMembershipFindFirst = vi.mocked(
   prisma.organizationMembership.findFirst,
+);
+const mockMembershipFindMany = vi.mocked(
+  prisma.organizationMembership.findMany,
 );
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
 const mockTransaction = vi.mocked(prisma.$transaction);
@@ -349,6 +353,128 @@ describe("GET /organizations/:id", () => {
 
     const res = await app.request("/organizations/org-1");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /organizations/:id/members", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const sampleMemberships = [
+    // 並び順検証用に、意図的に DB 順序を「想定の表示順」と逆にしておく。
+    {
+      userId: "user-3",
+      organizationId: "org-1",
+      role: "member" as const,
+      joinedAt: new Date("2026-05-05T00:00:00Z"),
+      user: {
+        id: "user-3",
+        name: "carol",
+        displayName: "Carol C.",
+        email: "carol@example.com",
+      },
+    },
+    {
+      userId: "user-2",
+      organizationId: "org-1",
+      role: "admin" as const,
+      joinedAt: new Date("2026-05-03T00:00:00Z"),
+      user: {
+        id: "user-2",
+        name: "bob",
+        displayName: "Bob B.",
+        email: "bob@example.com",
+      },
+    },
+    {
+      userId: "user-4",
+      organizationId: "org-1",
+      role: "member" as const,
+      joinedAt: new Date("2026-05-02T00:00:00Z"),
+      user: {
+        id: "user-4",
+        name: "dave",
+        displayName: "Dave D.",
+        email: "dave@example.com",
+      },
+    },
+    {
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "owner" as const,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+      user: {
+        id: "user-1",
+        name: "alice",
+        displayName: "Alice A.",
+        email: "alice@example.com",
+      },
+    },
+  ];
+
+  it("認証ユーザーが所属していれば 200 でメンバー一覧を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "owner",
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    });
+    mockMembershipFindMany.mockResolvedValue(sampleMemberships as never);
+
+    const res = await app.request("/organizations/org-1/members");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      userId: string;
+      name: string;
+      displayName: string;
+      email: string;
+      role: string;
+      joinedAt: string;
+    }>;
+
+    expect(body).toHaveLength(4);
+    // owner → admin → member、同 role 内は joinedAt asc
+    expect(body.map((m) => m.userId)).toEqual([
+      "user-1",
+      "user-2",
+      "user-4",
+      "user-3",
+    ]);
+    expect(body[0]).toEqual({
+      userId: "user-1",
+      name: "alice",
+      displayName: "Alice A.",
+      email: "alice@example.com",
+      role: "owner",
+      joinedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    expect(mockMembershipFindMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1" },
+      include: { user: true },
+    });
+  });
+
+  it("member ロールでも所属していればメンバー一覧を取得できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-3",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date("2026-05-05T00:00:00Z"),
+    });
+    mockMembershipFindMany.mockResolvedValue(sampleMemberships as never);
+
+    const res = await app.request("/organizations/org-1/members");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ role: string }>;
+    expect(body).toHaveLength(4);
+  });
+
+  it("認証ユーザーが所属していない場合は 404 を返し findMany は呼ばれない", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/organizations/org-1/members");
+    expect(res.status).toBe(404);
+    expect(mockMembershipFindMany).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #127

## 概要・目的
* 組織詳細画面 (#88) でメンバー一覧を表示するために、`GET /organizations/:id/members` を新設する

## 背景
* 組織詳細レスポンス (#126 で `role` と `recurringMeetings` を追加済み) にメンバー一覧は含めず、責務分離のため別エンドポイントとして切り出す
* User 情報（name / displayName / email）と OrganizationMembership.role の両方が必要

## 変更内容
* `apps/api/src/routes/organizations.ts`
  * `GET /:id/members` ハンドラを追加（`GET /:id` の直後）
  * `prisma.organizationMembership.findMany({ where: { organizationId }, include: { user: true } })`
  * 並び順は OrgRole の DB 順制御ができないため、メモリ内で owner → admin → member → joinedAt 昇順にソート
  * レスポンスは `{ userId, name, displayName, email, role, joinedAt }[]` に平坦化
  * 認可は所属メンバー全員 (`requireMembership`)、未所属者には 404 を返す
* `apps/api/test/organizations.test.ts`
  * `organizationMembership.findMany` のモックを追加
  * 並び順検証・member ロールでの取得可・未所属者の 404 の 3 ケースを追加

## 動作確認手順
1. `make install`（依存変更なしのため初回のみ）
2. `make lint` で lint エラーが出ないこと
3. `make test` で Vitest が `apps/api` の 86 件を含めてすべて GREEN になること
4. `make dev` でローカル環境を起動し、`make migrate` を一度実行しておく
5. fake-auth で取得したトークンを使って `GET http://localhost:8787/organizations/:id/members` を呼び出し、メンバーが owner → admin → member の順で返ることを確認

## スクリーンショット
* API レスポンス例:
  ```json
  [
    {
      "userId": "user-1",
      "name": "alice",
      "displayName": "Alice A.",
      "email": "alice@example.com",
      "role": "owner",
      "joinedAt": "2026-05-01T00:00:00.000Z"
    },
    {
      "userId": "user-2",
      "name": "bob",
      "displayName": "Bob B.",
      "email": "bob@example.com",
      "role": "admin",
      "joinedAt": "2026-05-03T00:00:00.000Z"
    }
  ]
  ```
