### PR TITLE
feat(api): 組織メンバー削除 API (DELETE /organizations/:id/members/:userId) を追加

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -192,6 +192,49 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     }));
     return c.json(result);
   })
+  .delete("/:id/members/:userId", async (c) => {
+    const id = c.req.param("id");
+    const targetUserId = c.req.param("userId");
+    const callerUserId = c.var.user.id;
+
+    const guard = await requireRole(
+      c,
+      id,
+      ["owner"],
+      "メンバー削除権限がありません",
+    );
+    if (!guard.ok) return guard.res;
+
+    // 自己削除は #125（退会）の責務として本エンドポイントでは拒否する。
+    if (callerUserId === targetUserId) {
+      return c.json({ error: "自分自身を削除することはできません" }, 400);
+    }
+
+    // 削除対象 membership の存在を事前確認し、無ければ 404。
+    // delete 時の P2025 を catch する方法もあるが、可読性優先で事前 findUnique を採る。
+    const target = await prisma.organizationMembership.findUnique({
+      where: {
+        userId_organizationId: {
+          userId: targetUserId,
+          organizationId: id,
+        },
+      },
+    });
+    if (!target) {
+      return c.json({ error: "対象メンバーが見つかりません" }, 404);
+    }
+
+    // MeetingMember は schema 側で onDelete: Cascade のため連鎖削除される。
+    await prisma.organizationMembership.delete({
+      where: {
+        userId_organizationId: {
+          userId: targetUserId,
+          organizationId: id,
+        },
+      },
+    });
+    return c.body(null, 204);
+  })
   .patch("/:id", zValidator("json", updateSchema), async (c) => {
     const id = c.req.param("id");
     const data = c.req.valid("json");

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -15,6 +15,7 @@ vi.mock("../src/lib/prisma.js", () => ({
       findFirst: vi.fn(),
       findMany: vi.fn(),
       create: vi.fn(),
+      delete: vi.fn(),
     },
     organizationInvitation: {
       create: vi.fn(),
@@ -76,6 +77,7 @@ const mockMembershipFindFirst = vi.mocked(
 const mockMembershipFindMany = vi.mocked(
   prisma.organizationMembership.findMany,
 );
+const mockMembershipDelete = vi.mocked(prisma.organizationMembership.delete);
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
@@ -475,6 +477,99 @@ describe("GET /organizations/:id/members", () => {
     const res = await app.request("/organizations/org-1/members");
     expect(res.status).toBe(404);
     expect(mockMembershipFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /organizations/:id/members/:userId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function membership(role: "owner" | "admin" | "member", userId = "user-1") {
+    return {
+      userId,
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  it("owner は他メンバーを削除でき 204 を返す", async () => {
+    // requireRole 内の findUnique（呼び出し元の membership）→ 削除対象の findUnique の順で呼ばれる
+    mockMembershipFindUnique
+      .mockResolvedValueOnce(membership("owner", "user-1"))
+      .mockResolvedValueOnce(membership("member", "user-2"));
+    mockMembershipDelete.mockResolvedValue(
+      membership("member", "user-2") as never,
+    );
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockMembershipDelete).toHaveBeenCalledWith({
+      where: {
+        userId_organizationId: { userId: "user-2", organizationId: "org-1" },
+      },
+    });
+  });
+
+  it("admin は 403 を返し delete は呼ばれない", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(
+      membership("admin", "user-1"),
+    );
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+
+  it("member は 403 を返し delete は呼ばれない", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(
+      membership("member", "user-1"),
+    );
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+
+  it("削除対象 membership が存在しない場合は 404 を返し delete は呼ばれない", async () => {
+    mockMembershipFindUnique
+      .mockResolvedValueOnce(membership("owner", "user-1"))
+      .mockResolvedValueOnce(null);
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+
+  it("自分自身を削除しようとした場合は 400 を返し delete は呼ばれない", async () => {
+    // requireRole では owner と判定されるが、対象が自分なら 400 で拒否
+    mockMembershipFindUnique.mockResolvedValueOnce(
+      membership("owner", "user-1"),
+    );
+
+    const res = await app.request("/organizations/org-1/members/user-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+
+  it("認証ユーザー自身が未所属の場合は 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(null);
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #128

## 概要・目的
* 組織詳細画面 (#88) で owner が他メンバーを組織から削除するため、`DELETE /organizations/:id/members/:userId` を新設する

## 背景
* 組織詳細画面 (#88) では owner のみがメンバーを削除できる UI を備える
* #125（自分の退会）とは責務が異なるため、本エンドポイントでは「他メンバーの削除」に限定し、自己削除は 400 で拒否する

## 変更内容
* `apps/api/src/routes/organizations.ts`
  * `DELETE /:id/members/:userId` ハンドラを追加（`GET /:id/members` の直後）
  * 認可: owner のみ（`requireRole(["owner"], "メンバー削除権限がありません")`）
  * 自己削除拒否: `c.var.user.id === :userId` の場合 400
  * 削除対象 membership の存在を事前 `findUnique` で確認 → 無ければ 404
  * `prisma.organizationMembership.delete` を複合主キーで実行、成功時は 204
  * `MeetingMember` は schema の `onDelete: Cascade` で連鎖削除されるため、本ハンドラでは追加処理なし
* `apps/api/test/organizations.test.ts`
  * `organizationMembership.delete` のモックを追加
  * 6 ケース追加: owner 成功、admin/member の 403、対象 404、自己削除 400、未所属の 404

## 動作確認手順
1. `make install`（依存変更なしのため初回のみ）
2. `make lint` で lint エラーが出ないこと
3. `make test` で Vitest が `apps/api` の 92 件を含めてすべて GREEN になること
4. `make dev` でローカル環境を起動し、`make migrate` を一度実行しておく
5. fake-auth で取得した owner のトークンで `DELETE http://localhost:8787/organizations/<orgId>/members/<otherUserId>` を呼び出し、204 が返ることを確認
6. 同じトークンで自分自身の userId を指定して呼ぶと 400、存在しないメンバーを指定すると 404 になることを確認
7. admin / member のトークンで呼ぶと 403 になることを確認

## スクリーンショット
* リクエスト例:
  ```
  DELETE /organizations/org-1/members/user-2
  Authorization: Bearer <owner-token>
  ```
* 成功時レスポンス: `204 No Content`
* 失敗時レスポンス例（自己削除）:
  ```json
  { "error": "自分自身を削除することはできません" }
  ```
