### PR TITLE
refactor(web): 組織関連の型・コンポーネントを共有モジュールに集約

### DIFF
--- a/apps/web/src/features/organizations/components/RoleBadge.tsx
+++ b/apps/web/src/features/organizations/components/RoleBadge.tsx
@@ -1,0 +1,10 @@
+import { roleLabels } from "../labels";
+import type { OrgRole } from "../types";
+
+export function RoleBadge({ role }: { role: OrgRole }) {
+  return (
+    <span className="inline-flex items-center rounded-md border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {roleLabels[role]}
+    </span>
+  );
+}

--- a/apps/web/src/features/organizations/labels.ts
+++ b/apps/web/src/features/organizations/labels.ts
@@ -1,0 +1,7 @@
+import type { OrgRole } from "./types";
+
+export const roleLabels: Record<OrgRole, string> = {
+  owner: "オーナー",
+  admin: "管理者",
+  member: "メンバー",
+};

--- a/apps/web/src/features/organizations/types.ts
+++ b/apps/web/src/features/organizations/types.ts
@@ -1,0 +1,39 @@
+export type OrgRole = "owner" | "admin" | "member";
+
+export type Organization = {
+  id: string;
+  name: string;
+  description: string | null;
+  role: OrgRole;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Member = {
+  userId: string;
+  name: string;
+  displayName: string;
+  email: string;
+  role: OrgRole;
+  joinedAt: string;
+};
+
+export type RecurringMeeting = {
+  id: string;
+  organizationId: string;
+  name: string;
+  description: string | null;
+  scheduleCron: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type OrganizationDetail = {
+  id: string;
+  name: string;
+  description: string | null;
+  role: OrgRole;
+  createdAt: string;
+  updatedAt: string;
+  recurringMeetings: RecurringMeeting[];
+};

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -10,6 +10,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RoleBadge } from "@/features/organizations/components/RoleBadge";
+import type {
+  Member,
+  OrganizationDetail,
+} from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
 import { authAtom } from "@/lib/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -23,51 +28,6 @@ import { z } from "zod";
 export const Route = createFileRoute("/organizations/$id")({
   component: OrganizationDetailPage,
 });
-
-type OrgRole = "owner" | "admin" | "member";
-
-type Member = {
-  userId: string;
-  name: string;
-  displayName: string;
-  email: string;
-  role: OrgRole;
-  joinedAt: string;
-};
-
-type RecurringMeeting = {
-  id: string;
-  organizationId: string;
-  name: string;
-  description: string | null;
-  scheduleCron: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-type OrganizationDetail = {
-  id: string;
-  name: string;
-  description: string | null;
-  role: OrgRole;
-  createdAt: string;
-  updatedAt: string;
-  recurringMeetings: RecurringMeeting[];
-};
-
-const roleLabels: Record<OrgRole, string> = {
-  owner: "オーナー",
-  admin: "管理者",
-  member: "メンバー",
-};
-
-function RoleBadge({ role }: { role: OrgRole }) {
-  return (
-    <span className="inline-flex items-center rounded-md border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
-      {roleLabels[role]}
-    </span>
-  );
-}
 
 function OrganizationDetailPage() {
   const { id } = Route.useParams();

--- a/apps/web/src/routes/organizations.index.tsx
+++ b/apps/web/src/routes/organizations.index.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RoleBadge } from "@/features/organizations/components/RoleBadge";
+import type { Organization } from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -27,31 +29,6 @@ import { z } from "zod";
 export const Route = createFileRoute("/organizations/")({
   component: OrganizationsPage,
 });
-
-type OrgRole = "owner" | "admin" | "member";
-
-type Organization = {
-  id: string;
-  name: string;
-  description: string | null;
-  role: OrgRole;
-  createdAt: string;
-  updatedAt: string;
-};
-
-const roleLabels: Record<OrgRole, string> = {
-  owner: "オーナー",
-  admin: "管理者",
-  member: "メンバー",
-};
-
-function RoleBadge({ role }: { role: OrgRole }) {
-  return (
-    <span className="inline-flex items-center rounded-md border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
-      {roleLabels[role]}
-    </span>
-  );
-}
 
 function OrganizationCard({ org }: { org: Organization }) {
   return (

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -1,3 +1,7 @@
+import type {
+  Member,
+  OrganizationDetail,
+} from "@/features/organizations/types";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,37 +37,6 @@ function mockJson<T>(data: T, status = 200) {
     json: async () => data,
   } as never;
 }
-
-type OrgRole = "owner" | "admin" | "member";
-
-type Member = {
-  userId: string;
-  name: string;
-  displayName: string;
-  email: string;
-  role: OrgRole;
-  joinedAt: string;
-};
-
-type RecurringMeeting = {
-  id: string;
-  organizationId: string;
-  name: string;
-  description: string | null;
-  scheduleCron: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-type OrganizationDetail = {
-  id: string;
-  name: string;
-  description: string | null;
-  role: OrgRole;
-  createdAt: string;
-  updatedAt: string;
-  recurringMeetings: RecurringMeeting[];
-};
 
 const ownerOrgDetail: OrganizationDetail = {
   id: "org-1",


### PR DESCRIPTION
## 関連Issue
Closes #134

## 概要・目的
* 組織一覧・詳細・テストに重複していた `OrgRole` 型 / `roleLabels` / `RoleBadge` 等を `apps/web/src/features/organizations/` に集約した。後続の組織詳細分割 (#135) や定例管理画面 (#89)、招待受諾画面 (#121) で同じ型・表示を再利用できる土台を作るため。

## 背景
* PR #132（組織詳細画面）のレビュー §3.6 で、`OrgRole` 型・`roleLabels` 定数・`RoleBadge` コンポーネントが `organizations.index.tsx` と `organizations.$id.tsx` で完全に重複していると指摘された
* 今後 recurring meetings 詳細など、同じロール表示が必要な画面が増える見込み
* テスト側 (`organizations.$id.test.tsx`) にも `OrgRole` / `Member` / `RecurringMeeting` / `OrganizationDetail` の型がローカル定義されていた

## 変更内容
* `apps/web/src/features/organizations/types.ts` を新設し、`OrgRole`, `Organization`, `Member`, `RecurringMeeting`, `OrganizationDetail` を export
* `apps/web/src/features/organizations/labels.ts` に `roleLabels` を集約
* `apps/web/src/features/organizations/components/RoleBadge.tsx` に `RoleBadge` を切り出し
* `organizations.index.tsx` / `organizations.$id.tsx` / `organizations.$id.test.tsx` のローカル定義を削除し、共有モジュールから import
* 配置は Issue #135（組織詳細のダイアログ単位分割）が `features/` 採用を提案しているため、ディレクトリ方針を `features/organizations/` に統一

## 動作確認手順
1. ブランチ checkout: `git checkout feature/issue-134-share-org-types`
2. 依存関係: `pnpm install`（差分なし、必要時のみ）
3. 型チェック: `apps/web` 配下で `pnpm typecheck` → エラー 0
4. Lint: `pnpm lint` → エラー 0
5. テスト: `pnpm test` → 100 件 passed
6. 動作確認: `pnpm dev` で `/organizations` と `/organizations/:id` を開き、ロールバッジ（オーナー / 管理者 / メンバー）が従来通り表示されることを確認

## スクリーンショット
* UI の見た目に変更なし（純粋なリファクタのため）