### PR TITLE
feat(web): サイドバー組織エリアから選択・作成・詳細遷移を可能にする

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.100.9",

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,18 +1,108 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
+import type { Organization } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import {
+  clearCurrentOrganizationIdAtom,
+  currentOrganizationIdAtom,
+  setCurrentOrganizationIdAtom,
+} from "@/lib/currentOrganization";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { CalendarDays, ChevronDown, LayoutDashboard } from "lucide-react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  CalendarDays,
+  ChevronDown,
+  LayoutDashboard,
+  ListIcon,
+  PlusIcon,
+  SettingsIcon,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+// 組織一覧フェッチ。クエリキー / fetcher は organizations.index.tsx と
+// 完全に同一にしておくことで、TanStack Query のキャッシュを共有する。
+// 結果として、一覧ページや作成ダイアログで invalidate された変更が
+// サイドバーにも即座に反映される。
+function useOrganizations() {
+  return useQuery<Organization[]>({
+    queryKey: ["organizations"],
+    queryFn: async () => {
+      const res = await api.organizations.$get(undefined, authHeaders());
+      if (!res.ok) {
+        throw new Error(`Failed to fetch organizations: ${res.status}`);
+      }
+      return (await res.json()) as Organization[];
+    },
+  });
+}
+
+// 組織アバター用の頭文字を取り出す。null/空文字を安全に扱う。
+function initial(name: string | null | undefined): string {
+  if (!name) return "?";
+  // サロゲートペア (絵文字等) を 1 文字として扱うため Array.from で分割する。
+  const chars = Array.from(name.trim());
+  return chars[0] ?? "?";
+}
 
 export function Sidebar() {
+  const { data: orgs, isLoading } = useOrganizations();
+  const currentId = useAtomValue(currentOrganizationIdAtom);
+  const setCurrentId = useSetAtom(setCurrentOrganizationIdAtom);
+  const clearCurrentId = useSetAtom(clearCurrentOrganizationIdAtom);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  // 組織一覧の取得結果を見て「現在の組織 ID」を整合させる。
+  //   - 一覧が空 → null にリセット (退会・削除直後など)
+  //   - 一覧があり、現在 ID が未設定 or 一覧に存在しない → 先頭を採用
+  // 「常にどれかが選択されている」状態を保つことで、サイドバーや詳細リンクの
+  // 表示分岐をシンプルにする。
+  useEffect(() => {
+    if (!orgs) return;
+    if (orgs.length === 0) {
+      if (currentId !== null) clearCurrentId();
+      return;
+    }
+    const stillExists = currentId
+      ? orgs.some((o) => o.id === currentId)
+      : false;
+    if (!stillExists) {
+      setCurrentId(orgs[0].id);
+    }
+  }, [orgs, currentId, setCurrentId, clearCurrentId]);
+
+  const currentOrg = orgs?.find((o) => o.id === currentId) ?? null;
+
   return (
-    <aside className="w-52 border-r border-border/50 bg-muted/30 flex flex-col shrink-0">
-      {/* 組織セレクター（未実装） */}
-      <button
-        type="button"
-        className="flex items-center gap-2.5 px-3 py-3 border-b border-border/50 hover:bg-muted/60 transition-colors text-left w-full"
-      >
-        <div className="w-6 h-6 rounded-md bg-muted-foreground/20 shrink-0" />
-        <span className="text-sm font-medium truncate flex-1">組織名</span>
-        <ChevronDown size={13} className="text-muted-foreground/70 shrink-0" />
-      </button>
+    <aside
+      aria-label="サイドバー"
+      className="w-52 border-r border-border/50 bg-muted/30 flex flex-col shrink-0"
+    >
+      <OrganizationSelector
+        isLoading={isLoading}
+        orgs={orgs ?? null}
+        currentOrg={currentOrg}
+        currentId={currentId}
+        onSelect={setCurrentId}
+        onOpenCreateDialog={() => setCreateDialogOpen(true)}
+      />
+
+      {/* 制御モードの作成ダイアログ。サイドバーのトリガー (CTA / メニュー項目)
+          から open=true にし、作成成功時は currentId を新組織に切り替える。 */}
+      <CreateOrganizationDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        onCreated={(id) => setCurrentId(id)}
+      />
 
       {/* ナビゲーション */}
       <nav className="flex flex-col gap-0.5 p-2 flex-1">
@@ -28,7 +118,7 @@ export function Sidebar() {
           ダッシュボード
         </Link>
 
-        {/* 定例セクション（将来的にAPIから取得） */}
+        {/* 定例セクション（API 実装後に Issue #86 / #89 で連動予定） */}
         <p className="px-2.5 pt-4 pb-1 text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
           定例
         </p>
@@ -38,5 +128,133 @@ export function Sidebar() {
         </div>
       </nav>
     </aside>
+  );
+}
+
+// サイドバー上部の「組織エリア」を切り出した内部コンポーネント。
+// 状態は親が管理し、こちらは表示分岐とイベント転送のみを担う。
+function OrganizationSelector({
+  isLoading,
+  orgs,
+  currentOrg,
+  currentId,
+  onSelect,
+  onOpenCreateDialog,
+}: {
+  isLoading: boolean;
+  orgs: Organization[] | null;
+  currentOrg: Organization | null;
+  currentId: string | null;
+  onSelect: (id: string) => void;
+  onOpenCreateDialog: () => void;
+}) {
+  if (isLoading) {
+    // 取得中はレイアウトずれを避けるためボタンと同じ高さのスケルトンを置く。
+    return (
+      <div
+        role="status"
+        aria-label="組織一覧を読み込み中"
+        className="h-12 border-b border-border/50 px-3 py-3 flex items-center"
+      >
+        <div className="h-6 w-full rounded-md bg-muted-foreground/15 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!orgs || orgs.length === 0) {
+    // 0 件のときは作成 CTA のみを表示する。強制的にダイアログを開かないのは、
+    // 招待リンク経由で参加するユーザーが居ても邪魔にならないようにするため。
+    return (
+      <button
+        type="button"
+        onClick={onOpenCreateDialog}
+        className="flex items-center gap-2.5 px-3 py-3 border-b border-border/50 hover:bg-muted/60 transition-colors text-left w-full"
+      >
+        <div className="w-6 h-6 rounded-md bg-muted-foreground/20 shrink-0 flex items-center justify-center">
+          <PlusIcon size={13} />
+        </div>
+        <span className="text-sm font-medium truncate flex-1">
+          新しい組織を作成
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="組織を切り替え"
+          className="flex items-center gap-2.5 px-3 py-3 border-b border-border/50 hover:bg-muted/60 transition-colors text-left w-full"
+        >
+          <div className="w-6 h-6 rounded-md bg-muted-foreground/20 shrink-0 flex items-center justify-center text-[11px] font-semibold uppercase">
+            {initial(currentOrg?.name)}
+          </div>
+          <span className="text-sm font-medium truncate flex-1">
+            {currentOrg?.name ?? "組織を選択"}
+          </span>
+          <ChevronDown
+            size={13}
+            className="text-muted-foreground/70 shrink-0"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        // トリガーの幅に概ね合わせる。ChevronDown が右端に来るデザインに揃える。
+        className="w-56"
+      >
+        <DropdownMenuLabel>組織を切り替え</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={currentId ?? ""}
+          onValueChange={(value) => {
+            // RadioGroup の onValueChange は同値選択でも発火することがあるため
+            // 念のため変化時のみ書き込む。
+            if (value && value !== currentId) onSelect(value);
+          }}
+        >
+          {orgs.map((o) => (
+            <DropdownMenuRadioItem key={o.id} value={o.id}>
+              <span className="truncate">{o.name}</span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        {currentId ? (
+          <DropdownMenuItem asChild>
+            <Link
+              to="/organizations/$id"
+              params={{ id: currentId }}
+              className="cursor-pointer"
+            >
+              <SettingsIcon />
+              現在の組織の詳細
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem asChild>
+          <Link to="/organizations" className="cursor-pointer">
+            <ListIcon />
+            すべての組織を見る
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(e) => {
+            // onSelect のデフォルト挙動でメニューが閉じた直後にダイアログを
+            // 開こうとすると Radix の focus 管理と競合してフォーカスがずれる
+            // ことがある。preventDefault でメニューの自動 close を抑止し、
+            // setTimeout で 1 tick 遅らせてからダイアログを開く。
+            e.preventDefault();
+            onOpenCreateDialog();
+          }}
+          className="cursor-pointer"
+        >
+          <PlusIcon />
+          新しい組織を作成
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -17,7 +17,7 @@ import {
   setCurrentOrganizationIdAtom,
 } from "@/lib/currentOrganization";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
   CalendarDays,
@@ -54,12 +54,33 @@ function initial(name: string | null | undefined): string {
   return chars[0] ?? "?";
 }
 
+// 組織詳細ページのパスにマッチする正規表現。
+// `/organizations` (一覧) や `/organizations/` (末尾スラッシュのみ) は除外し、
+// 末尾セグメントが 1 文字以上ある場合だけ詳細ページとみなす。
+const ORGANIZATION_DETAIL_PATH = /^\/organizations\/[^/]+/;
+
 export function Sidebar() {
   const { data: orgs, isLoading } = useOrganizations();
   const currentId = useAtomValue(currentOrganizationIdAtom);
   const setCurrentId = useSetAtom(setCurrentOrganizationIdAtom);
   const clearCurrentId = useSetAtom(clearCurrentOrganizationIdAtom);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const navigate = useNavigate();
+  // selector で必要な値だけ subscribe し、関係のない state 変化での再描画を抑える。
+  const pathname = useRouterState({
+    select: (s) => s.location.pathname,
+  });
+
+  // 組織詳細ページを開いている時に組織を切り替えた場合、URL の id 部分は古いままで
+  // 表示も古い組織の詳細を引き続き取得してしまう。同じ詳細ページの新しい id に
+  // 自動遷移して内容を切り替える。それ以外のページではその場に留まる
+  // (ダッシュボードや組織非依存ページで操作中のコンテキストを破壊しないため)。
+  const handleSelectOrganization = (newId: string) => {
+    setCurrentId(newId);
+    if (ORGANIZATION_DETAIL_PATH.test(pathname)) {
+      navigate({ to: "/organizations/$id", params: { id: newId } });
+    }
+  };
 
   // 組織一覧の取得結果を見て「現在の組織 ID」を整合させる。
   //   - 一覧が空 → null にリセット (退会・削除直後など)
@@ -92,7 +113,7 @@ export function Sidebar() {
         orgs={orgs ?? null}
         currentOrg={currentOrg}
         currentId={currentId}
-        onSelect={setCurrentId}
+        onSelect={handleSelectOrganization}
         onOpenCreateDialog={() => setCreateDialogOpen(true)}
       />
 

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -265,8 +265,8 @@ function OrganizationSelector({
           onSelect={(e) => {
             // onSelect のデフォルト挙動でメニューが閉じた直後にダイアログを
             // 開こうとすると Radix の focus 管理と競合してフォーカスがずれる
-            // ことがある。preventDefault でメニューの自動 close を抑止し、
-            // setTimeout で 1 tick 遅らせてからダイアログを開く。
+            // ことがある。preventDefault でメニューの自動 close を抑止してから
+            // ダイアログを開く。
             e.preventDefault();
             onOpenCreateDialog();
           }}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,176 @@
+import { cn } from "@/lib/utils";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, CircleIcon } from "lucide-react";
+import type * as React from "react";
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPortal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPortal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset ? "" : undefined}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[inset]:pl-8 [&_svg]:size-4 [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset ? "" : undefined}
+      className={cn(
+        "px-2 py-1.5 text-xs font-medium text-muted-foreground data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      checked={checked}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
+++ b/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
@@ -1,0 +1,145 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api, authHeaders } from "@/lib/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useId, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+const createSchema = z.object({
+  name: z.string().min(1, "組織名は必須です"),
+  description: z.string().optional(),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+
+export interface CreateOrganizationDialogProps {
+  // 任意のトリガー要素を差し込み可能にする。未指定時は「組織を作成」ボタンを使う。
+  // ドロップダウンメニューから開くケース等で外部 state を使いたい場合は trigger を
+  // 渡さず、open / onOpenChange のセットを使うことを想定する。
+  trigger?: ReactNode;
+  // 作成成功時に新規組織 ID を受け取るコールバック。サイドバーが「現在の組織」を
+  // 切り替えるためにこれを利用する。
+  onCreated?: (organizationId: string) => void;
+  // 制御モード用。指定された場合は内部 state ではなくこちらに従う。
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function CreateOrganizationDialog({
+  trigger,
+  onCreated,
+  open: openProp,
+  onOpenChange,
+}: CreateOrganizationDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (onOpenChange) onOpenChange(next);
+    if (openProp === undefined) setInternalOpen(next);
+  };
+  const queryClient = useQueryClient();
+  const nameId = useId();
+  const descriptionId = useId();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: { name: "", description: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateFormValues) => {
+      // description は空文字なら API に渡さない（API 側 schema が optional のため）
+      const json: { name: string; description?: string } = { name: data.name };
+      if (data.description && data.description.length > 0) {
+        json.description = data.description;
+      }
+      // headers は第 2 引数で渡す（第 1 引数に混ぜると無視される）。
+      const res = await api.organizations.$post({ json }, authHeaders());
+      // 非 2xx を success として扱うと、API が 400/401/500 を返した場合でも
+      // Dialog が閉じてしまい、ユーザーが成功したと誤認する。res.ok を見て
+      // エラー扱いに落とし、useMutation の onError / isError 経路に流す。
+      if (!res.ok) {
+        throw new Error(`Failed to create organization: ${res.status}`);
+      }
+      return (await res.json()) as { id: string };
+    },
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ["organizations"] });
+      reset();
+      setOpen(false);
+      if (onCreated) onCreated(created.id);
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        {trigger ?? <Button>組織を作成</Button>}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>新しい組織を作成</DialogTitle>
+          <DialogDescription>
+            組織名と説明（任意）を入力してください。
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit((data) => mutation.mutate(data))}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={nameId}>組織名</Label>
+            <Input
+              id={nameId}
+              placeholder="例: ACME 株式会社"
+              {...register("name")}
+            />
+            {errors.name && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={descriptionId}>説明</Label>
+            <Input
+              id={descriptionId}
+              placeholder="組織の説明（任意）"
+              {...register("description")}
+            />
+          </div>
+          {mutation.isError && (
+            <p className="text-destructive text-sm">作成に失敗しました</p>
+          )}
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              作成
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
+++ b/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
@@ -95,9 +95,15 @@ export function CreateOrganizationDialog({
         if (!next) reset();
       }}
     >
-      <DialogTrigger asChild>
-        {trigger ?? <Button>組織を作成</Button>}
-      </DialogTrigger>
+      {/* 外部から open を制御する場合 (openProp 指定時) はトリガーを描画しない。
+          サイドバーのドロップダウンメニューから開くようなケースでは、
+          DropdownMenuItem 自体がトリガーの役割を担うため、ここに別のトリガーを
+          置くと a11y 上の役割が二重化してしまう。 */}
+      {openProp === undefined && (
+        <DialogTrigger asChild>
+          {trigger ?? <Button>組織を作成</Button>}
+        </DialogTrigger>
+      )}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>新しい組織を作成</DialogTitle>

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -14,6 +14,7 @@
 
 import { type Atom, atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import { clearCurrentOrganizationIdAtom } from "./currentOrganization";
 
 // jotai/utils は SyncStorage 型を public な entry point から再エクスポートして
 // いないため、atomWithStorage が受け付ける形に合わせてローカルで定義する。
@@ -173,6 +174,9 @@ export const loginAtom = atom(null, (_get, set, token: string) => {
 
 export const logoutAtom = atom(null, (_get, set) => {
   set(idTokenAtom, null);
+  // 「前のユーザーが選択していた組織」が次のユーザーに引き継がれる事故を
+  // 防ぐため、id_token と同じタイミングで current_organization_id も破棄する。
+  set(clearCurrentOrganizationIdAtom);
 });
 
 export function getIdToken(): string | null {

--- a/apps/web/src/lib/currentOrganization.ts
+++ b/apps/web/src/lib/currentOrganization.ts
@@ -1,0 +1,89 @@
+// 「現在選択中の組織」を管理する atom 群。
+//
+// 真実源: localStorage（current_organization_id キー）に一本化する。
+// 公開 atom は派生 read-only であり、書き込みは set / clear の write-only atom
+// を介して行う。auth.ts の id_token と同じ構造で、UI と localStorage の
+// 二重管理を構造的に排除している。
+//
+// 値の意味:
+//   - 文字列: 選択中の組織 ID
+//   - null  : 未選択（組織 0 件 or ログアウト直後）
+
+import { type Atom, atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+// jotai/utils は SyncStorage 型を public な entry point から再エクスポートして
+// いないため、atomWithStorage が受け付ける形に合わせてローカルで定義する。
+type StringStorage = {
+  getItem: (key: string, initialValue: string | null) => string | null;
+  setItem: (key: string, newValue: string | null) => void;
+  removeItem: (key: string) => void;
+  subscribe: (
+    key: string,
+    callback: (value: string | null) => void,
+    initialValue: string | null,
+  ) => (() => void) | undefined;
+};
+
+const CURRENT_ORGANIZATION_ID_KEY = "current_organization_id";
+
+// JSON エンコードを介さない raw 文字列ストレージ。
+// 既定の createJSONStorage は値を JSON 化するため、外部ツール等で
+// localStorage を覗いた際にダブルクォートで囲まれた値になる。それを避ける。
+const stringStorage: StringStorage = {
+  getItem(key, initialValue) {
+    if (typeof window === "undefined") return initialValue;
+    return localStorage.getItem(key);
+  },
+  setItem(key, newValue) {
+    if (typeof window === "undefined") return;
+    if (newValue === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, newValue);
+    }
+  },
+  removeItem(key) {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(key);
+  },
+  subscribe(key, callback, _initialValue) {
+    if (typeof window === "undefined") return undefined;
+    const handler = (e: StorageEvent) => {
+      if (e.storageArea !== localStorage) return;
+      // localStorage.clear() の場合は key=null で発火するため、それも null 扱い。
+      if (e.key === null || e.key === key) {
+        callback(e.newValue);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  },
+};
+
+// 真実源としての atom（モジュール外には公開しない）。
+const currentOrganizationIdStorageAtom = atomWithStorage<string | null>(
+  CURRENT_ORGANIZATION_ID_KEY,
+  null,
+  stringStorage,
+  { getOnInit: true },
+);
+
+// 公開 read-only atom。
+export const currentOrganizationIdAtom: Atom<string | null> = atom((get) =>
+  get(currentOrganizationIdStorageAtom),
+);
+
+// 書き込み専用 atom。値をセットする。
+export const setCurrentOrganizationIdAtom = atom(
+  null,
+  (_get, set, organizationId: string) => {
+    set(currentOrganizationIdStorageAtom, organizationId);
+  },
+);
+
+// 書き込み専用 atom。null にする（未選択状態に戻す）。
+// logout 時や、選択中の組織が削除されたケースで利用する。
+export const clearCurrentOrganizationIdAtom = atom(null, (_get, set) => {
+  set(currentOrganizationIdStorageAtom, null);
+});

--- a/apps/web/src/routes/organizations.index.tsx
+++ b/apps/web/src/routes/organizations.index.tsx
@@ -1,30 +1,15 @@
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
 import { RoleBadge } from "@/features/organizations/components/RoleBadge";
 import type { Organization } from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
-import { useId, useState } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
 
 export const Route = createFileRoute("/organizations/")({
   component: OrganizationsPage,
@@ -49,111 +34,6 @@ function OrganizationCard({ org }: { org: Organization }) {
         </CardHeader>
       </Card>
     </Link>
-  );
-}
-
-// ===== 作成フォーム =====
-
-const createSchema = z.object({
-  name: z.string().min(1, "組織名は必須です"),
-  description: z.string().optional(),
-});
-
-type CreateFormValues = z.infer<typeof createSchema>;
-
-function CreateOrganizationDialog() {
-  const [open, setOpen] = useState(false);
-  const queryClient = useQueryClient();
-  const nameId = useId();
-  const descriptionId = useId();
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<CreateFormValues>({
-    resolver: zodResolver(createSchema),
-    defaultValues: { name: "", description: "" },
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (data: CreateFormValues) => {
-      // description は空文字なら API に渡さない（API 側 schema が optional のため）
-      const json: { name: string; description?: string } = { name: data.name };
-      if (data.description && data.description.length > 0) {
-        json.description = data.description;
-      }
-      // headers は第 2 引数で渡す（第 1 引数に混ぜると無視される）。
-      const res = await api.organizations.$post({ json }, authHeaders());
-      // 非 2xx を success として扱うと、API が 400/401/500 を返した場合でも
-      // Dialog が閉じてしまい、ユーザーが成功したと誤認する。res.ok を見て
-      // エラー扱いに落とし、useMutation の onError / isError 経路に流す。
-      if (!res.ok) {
-        throw new Error(`Failed to create organization: ${res.status}`);
-      }
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["organizations"] });
-      reset();
-      setOpen(false);
-    },
-  });
-
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) reset();
-      }}
-    >
-      <DialogTrigger asChild>
-        <Button>組織を作成</Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>新しい組織を作成</DialogTitle>
-          <DialogDescription>
-            組織名と説明（任意）を入力してください。
-          </DialogDescription>
-        </DialogHeader>
-        <form
-          onSubmit={handleSubmit((data) => mutation.mutate(data))}
-          className="flex flex-col gap-4"
-        >
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={nameId}>組織名</Label>
-            <Input
-              id={nameId}
-              placeholder="例: ACME 株式会社"
-              {...register("name")}
-            />
-            {errors.name && (
-              <p role="alert" className="text-destructive text-sm">
-                {errors.name.message}
-              </p>
-            )}
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={descriptionId}>説明</Label>
-            <Input
-              id={descriptionId}
-              placeholder="組織の説明（任意）"
-              {...register("description")}
-            />
-          </div>
-          {mutation.isError && (
-            <p className="text-destructive text-sm">作成に失敗しました</p>
-          )}
-          <DialogFooter>
-            <Button type="submit" disabled={mutation.isPending}>
-              作成
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/apps/web/src/test/auth.test.ts
+++ b/apps/web/src/test/auth.test.ts
@@ -203,6 +203,27 @@ describe("authAtom（localStorage 真実源・派生 atom）", () => {
     });
   });
 
+  it("logoutAtom 経由で書き込むと currentOrganizationId もクリアされる", async () => {
+    // logout 時に「前回のユーザーの選択中組織」が次のユーザーに引き継がれて
+    // しまう事故を防ぐため、id_token と同時に current_organization_id も
+    // クリアされることを確認する。
+    const { setCurrentOrganizationIdAtom, currentOrganizationIdAtom } =
+      await import("../lib/currentOrganization");
+    const token = makeFakeIdToken({
+      sub: "u1",
+      email: "u1@example.com",
+      name: "u1",
+    });
+    const store = createStore();
+    store.set(loginAtom, token);
+    store.set(setCurrentOrganizationIdAtom, "org-1");
+
+    store.set(logoutAtom);
+
+    expect(localStorage.getItem("current_organization_id")).toBeNull();
+    expect(store.get(currentOrganizationIdAtom)).toBeNull();
+  });
+
   it("他タブの logout（storage イベント newValue=null）で authAtom が未認証に追従する", () => {
     const token = makeFakeIdToken({
       sub: "u1",

--- a/apps/web/src/test/currentOrganization.test.ts
+++ b/apps/web/src/test/currentOrganization.test.ts
@@ -1,0 +1,96 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearCurrentOrganizationIdAtom,
+  currentOrganizationIdAtom,
+  setCurrentOrganizationIdAtom,
+} from "../lib/currentOrganization";
+
+// 他タブからの localStorage 変更を擬似的に再現するヘルパー。
+// 同一 window 内の localStorage.setItem では storage イベントが発火しないため、
+// dispatchEvent で別タブからの通知を模す（auth.test.ts と同じ手法）。
+function dispatchStorageEvent(key: string | null, newValue: string | null) {
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key,
+      newValue,
+      storageArea: localStorage,
+    }),
+  );
+}
+
+describe("currentOrganizationIdAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("初期状態は null を返す", () => {
+    const store = createStore();
+    expect(store.get(currentOrganizationIdAtom)).toBeNull();
+  });
+
+  it("setCurrentOrganizationIdAtom 経由で書き込むと localStorage と atom の双方が更新される", () => {
+    const store = createStore();
+
+    store.set(setCurrentOrganizationIdAtom, "org-1");
+
+    expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    expect(store.get(currentOrganizationIdAtom)).toBe("org-1");
+  });
+
+  it("clearCurrentOrganizationIdAtom 経由で書き込むと localStorage から削除され atom も null になる", () => {
+    const store = createStore();
+    store.set(setCurrentOrganizationIdAtom, "org-1");
+
+    store.set(clearCurrentOrganizationIdAtom);
+
+    expect(localStorage.getItem("current_organization_id")).toBeNull();
+    expect(store.get(currentOrganizationIdAtom)).toBeNull();
+  });
+
+  it("他タブからの変更（storage イベント）で atom が追従する", () => {
+    const store = createStore();
+    // atomWithStorage の subscribe は購読者がいる時のみ有効化されるため、
+    // テストでも store.sub で明示的にサブスクライブする。
+    const unsubscribe = store.sub(currentOrganizationIdAtom, () => {});
+
+    try {
+      localStorage.setItem("current_organization_id", "org-2");
+      dispatchStorageEvent("current_organization_id", "org-2");
+
+      expect(store.get(currentOrganizationIdAtom)).toBe("org-2");
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("他タブからの clear（storage イベント newValue=null）で atom が null に戻る", () => {
+    const store = createStore();
+    store.set(setCurrentOrganizationIdAtom, "org-1");
+    const unsubscribe = store.sub(currentOrganizationIdAtom, () => {});
+
+    try {
+      dispatchStorageEvent("current_organization_id", null);
+      expect(store.get(currentOrganizationIdAtom)).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("localStorage.clear() 相当の storage イベント（key=null）でも atom がクリアされる", () => {
+    const store = createStore();
+    store.set(setCurrentOrganizationIdAtom, "org-1");
+    const unsubscribe = store.sub(currentOrganizationIdAtom, () => {});
+
+    try {
+      dispatchStorageEvent(null, null);
+      expect(store.get(currentOrganizationIdAtom)).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -25,10 +25,17 @@ vi.mock("@/lib/api", () => ({
   authHeaders: () => ({ headers: {} }),
 }));
 
+// 現在パスを切り替えるためのテスト用ホルダー。useRouterState のモックから参照する。
+// テストごとに beforeEach で "/" にリセットされる。
+const currentPathnameRef = { value: "/" };
+const navigateMock = vi.fn();
+
 // TanStack Router の Link は RouterProvider 配下でないと落ちるため、
 // テスト中は href を持つ <a> として描画するモックに差し替える。
 // asChild で囲んだ場合に Radix が DropdownMenuItem 上にイベントを伝搬しても
 // 単純な <a> として href が assert できる形にする。
+// 併せて useRouterState / useNavigate も Sidebar が組織切替時の遷移判定に
+// 用いているためモック差し替えする。
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
     "@tanstack/react-router",
@@ -53,6 +60,11 @@ vi.mock("@tanstack/react-router", async () => {
         </a>
       );
     },
+    // selector を無視して現在の pathname を返す軽量モック。
+    // 実装側は useRouterState({ select: (s) => s.location.pathname }) を呼ぶが、
+    // テストでは selector を素通しして固定値を返せれば十分。
+    useRouterState: () => currentPathnameRef.value,
+    useNavigate: () => navigateMock,
   };
 });
 
@@ -115,6 +127,9 @@ beforeEach(() => {
   // 使わないため、明示的にリセットしておくだけで十分。
   (api.organizations.$get as Mock).mockReset();
   (api.organizations.$post as Mock).mockReset();
+  // ルーターモックの状態もデフォルト (ダッシュボード) に戻す。
+  currentPathnameRef.value = "/";
+  navigateMock.mockReset();
 });
 
 afterEach(() => {
@@ -221,6 +236,84 @@ describe("Sidebar 組織セレクター", () => {
     await waitFor(() => {
       expect(localStorage.getItem("current_organization_id")).toBe("org-2");
     });
+  });
+
+  it("組織詳細ページにいるときに切替すると、新しい組織の詳細ページに navigate される", async () => {
+    // /organizations/$id 上では「その場に留まる」と古い組織の内容が
+    // 表示されたままになるため、新しい組織の詳細ページに自動遷移する。
+    currentPathnameRef.value = "/organizations/org-1";
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "別の組織" }),
+    );
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: "/organizations/$id",
+        params: { id: "org-2" },
+      });
+    });
+  });
+
+  it("詳細ページ以外で切替したときは navigate されない（その場に留まる）", async () => {
+    // 一覧やダッシュボードにいる時は遷移を強制しない。例えば /organizations は
+    // 組織非依存のページで、切替時に飛ばすと UX が破壊的になる。
+    currentPathnameRef.value = "/organizations";
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "別の組織" }),
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-2");
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("ダッシュボード上で切替しても navigate されない", async () => {
+    currentPathnameRef.value = "/";
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "別の組織" }),
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-2");
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("ドロップダウンに「現在の組織の詳細」リンクが /organizations/{currentId} で出る", async () => {

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -1,0 +1,319 @@
+import { Sidebar } from "@/components/layout/Sidebar";
+import { api } from "@/lib/api";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider, createStore } from "jotai";
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// hono RPC client は型が複雑なので、Sidebar が触る GET / POST だけモックする。
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      $get: vi.fn(),
+      $post: vi.fn(),
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+// TanStack Router の Link は RouterProvider 配下でないと落ちるため、
+// テスト中は href を持つ <a> として描画するモックに差し替える。
+// asChild で囲んだ場合に Radix が DropdownMenuItem 上にイベントを伝搬しても
+// 単純な <a> として href が assert できる形にする。
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  type MockLinkProps = {
+    to: string;
+    params?: Record<string, string>;
+    children?: React.ReactNode;
+    className?: string;
+    activeProps?: unknown;
+  };
+  return {
+    ...actual,
+    Link: ({ to, params, children, className }: MockLinkProps) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+  };
+});
+
+type Organization = {
+  id: string;
+  name: string;
+  description: string | null;
+  role: "owner" | "admin" | "member";
+  createdAt: string;
+  updatedAt: string;
+};
+
+const mockOrgs: Organization[] = [
+  {
+    id: "org-1",
+    name: "ACME 株式会社",
+    description: "テスト組織",
+    role: "owner",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+  },
+  {
+    id: "org-2",
+    name: "別の組織",
+    description: null,
+    role: "member",
+    createdAt: "2026-05-02T00:00:00.000Z",
+    updatedAt: "2026-05-02T00:00:00.000Z",
+  },
+];
+
+function mockJson<T>(data: T) {
+  return { ok: true, status: 200, json: async () => data } as never;
+}
+
+function renderSidebar() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const store = createStore();
+  return {
+    client,
+    store,
+    ...render(
+      <QueryClientProvider client={client}>
+        <Provider store={store}>
+          <Sidebar />
+        </Provider>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  // localStorage はテスト全体で共有されるため、状態を引き継がないように毎回クリア。
+  // currentOrganizationId は localStorage から復元されるため、ここをクリアしないと
+  // 他テストで set した値が次のテストの初期状態に漏れる。
+  localStorage.clear();
+  // userEvent は内部で setTimeout を使う場面があるが本テストでは fakeTimers を
+  // 使わないため、明示的にリセットしておくだけで十分。
+  (api.organizations.$get as Mock).mockReset();
+  (api.organizations.$post as Mock).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Sidebar 組織セレクター", () => {
+  it("一覧取得中はスケルトンが表示される", () => {
+    (api.organizations.$get as Mock).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    renderSidebar();
+
+    expect(screen.getByLabelText("組織一覧を読み込み中")).toBeInTheDocument();
+  });
+
+  it("組織が 0 件のとき「新しい組織を作成」CTA が表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson([]));
+
+    renderSidebar();
+
+    expect(
+      await screen.findByRole("button", { name: /新しい組織を作成/ }),
+    ).toBeInTheDocument();
+    // 切り替えメニューはまだ出ない。
+    expect(
+      screen.queryByRole("button", { name: "組織を切り替え" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("0 件のとき CTA を押すと作成ダイアログが開く", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson([]));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await user.click(
+      await screen.findByRole("button", { name: /新しい組織を作成/ }),
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "新しい組織を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("1 件以上あり currentId 未設定なら先頭組織が自動選択され、トリガーボタンに表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+
+    renderSidebar();
+
+    // 自動選択後、トリガーボタンに先頭組織名が出る (effect が走るのを待つ)
+    const trigger = await screen.findByRole("button", {
+      name: "組織を切り替え",
+    });
+    expect(within(trigger).getByText("ACME 株式会社")).toBeInTheDocument();
+    // localStorage にも書き込まれる
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+  });
+
+  it("currentId が一覧に存在しない場合は先頭組織にフォールバックする", async () => {
+    // 「以前選択していた組織」が削除/退会された等で消えたケース。
+    localStorage.setItem("current_organization_id", "org-deleted");
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+  });
+
+  it("組織が 0 件になると currentId はクリアされる", async () => {
+    localStorage.setItem("current_organization_id", "org-1");
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson([]));
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBeNull();
+    });
+  });
+
+  it("ドロップダウンから別組織を選択すると localStorage が更新される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    // 自動選択を待つ
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    // RadioItem として別組織を選択
+    const item = await screen.findByRole("menuitemradio", { name: "別の組織" });
+    await user.click(item);
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-2");
+    });
+  });
+
+  it("ドロップダウンに「現在の組織の詳細」リンクが /organizations/{currentId} で出る", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+
+    const link = await screen.findByRole("link", {
+      name: /現在の組織の詳細/,
+    });
+    expect(link).toHaveAttribute("href", "/organizations/org-1");
+  });
+
+  it("ドロップダウンに「すべての組織を見る」リンクが /organizations で出る", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+
+    const link = await screen.findByRole("link", {
+      name: /すべての組織を見る/,
+    });
+    expect(link).toHaveAttribute("href", "/organizations");
+  });
+
+  it("ドロップダウン内の「新しい組織を作成」で作成ダイアログが開く", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: /新しい組織を作成/ }),
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "新しい組織を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("作成ダイアログから組織を作成すると、新しい組織が currentId に設定される", async () => {
+    const created: Organization = {
+      id: "org-new",
+      name: "新規",
+      description: null,
+      role: "owner",
+      createdAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+    };
+    // 0 件 → 作成 → 1 件 (refetch 結果) の順で返す
+    (api.organizations.$get as Mock)
+      .mockResolvedValueOnce(mockJson([]))
+      .mockResolvedValue(mockJson([created]));
+    (api.organizations.$post as Mock).mockResolvedValue(mockJson(created));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await user.click(
+      await screen.findByRole("button", { name: /新しい組織を作成/ }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    await user.type(within(dialog).getByLabelText("組織名"), "新規");
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-new");
+    });
+  });
+});

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -61,10 +61,15 @@ vi.mock("@tanstack/react-router", async () => {
         </a>
       );
     },
-    // selector を無視して現在の pathname を返す軽量モック。
-    // 実装側は useRouterState({ select: (s) => s.location.pathname }) を呼ぶが、
-    // テストでは selector を素通しして固定値を返せれば十分。
-    useRouterState: () => currentPathnameRef.value,
+    // 実装側 (useRouterState({ select: (s) => s.location.pathname })) と同じ
+    // 呼び出し形を維持するため、selector を実行して値を返す。selector の
+    // シグネチャが壊れた場合にテストでも検知できるようにするのが目的。
+    useRouterState: (opts?: {
+      select?: (state: { location: { pathname: string } }) => unknown;
+    }) => {
+      const state = { location: { pathname: currentPathnameRef.value } };
+      return opts?.select ? opts.select(state) : state;
+    },
     useNavigate: () => navigateMock,
   };
 });

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -1,4 +1,5 @@
 import { Sidebar } from "@/components/layout/Sidebar";
+import type { Organization } from "@/features/organizations/types";
 import { api } from "@/lib/api";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
@@ -67,15 +68,6 @@ vi.mock("@tanstack/react-router", async () => {
     useNavigate: () => navigateMock,
   };
 });
-
-type Organization = {
-  id: string;
-  name: string;
-  description: string | null;
-  role: "owner" | "admin" | "member";
-  createdAt: string;
-  updatedAt: string;
-};
 
 const mockOrgs: Organization[] = [
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -640,6 +643,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@hono/node-server@2.0.1':
     resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
     engines: {node: '>=20'}
@@ -754,6 +772,32 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -785,8 +829,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -842,6 +908,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -883,6 +975,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -969,6 +1074,27 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
@@ -3277,6 +3403,23 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@hono/node-server@2.0.1(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
@@ -3424,6 +3567,27 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -3458,6 +3622,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3465,6 +3635,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3504,6 +3689,50 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3536,6 +3765,23 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3600,6 +3846,22 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     optional: true


### PR DESCRIPTION
## 関連Issue
Closes #139

## 概要・目的
* サイドバー左上の「組織名」ボタンをドロップダウンメニュー化し、組織の切替・作成・詳細遷移・全組織一覧遷移を 1 か所から行えるようにした。
* 「現在選択中の組織」を Jotai + localStorage で永続化し、画面遷移やリロード後も維持できるようにした。

## 背景
* これまでサイドバー左上のボタンは UI のみで、クリックしても何も起きなかった (`apps/web/src/components/layout/Sidebar.tsx`)。
* 組織の作成・閲覧は `/organizations` (一覧) と `/organizations/$id` (詳細) に分かれており、サイドバーから直接到達できなかった。
* 「現在どの組織を見ているか」をアプリ全体で保持する仕組みも未整備で、定例セクションなど今後の組織紐付け機能を組む土台が無かった。

## 変更内容
* `@radix-ui/react-dropdown-menu` を `apps/web/` に追加し、`components/ui/dropdown-menu.tsx` を既存 `dialog.tsx` と同じスタイルで実装。
* `lib/currentOrganization.ts` を `auth.ts` と同じパターン (atomWithStorage + カスタム storage + 派生 read-only + write-only) で追加。localStorage キーは `current_organization_id`。
* `CreateOrganizationDialog` を `routes/organizations.index.tsx` から `features/organizations/components/` に切り出し、`trigger` / `onCreated` / `open` / `onOpenChange` を受け取れるようにしてサイドバーから再利用。
* `Sidebar.tsx` を全面改修:
  * `useQuery(["organizations"])` で取得 (一覧ページとキャッシュ共有)
  * loading / 0 件 / 1 件以上 で表示を分岐 (スケルトン / CTA / トリガー + ドロップダウン)
  * 一覧取得後に「現在の組織」を整合させる (未設定 or 一覧に存在しなければ先頭、0 件なら null)
  * ドロップダウンに切替・現在の組織の詳細・すべての組織を見る・新しい組織を作成 を配置
* `auth.ts` の `logoutAtom` で `current_organization_id` も同時にクリア。
* 組織詳細ページ (`/organizations/$id`) を開いている時に切替した場合は新組織の詳細ページに自動遷移。それ以外のページではその場に留まる。
* テストを追加: `currentOrganization.test.ts` (6) / `sidebar.test.tsx` (14) / `auth.test.ts` への追記 (1)。合計 121 passed。

## 動作確認手順
1. `pnpm --filter web dev` でフロントを起動し、ローカル fake-auth でログインする。
2. ログイン直後、所属組織が 1 件以上ある場合は、サイドバー左上に先頭組織名が自動的に表示されることを確認する。
3. サイドバーの組織ボタンをクリックし、ドロップダウンが開き、所属組織のリスト・「現在の組織の詳細」・「すべての組織を見る」・「新しい組織を作成」が並ぶことを確認する。
4. 別組織を選択し、サイドバーの表示が新組織名に変わること、リロードしても維持されること (DevTools → Application → Local Storage の `current_organization_id` を確認) を確認する。
5. `/organizations/$id` (組織詳細ページ) を開いた状態で別組織に切替し、URL が新組織の詳細ページに遷移し、表示も新組織のものに更新されることを確認する。
6. ダッシュボード (`/`) や組織一覧 (`/organizations`) を開いた状態で切替した場合は、その場に留まることを確認する。
7. 所属組織が 0 件の状態 (新規ユーザー or 全退会した状態) で、サイドバーに「＋ 新しい組織を作成」CTA が表示されること、押下で作成ダイアログが開くこと、作成成功で新組織が現在の組織になることを確認する。
8. ドロップダウン内の「新しい組織を作成」からも同様に作成でき、新組織が現在の組織になることを確認する。
9. ログアウトし再度ログインしたとき、`current_organization_id` がクリアされ、所属組織があれば先頭が再選択されることを確認する。

## スクリーンショット
<img width="867" height="564" alt="image" src="https://github.com/user-attachments/assets/1355c664-8d6f-4da3-85bf-d80a8502afa4" />