### PR TITLE
feat(web): トップバーのユーザー情報表示・ログアウト機能

### DIFF
--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,12 +1,14 @@
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { authAtom } from "@/lib/auth";
-import { useAtomValue } from "jotai";
+import { authAtom, logoutAtom } from "@/lib/auth";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useNavigate } from "@tanstack/react-router";
 import { Settings } from "lucide-react";
 
 // 名前の頭文字を取り出す。サロゲートペアを Array.from で正しく扱う。
@@ -17,7 +19,14 @@ function initial(name: string | null | undefined): string {
 
 function UserAvatar() {
   const auth = useAtomValue(authAtom);
+  const logout = useSetAtom(logoutAtom);
+  const navigate = useNavigate();
   const user = auth.isAuthenticated ? auth.user : null;
+
+  const handleLogout = () => {
+    logout();
+    navigate({ to: "/login" });
+  };
 
   return (
     <DropdownMenu>
@@ -38,7 +47,12 @@ function UserAvatar() {
           </p>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {/* ログアウト（未実装） */}
+        <DropdownMenuItem
+          onSelect={handleLogout}
+          className="cursor-pointer text-destructive focus:text-destructive"
+        >
+          ログアウト
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -18,10 +18,9 @@ function initial(name: string | null | undefined): string {
 }
 
 function UserAvatar() {
-  const auth = useAtomValue(authAtom);
   const logout = useSetAtom(logoutAtom);
   const navigate = useNavigate();
-  const user = auth.isAuthenticated ? auth.user : null;
+  const { user } = useAtomValue(authAtom);
 
   const handleLogout = () => {
     logout();

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,4 +1,48 @@
-import { Settings, UserCircle } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { authAtom } from "@/lib/auth";
+import { useAtomValue } from "jotai";
+import { Settings } from "lucide-react";
+
+// 名前の頭文字を取り出す。サロゲートペアを Array.from で正しく扱う。
+function initial(name: string | null | undefined): string {
+  if (!name) return "?";
+  return Array.from(name.trim())[0] ?? "?";
+}
+
+function UserAvatar() {
+  const auth = useAtomValue(authAtom);
+  const user = auth.isAuthenticated ? auth.user : null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="ユーザーメニュー"
+          className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-semibold select-none hover:opacity-80 transition-opacity"
+        >
+          {initial(user?.name)}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="font-normal">
+          <p className="font-medium">{user?.name ?? "—"}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {user?.email ?? "—"}
+          </p>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {/* ログアウト（未実装） */}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export function Topbar() {
   return (
@@ -13,13 +57,7 @@ export function Topbar() {
         >
           <Settings size={18} />
         </button>
-        {/* ユーザーアバター（未実装） */}
-        <button
-          type="button"
-          className="p-1 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-        >
-          <UserCircle size={26} />
-        </button>
+        <UserAvatar />
       </div>
     </header>
   );

--- a/apps/web/src/test/topbar.test.tsx
+++ b/apps/web/src/test/topbar.test.tsx
@@ -1,0 +1,50 @@
+import { Topbar } from "@/components/layout/Topbar";
+import { loginAtom } from "@/lib/auth";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider, createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+import { makeFakeIdToken } from "./helpers/auth";
+
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function renderTopbar(name = "田中太郎", email = "tanaka@example.com") {
+  const store = createStore();
+  store.set(loginAtom, makeFakeIdToken({ sub: "u1", name, email }));
+  return {
+    user: userEvent.setup(),
+    ...render(
+      <Provider store={store}>
+        <Topbar />
+      </Provider>,
+    ),
+  };
+}
+
+describe("Topbar", () => {
+  it("アバターに名前の頭文字が表示される", () => {
+    renderTopbar("田中太郎");
+    expect(screen.getByRole("button", { name: "ユーザーメニュー" })).toHaveTextContent("田");
+  });
+
+  it("ログアウトをクリックすると /login へ遷移する", async () => {
+    const { user } = renderTopbar();
+
+    await user.click(screen.getByRole("button", { name: "ユーザーメニュー" }));
+    await user.click(screen.getByText("ログアウト"));
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({ to: "/login" });
+    });
+  });
+});

--- a/apps/web/src/test/topbar.test.tsx
+++ b/apps/web/src/test/topbar.test.tsx
@@ -34,7 +34,9 @@ function renderTopbar(name = "田中太郎", email = "tanaka@example.com") {
 describe("Topbar", () => {
   it("アバターに名前の頭文字が表示される", () => {
     renderTopbar("田中太郎");
-    expect(screen.getByRole("button", { name: "ユーザーメニュー" })).toHaveTextContent("田");
+    expect(
+      screen.getByRole("button", { name: "ユーザーメニュー" }),
+    ).toHaveTextContent("田");
   });
 
   it("ログアウトをクリックすると /login へ遷移する", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #149 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* トップバーにログイン中のユーザー情報を表示し、ログアウト操作を可能にした。
* これまでプレースホルダーだったユーザーアイコンを機能化する。

## 背景
* トップバーの骨格(#108 )実装済みだが、ユーザー情報はプレースホルダーのまま

## 変更内容
* `Topbar.tsx` のユーザーアイコンをイニシャル表示の丸アバターに変更
* アイコンクリックで DropdownMenu を開き、ユーザー名・メールアドレスを表示
* ドロップダウン内にログアウトボタンを実装（`logoutAtom` 呼び出し → `/login` リダイレクト）

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
1. `make dev` でアプリを起動      
2. ログイン後、トップバー右端のアバターアイコンをクリック
3. 「ログアウト」をクリックし、ログインページへ遷移することを確認

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1468" height="730" alt="スクリーンショット 2026-05-14 17 45 08" src="https://github.com/user-attachments/assets/4e85dcf0-2236-43d5-9dad-377bd86e6f4f" />


