### PR TITLE
定例（RecurringMeeting）CRUD API を追加

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,13 +2,15 @@ import { Hono } from "hono";
 import { healthRoute } from "./routes/health.js";
 import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
+import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
 
 const app = new Hono();
 
 const routes = app
   .route("/health", healthRoute)
   .route("/meetings", meetingsRoute)
-  .route("/organizations", organizationsRoute);
+  .route("/organizations", organizationsRoute)
+  .route("/recurring-meetings", recurringMeetingsRoute);
 
 export { app };
 export type AppType = typeof routes;

--- a/apps/api/src/lib/schemas/recurring-meeting.ts
+++ b/apps/api/src/lib/schemas/recurring-meeting.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// scheduleCron は MVP 段階では「スペース区切り 5 フィールド」の形式のみ検証する。
+// 各フィールドの妥当性（分・時・日・月・曜日の範囲）は後続 Issue で
+// cron パーサー導入時に厳格化する予定。
+const cronFieldFormat = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/;
+const scheduleCronSchema = z
+  .string()
+  .min(1)
+  .regex(
+    cronFieldFormat,
+    "scheduleCron は 5 フィールドの cron 形式で指定してください",
+  );
+
+export const recurringMeetingCreateSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  scheduleCron: scheduleCronSchema,
+});
+
+// 既存 organization の updateSchema と同じ流儀。
+// 全フィールド未指定の空ボディは更新意図が不明瞭なため 400 で弾く。
+export const recurringMeetingUpdateSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    scheduleCron: scheduleCronSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.name !== undefined ||
+      d.description !== undefined ||
+      d.scheduleCron !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
+import { recurringMeetingCreateSchema } from "../lib/schemas/recurring-meeting.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 const createSchema = z.object({
@@ -265,6 +266,41 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     await prisma.organization.delete({ where: { id } });
     return c.body(null, 204);
   })
+  .post(
+    "/:id/meetings",
+    zValidator("json", recurringMeetingCreateSchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const user = c.var.user;
+      const { name, description, scheduleCron } = c.req.valid("json");
+
+      const guard = await requireMembership(c, id);
+      if (!guard.ok) return guard.res;
+
+      // RecurringMeeting 作成と作成者を MeetingMember.owner として登録する処理は
+      // 整合性確保のため $transaction で原子的に実行する。
+      const meeting = await prisma.$transaction(async (tx) => {
+        const created = await tx.recurringMeeting.create({
+          data: {
+            organizationId: id,
+            name,
+            description,
+            scheduleCron,
+          },
+        });
+        await tx.meetingMember.create({
+          data: {
+            recurringMeetingId: created.id,
+            userId: user.id,
+            role: "owner",
+          },
+        });
+        return created;
+      });
+
+      return c.json(meeting, 201);
+    },
+  )
   .post("/:id/invite", zValidator("json", inviteSchema), async (c) => {
     const id = c.req.param("id");
     const user = c.var.user;

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -266,6 +266,21 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     await prisma.organization.delete({ where: { id } });
     return c.body(null, 204);
   })
+  .get("/:id/meetings", async (c) => {
+    const id = c.req.param("id");
+
+    const guard = await requireMembership(c, id);
+    if (!guard.ok) return guard.res;
+
+    // 一覧画面でメンバー数バッジを出せるよう _count.members を併せて取得する。
+    // メンバー詳細は重いので別エンドポイント（GET /recurring-meetings/:id）で返す。
+    const meetings = await prisma.recurringMeeting.findMany({
+      where: { organizationId: id },
+      orderBy: { createdAt: "desc" },
+      include: { _count: { select: { members: true } } },
+    });
+    return c.json(meetings);
+  })
   .post(
     "/:id/meetings",
     zValidator("json", recurringMeetingCreateSchema),

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -98,4 +98,33 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
       });
       return c.json(updated);
     },
-  );
+  )
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const user = c.var.user;
+
+    const meeting = await prisma.recurringMeeting.findUnique({
+      where: { id },
+    });
+    const guard = await requireRecurringAccess(c, meeting);
+    if (!guard.ok) return guard.res;
+
+    // 削除は MeetingMember.owner のみ許可。組織メンバーでも MeetingMember
+    // 未参加・member ロールの場合は 403。
+    const member = await prisma.meetingMember.findUnique({
+      where: {
+        recurringMeetingId_userId: {
+          recurringMeetingId: id,
+          userId: user.id,
+        },
+      },
+    });
+    if (!member || member.role !== "owner") {
+      return c.json({ error: "定例の削除権限がありません" }, 403);
+    }
+
+    // 配下の MeetingMember / Meeting は schema 側で onDelete: Cascade のため
+    // delete 一発で連鎖削除される。
+    await prisma.recurringMeeting.delete({ where: { id } });
+    return c.body(null, 204);
+  });

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -1,0 +1,77 @@
+import type { MeetingRole, RecurringMeeting } from "@prisma/client";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+
+// 認証ユーザーが定例の所属組織のメンバーであるかを確認する共通ガード。
+// 定例不存在・所属なしいずれも 404 で統一し、組織や定例の存在自体を
+// 露出させない（organizations.ts の requireMembership と同方針）。
+async function requireRecurringAccess<T extends RecurringMeeting>(
+  c: Context<{ Variables: AuthVariables }>,
+  meeting: T | null,
+): Promise<{ ok: false; res: Response } | { ok: true; meeting: T }> {
+  if (!meeting) {
+    return {
+      ok: false,
+      res: c.json({ error: "定例が見つかりません" }, 404),
+    };
+  }
+  const user = c.var.user;
+  const membership = await prisma.organizationMembership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId: user.id,
+        organizationId: meeting.organizationId,
+      },
+    },
+  });
+  if (!membership) {
+    return {
+      ok: false,
+      res: c.json({ error: "定例が見つかりません" }, 404),
+    };
+  }
+  return { ok: true, meeting };
+}
+
+// メンバー一覧の表示順。MeetingRole は owner / member の 2 値で OrgRole より簡素。
+const meetingRoleOrder: Record<MeetingRole, number> = {
+  owner: 0,
+  member: 1,
+};
+
+export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+
+    const meeting = await prisma.recurringMeeting.findUnique({
+      where: { id },
+      include: {
+        members: { include: { user: true } },
+      },
+    });
+    const guard = await requireRecurringAccess(c, meeting);
+    if (!guard.ok) return guard.res;
+
+    // owner → member の順、同一ロール内は参加日時昇順で並べる。
+    // MeetingRole enum を DB 側で並べる手段がないためメモリ内ソートする。
+    const sortedMembers = [...guard.meeting.members].sort((a, b) => {
+      if (a.role !== b.role)
+        return meetingRoleOrder[a.role] - meetingRoleOrder[b.role];
+      return a.joinedAt.getTime() - b.joinedAt.getTime();
+    });
+    const members = sortedMembers.map((m) => ({
+      userId: m.userId,
+      name: m.user.name,
+      displayName: m.user.displayName,
+      email: m.user.email,
+      role: m.role,
+      joinedAt: m.joinedAt,
+    }));
+
+    // include で取得した members は整形後の配列で置き換えて返す。
+    const { members: _members, ...rest } = guard.meeting;
+    return c.json({ ...rest, members });
+  });

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -1,7 +1,9 @@
+import { zValidator } from "@hono/zod-validator";
 import type { MeetingRole, RecurringMeeting } from "@prisma/client";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
+import { recurringMeetingUpdateSchema } from "../lib/schemas/recurring-meeting.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 // 認証ユーザーが定例の所属組織のメンバーであるかを確認する共通ガード。
@@ -74,4 +76,26 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
     // include で取得した members は整形後の配列で置き換えて返す。
     const { members: _members, ...rest } = guard.meeting;
     return c.json({ ...rest, members });
-  });
+  })
+  .patch(
+    "/:id",
+    zValidator("json", recurringMeetingUpdateSchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const data = c.req.valid("json");
+
+      // 編集は組織メンバー全員に許可（削除のみ MeetingMember.owner 限定）。
+      // 定例取得時は members を含めずに済むため include しない軽量クエリ。
+      const meeting = await prisma.recurringMeeting.findUnique({
+        where: { id },
+      });
+      const guard = await requireRecurringAccess(c, meeting);
+      if (!guard.ok) return guard.res;
+
+      const updated = await prisma.recurringMeeting.update({
+        where: { id },
+        data,
+      });
+      return c.json(updated);
+    },
+  );

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma を全モックしてルートロジックのみ検証する。
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+    },
+    recurringMeeting: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    meetingMember: {
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+// auth ミドルウェアを差し替え、認証済みユーザーを c.var.user に注入する。
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return {
+    defaultUser,
+    current: { ...defaultUser },
+  };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: {
+      set: (key: string, value: unknown) => void;
+    },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+function membership(role: "owner" | "admin" | "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+const sampleRecurring = {
+  id: "rmtg-1",
+  organizationId: "org-1",
+  name: "週次定例",
+  description: "毎週月曜",
+  scheduleCron: "0 10 * * 1",
+  createdAt: new Date("2026-05-06T00:00:00Z"),
+  updatedAt: new Date("2026-05-06T00:00:00Z"),
+};
+
+describe("POST /organizations/:id/meetings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは定例を作成でき、自身を MeetingMember.owner として登録する", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    // $transaction はコールバックに tx を渡して RecurringMeeting と
+    // MeetingMember.owner を原子的に作成する想定。
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        recurringMeeting: {
+          create: vi.fn().mockResolvedValue(sampleRecurring),
+        },
+        meetingMember: { create: vi.fn().mockResolvedValue({}) },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用のミニマルな tx スタブ
+      const result = await (fn as (t: any) => Promise<unknown>)(tx);
+      expect(tx.recurringMeeting.create).toHaveBeenCalledWith({
+        data: {
+          organizationId: "org-1",
+          name: "週次定例",
+          description: "毎週月曜",
+          scheduleCron: "0 10 * * 1",
+        },
+      });
+      expect(tx.meetingMember.create).toHaveBeenCalledWith({
+        data: {
+          recurringMeetingId: "rmtg-1",
+          userId: "user-1",
+          role: "owner",
+        },
+      });
+      return result;
+    });
+
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "週次定例",
+        description: "毎週月曜",
+        scheduleCron: "0 10 * * 1",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; name: string };
+    expect(body.id).toBe("rmtg-1");
+    expect(body.name).toBe("週次定例");
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("description は省略可能", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        recurringMeeting: {
+          create: vi
+            .fn()
+            .mockResolvedValue({ ...sampleRecurring, description: null }),
+        },
+        meetingMember: { create: vi.fn().mockResolvedValue({}) },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用のミニマルな tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "週次定例",
+        scheduleCron: "0 10 * * 1",
+      }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("未所属ユーザーは 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "週次定例",
+        scheduleCron: "0 10 * * 1",
+      }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("name が空の場合は 400 を返す", async () => {
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "", scheduleCron: "0 10 * * 1" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipFindUnique).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("name 欠落は 400 を返す", async () => {
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scheduleCron: "0 10 * * 1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("scheduleCron 欠落は 400 を返す", async () => {
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "週次定例" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("scheduleCron がフィールド 5 個でない場合は 400 を返す", async () => {
+    // MVP 段階では「スペース区切りで 5 フィールド」のみ検証する。
+    // 中身（分・時・日・月・曜日）の妥当性検証は後続 Issue で対応。
+    const res = await app.request("/organizations/org-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "週次定例",
+        scheduleCron: "invalid cron",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -54,6 +54,7 @@ import { prisma } from "../src/lib/prisma.js";
 const mockMembershipFindUnique = vi.mocked(
   prisma.organizationMembership.findUnique,
 );
+const mockRecurringFindUnique = vi.mocked(prisma.recurringMeeting.findUnique);
 const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
@@ -264,5 +265,81 @@ describe("GET /organizations/:id/meetings", () => {
     const res = await app.request("/organizations/org-1/meetings");
     expect(res.status).toBe(404);
     expect(mockRecurringFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /recurring-meetings/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const sampleMembers = [
+    // 並び順検証用に DB 順序を意図的に role 逆順で返し、ハンドラ側で
+    // owner → member の順にソートされることを確認する。
+    {
+      recurringMeetingId: "rmtg-1",
+      userId: "user-2",
+      role: "member" as const,
+      joinedAt: new Date("2026-05-07T00:00:00Z"),
+      user: {
+        id: "user-2",
+        name: "bob",
+        displayName: "Bob B.",
+        email: "bob@example.com",
+      },
+    },
+    {
+      recurringMeetingId: "rmtg-1",
+      userId: "user-1",
+      role: "owner" as const,
+      joinedAt: new Date("2026-05-06T00:00:00Z"),
+      user: {
+        id: "user-1",
+        name: "alice",
+        displayName: "Alice A.",
+        email: "alice@example.com",
+      },
+    },
+  ];
+
+  it("組織メンバーは定例詳細を取得でき、メンバー一覧を owner→member 順で返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue({
+      ...sampleRecurring,
+      members: sampleMembers,
+    } as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+
+    const res = await app.request("/recurring-meetings/rmtg-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      members: Array<{ userId: string; role: string; name: string }>;
+    };
+    expect(body.id).toBe("rmtg-1");
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0].userId).toBe("user-1");
+    expect(body.members[0].role).toBe("owner");
+    expect(body.members[0].name).toBe("alice");
+    expect(body.members[1].userId).toBe("user-2");
+    expect(body.members[1].role).toBe("member");
+  });
+
+  it("定例が存在しない場合は 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/missing");
+    expect(res.status).toBe(404);
+    // 組織所属チェックに進む前に 404 で短絡する。
+    expect(mockMembershipFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("定例所属組織のメンバーでない場合は 404 を返す", async () => {
+    // 組織の存在自体を露出させないため、所属していない場合は 404 で統一する。
+    mockRecurringFindUnique.mockResolvedValue({
+      ...sampleRecurring,
+      members: [],
+    } as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1");
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -57,6 +57,8 @@ const mockMembershipFindUnique = vi.mocked(
 const mockRecurringFindUnique = vi.mocked(prisma.recurringMeeting.findUnique);
 const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockRecurringUpdate = vi.mocked(prisma.recurringMeeting.update);
+const mockRecurringDelete = vi.mocked(prisma.recurringMeeting.delete);
+const mockMeetingMemberFindUnique = vi.mocked(prisma.meetingMember.findUnique);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -448,5 +450,81 @@ describe("PATCH /recurring-meetings/:id", () => {
     });
     expect(res.status).toBe(404);
     expect(mockRecurringUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /recurring-meetings/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("MeetingMember.owner は削除でき、204 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingMemberFindUnique.mockResolvedValue({
+      recurringMeetingId: "rmtg-1",
+      userId: "user-1",
+      role: "owner",
+      joinedAt: new Date("2026-05-06T00:00:00Z"),
+    });
+    mockRecurringDelete.mockResolvedValue(sampleRecurring as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+    expect(mockRecurringDelete).toHaveBeenCalledWith({
+      where: { id: "rmtg-1" },
+    });
+    // 配下の Meeting / MeetingMember は schema 側の onDelete: Cascade に委ねる。
+  });
+
+  it("MeetingMember.member は 403 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingMemberFindUnique.mockResolvedValue({
+      recurringMeetingId: "rmtg-1",
+      userId: "user-1",
+      role: "member",
+      joinedAt: new Date("2026-05-06T00:00:00Z"),
+    });
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockRecurringDelete).not.toHaveBeenCalled();
+  });
+
+  it("組織メンバーだが MeetingMember 未参加なら 403 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockMeetingMemberFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockRecurringDelete).not.toHaveBeenCalled();
+  });
+
+  it("組織メンバーでなければ 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockMeetingMemberFindUnique).not.toHaveBeenCalled();
+    expect(mockRecurringDelete).not.toHaveBeenCalled();
+  });
+
+  it("定例が存在しない場合は 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/missing", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockRecurringDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -54,6 +54,7 @@ import { prisma } from "../src/lib/prisma.js";
 const mockMembershipFindUnique = vi.mocked(
   prisma.organizationMembership.findUnique,
 );
+const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -207,5 +208,61 @@ describe("POST /organizations/:id/meetings", () => {
       }),
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /organizations/:id/meetings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const listSample = [
+    {
+      ...sampleRecurring,
+      id: "rmtg-2",
+      name: "月次レビュー",
+      createdAt: new Date("2026-05-08T00:00:00Z"),
+      _count: { members: 3 },
+    },
+    {
+      ...sampleRecurring,
+      id: "rmtg-1",
+      _count: { members: 5 },
+    },
+  ];
+
+  it("組織メンバーは定例一覧を取得でき、_count.members を含む", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockRecurringFindMany.mockResolvedValue(listSample as never);
+
+    const res = await app.request("/organizations/org-1/meetings");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      _count: { members: number };
+    }>;
+    expect(body).toHaveLength(2);
+    expect(body[0].id).toBe("rmtg-2");
+    expect(body[0]._count.members).toBe(3);
+    expect(body[1].id).toBe("rmtg-1");
+    expect(body[1]._count.members).toBe(5);
+    expect(mockRecurringFindMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1" },
+      orderBy: { createdAt: "desc" },
+      include: { _count: { select: { members: true } } },
+    });
+  });
+
+  it("定例が無い組織は空配列を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockRecurringFindMany.mockResolvedValue([] as never);
+    const res = await app.request("/organizations/org-1/meetings");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("未所属ユーザーは 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/organizations/org-1/meetings");
+    expect(res.status).toBe(404);
+    expect(mockRecurringFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -56,6 +56,7 @@ const mockMembershipFindUnique = vi.mocked(
 );
 const mockRecurringFindUnique = vi.mocked(prisma.recurringMeeting.findUnique);
 const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
+const mockRecurringUpdate = vi.mocked(prisma.recurringMeeting.update);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -341,5 +342,111 @@ describe("GET /recurring-meetings/:id", () => {
 
     const res = await app.request("/recurring-meetings/rmtg-1");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /recurring-meetings/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは定例を編集できる（name のみ）", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockRecurringUpdate.mockResolvedValue({
+      ...sampleRecurring,
+      name: "新しい定例名",
+    } as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "新しい定例名" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockRecurringUpdate).toHaveBeenCalledWith({
+      where: { id: "rmtg-1" },
+      data: { name: "新しい定例名" },
+    });
+  });
+
+  it("scheduleCron も編集できる", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockRecurringUpdate.mockResolvedValue({
+      ...sampleRecurring,
+      scheduleCron: "0 14 * * 5",
+    } as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scheduleCron: "0 14 * * 5" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockRecurringUpdate).toHaveBeenCalledWith({
+      where: { id: "rmtg-1" },
+      data: { scheduleCron: "0 14 * * 5" },
+    });
+  });
+
+  it("scheduleCron が不正フォーマットなら 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scheduleCron: "not-a-cron" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockRecurringUpdate).not.toHaveBeenCalled();
+  });
+
+  it("空ボディの PATCH は 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("name が空文字なら 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("定義外フィールドを含む PATCH は 400 を返す", async () => {
+    // strict() により未知のフィールドはエラーになる。
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "新しい名前", unknown: "foo" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("定例が存在しない場合は 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "新しい名前" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockRecurringUpdate).not.toHaveBeenCalled();
+  });
+
+  it("組織メンバーでなければ 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "新しい名前" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockRecurringUpdate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #86

## 概要・目的
* 組織配下の定例（RecurringMeeting）を CRUD で管理する API を追加。前回→今回→次回の意思決定・タスクを定例単位で繋ぐための土台として、まずは枠の作成・閲覧・編集・削除を Backend 側で揃える。

## 背景
* 組織 API までは実装済みだが、その配下に定例を作る手段が無く、フロント側（一覧画面・サイドバーの定例セレクター等）が API 待ちになっていた。
* Issue #86 では `/meetings/:id` 系で定例の CRUD を切る指示だったが、既存 `/meetings` ルーター（`apps/web` ホーム画面で利用中の個別 Meeting CRUD）と URL が衝突するため、定例側を **`/recurring-meetings/:id`** に変更している（Issue にコメントで補足済み）。

## 変更内容
* 定例作成 `POST /organizations/:id/meetings`：作成者を `MeetingMember.owner` として `$transaction` で同時登録。組織未所属は 404、入力不正は 400。
* 定例一覧 `GET /organizations/:id/meetings`：組織メンバーのみ取得可。一覧画面のメンバー数バッジ用に `_count.members` を付与し、`createdAt` 降順で返す。
* 定例詳細 `GET /recurring-meetings/:id`：定例不存在・組織未所属いずれも 404 で統一し存在露出を防止。メンバーは `owner → member` 順、同一ロール内は参加日時昇順。
* 定例編集 `PATCH /recurring-meetings/:id`：編集権限は組織メンバー全員。`name` / `description` / `scheduleCron` を部分更新。`strict()` で未知フィールドや空ボディは 400。
* 定例削除 `DELETE /recurring-meetings/:id`：削除権限は `MeetingMember.owner` のみ。配下の `Meeting` / `MeetingMember` は schema 側の `onDelete: Cascade` に委ねる。
* `scheduleCron` バリデーションを `src/lib/schemas/recurring-meeting.ts` に共通化。MVP では「スペース区切り 5 フィールド」のみチェックし、内容の妥当性検証は cron パーサー導入時に厳格化予定。
* 新規ルーター `apps/api/src/routes/recurring-meetings.ts` を追加し `app.ts` で `/recurring-meetings` にマウント。
* ルートテスト 26 件を `apps/api/test/recurring-meetings.test.ts` に追加。

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-86-recurring-meeting-crud-api`
2. 依存をインストール: `make install`
3. 自動テスト・lint を実行: `make test && make lint`
   - `apps/api` の Vitest 118 件、`apps/web` 121 件すべて PASS、Biome / Ruff のエラーなしを確認
4. Docker Compose で全サービスを起動: `make dev-build`（初回または依存変更後）
5. 別ターミナルでマイグレーション状況を確認し、未適用があれば適用: `make migrate-status`（必要なら `make migrate`）
6. FakeAuth で `admin@example.com` 等としてログインし、取得した Bearer トークンを `$TOKEN` に設定。組織が無ければ `POST /organizations` で作り、その `id` を `$ORG_ID` に設定する
7. 以下を curl で叩き、レスポンスを確認:
   - 作成: `curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"name":"週次定例","scheduleCron":"0 10 * * 1"}' "http://localhost:3001/organizations/$ORG_ID/meetings"` → 201、`MeetingMember.owner` として作成者が登録される
   - 一覧: `curl -H "Authorization: Bearer $TOKEN" "http://localhost:3001/organizations/$ORG_ID/meetings"` → 200、各要素に `_count.members` が付く
   - 詳細: `curl -H "Authorization: Bearer $TOKEN" "http://localhost:3001/recurring-meetings/$MTG_ID"` → 200、`members` に owner ロールで自分が含まれる
   - 編集: `curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"name":"新しい名前"}' "http://localhost:3001/recurring-meetings/$MTG_ID"` → 200、`updatedAt` が更新される
   - 削除: `curl -i -X DELETE -H "Authorization: Bearer $TOKEN" "http://localhost:3001/recurring-meetings/$MTG_ID"` → `HTTP/1.1 204 No Content`

### 実機 E2E 確認結果
- `admin@example.com` で全 5 エンドポイントを上記手順で実行し、いずれも想定通りに動作
- 一覧レスポンスに `_count.members: 1`（作成者が owner として登録された結果）が含まれることを確認
- PATCH 後の `updatedAt` が作成時刻から進むことを確認
- DELETE で `HTTP/1.1 204 No Content` ヘッダが返り、body が空であることを確認

## スクリーンショット
* 作成レスポンス例（201）:
  ```json
  {
    "id": "cmp834o1600040ynvpydpkz8u",
    "organizationId": "cmp2pl6i300020zndu7tol6x6",
    "name": "週次定例",
    "description": null,
    "scheduleCron": "0 10 * * 1",
    "createdAt": "2026-05-16T08:29:14.539Z",
    "updatedAt": "2026-05-16T08:29:14.539Z"
  }
  ```
* 一覧レスポンス例（200・`_count.members` 付き）:
  ```json
  [
    {
      "id": "cmp834o1600040ynvpydpkz8u",
      "organizationId": "cmp2pl6i300020zndu7tol6x6",
      "name": "週次定例",
      "description": null,
      "scheduleCron": "0 10 * * 1",
      "createdAt": "2026-05-16T08:29:14.539Z",
      "updatedAt": "2026-05-16T08:29:14.539Z",
      "_count": { "members": 1 }
    }
  ]
  ```
* 詳細レスポンス例（200・作成者が owner として登録されている）:
  ```json
  {
    "id": "cmp834o1600040ynvpydpkz8u",
    "organizationId": "cmp2pl6i300020zndu7tol6x6",
    "name": "週次定例",
    "description": null,
    "scheduleCron": "0 10 * * 1",
    "createdAt": "2026-05-16T08:29:14.539Z",
    "updatedAt": "2026-05-16T08:29:14.539Z",
    "members": [
      {
        "userId": "cmp2k22yt00000zndb2ur0jl3",
        "name": "admin",
        "displayName": "admin",
        "email": "admin@example.com",
        "role": "owner",
        "joinedAt": "2026-05-16T08:29:14.541Z"
      }
    ]
  }
  ```
* 編集レスポンス例（200・`updatedAt` が進む）:
  ```json
  {
    "id": "cmp834o1600040ynvpydpkz8u",
    "name": "新しい名前",
    "scheduleCron": "0 10 * * 1",
    "createdAt": "2026-05-16T08:29:14.539Z",
    "updatedAt": "2026-05-16T08:29:47.840Z"
  }
  ```
* 削除レスポンス（body 無し）:
  ```
  HTTP/1.1 204 No Content
  Date: Sat, 16 May 2026 08:29:52 GMT
  Connection: keep-alive
  Keep-Alive: timeout=5
  ```
