### PR TITLE
定例管理 UI と cron ビルダーを追加

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
 import type { Organization } from "@/features/organizations/types";
+import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
 import { api, authHeaders } from "@/lib/api";
 import {
   clearCurrentOrganizationIdAtom,
@@ -139,16 +140,68 @@ export function Sidebar() {
           ダッシュボード
         </Link>
 
-        {/* 定例セクション（API 実装後に Issue #86 / #89 で連動予定） */}
+        {/* 定例セクション。選択中組織配下の定例を一覧表示する。
+            クリック時の遷移先は組織詳細画面（定例詳細画面は将来 Issue）。 */}
         <p className="px-2.5 pt-4 pb-1 text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
           定例
         </p>
-        <div className="flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm text-foreground/70">
-          <CalendarDays size={15} />
-          <span className="truncate">〜定例会議</span>
-        </div>
+        <SidebarMeetingList orgId={currentId} />
       </nav>
     </aside>
+  );
+}
+
+// サイドバーの「定例」セクション。選択中組織配下の定例を一覧表示する。
+// 各項目クリックで組織詳細画面へ遷移し、サイドバー上では現在の組織コンテキストを
+// 保ったまま定例を素早く認識できる状態にする。
+function SidebarMeetingList({ orgId }: { orgId: string | null }) {
+  const { data, isLoading, isError } = useOrganizationMeetings(orgId);
+
+  if (orgId === null) return null;
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-label="定例一覧を読み込み中"
+        className="px-2.5 py-2"
+      >
+        <div className="h-4 w-full rounded-md bg-muted-foreground/15 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="px-2.5 py-2 text-xs text-destructive">
+        定例の取得に失敗しました
+      </p>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <p className="px-2.5 py-2 text-xs text-muted-foreground/70">
+        定例はまだありません
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {data.map((m) => (
+        <li key={m.id}>
+          <Link
+            to="/organizations/$id"
+            params={{ id: orgId }}
+            className="flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <CalendarDays size={15} className="shrink-0" />
+            <span className="truncate">{m.name}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
 import type { Organization } from "@/features/organizations/types";
+import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
 import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
 import { api, authHeaders } from "@/lib/api";
 import {
@@ -66,6 +67,7 @@ export function Sidebar() {
   const setCurrentId = useSetAtom(setCurrentOrganizationIdAtom);
   const clearCurrentId = useSetAtom(clearCurrentOrganizationIdAtom);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createMeetingOpen, setCreateMeetingOpen] = useState(false);
   const navigate = useNavigate();
   // selector で必要な値だけ subscribe し、関係のない state 変化での再描画を抑える。
   const pathname = useRouterState({
@@ -141,11 +143,31 @@ export function Sidebar() {
         </Link>
 
         {/* 定例セクション。選択中組織配下の定例を一覧表示する。
-            クリック時の遷移先は組織詳細画面（定例詳細画面は将来 Issue）。 */}
-        <p className="px-2.5 pt-4 pb-1 text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
-          定例
-        </p>
+            クリック時の遷移先は組織詳細画面（定例詳細画面は将来 Issue）。
+            組織が選択されているときだけ「+ 定例を追加」ボタンを表示する。 */}
+        <div className="flex items-center justify-between pt-4 pb-1 pl-2.5 pr-1">
+          <p className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+            定例
+          </p>
+          {currentId && (
+            <button
+              type="button"
+              aria-label="定例を追加"
+              onClick={() => setCreateMeetingOpen(true)}
+              className="h-6 w-6 rounded-md text-muted-foreground/80 hover:bg-muted hover:text-foreground flex items-center justify-center"
+            >
+              <PlusIcon size={13} />
+            </button>
+          )}
+        </div>
         <SidebarMeetingList orgId={currentId} />
+        {currentId && (
+          <CreateRecurringMeetingDialog
+            orgId={currentId}
+            open={createMeetingOpen}
+            onOpenChange={setCreateMeetingOpen}
+          />
+        )}
       </nav>
     </aside>
   );

--- a/apps/web/src/features/recurring-meetings/components/CreateRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/CreateRecurringMeetingDialog.tsx
@@ -13,12 +13,15 @@ import { Label } from "@/components/ui/label";
 import { api, authHeaders } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useId, useState } from "react";
-import { useForm } from "react-hook-form";
+import { type ReactNode, useId, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
+import { buildCron, defaultCronBuilderState } from "../scheduleCron";
+import { ScheduleCronBuilder } from "./ScheduleCronBuilder";
 
-// API 側 schema と同様、MVP では「スペース区切り 5 フィールド」のみ検証する。
-// 詳細な妥当性チェックは cron パーサー導入時に厳格化予定。
+// API 側 schema と同じ：scheduleCron は「スペース区切り 5 フィールド」のみ検証する。
+// ビルダー UI を経由する場合は常に有効な cron が生成されるため、フォーム値としては
+// regex を満たすが、防御的に schema 側も維持しておく。
 const cronFieldFormat = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/;
 
 const createSchema = z.object({
@@ -32,26 +35,47 @@ const createSchema = z.object({
 
 type CreateFormValues = z.infer<typeof createSchema>;
 
-export function CreateRecurringMeetingDialog({ orgId }: { orgId: string }) {
-  const [open, setOpen] = useState(false);
+export function CreateRecurringMeetingDialog({
+  orgId,
+  trigger,
+  open: openProp,
+  onOpenChange,
+}: {
+  orgId: string;
+  // 任意のトリガー要素を差し込み可能にする。未指定時は「定例を作成」ボタンを使う。
+  trigger?: ReactNode;
+  // 制御モード用。サイドバー等の外側 UI から開きたい場合に使う。
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (onOpenChange) onOpenChange(next);
+    if (openProp === undefined) setInternalOpen(next);
+  };
+
   const queryClient = useQueryClient();
   const nameId = useId();
   const descriptionId = useId();
-  const cronId = useId();
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { errors },
   } = useForm<CreateFormValues>({
     resolver: zodResolver(createSchema),
-    defaultValues: { name: "", description: "", scheduleCron: "" },
+    defaultValues: {
+      name: "",
+      description: "",
+      scheduleCron: buildCron(defaultCronBuilderState),
+    },
   });
 
   const mutation = useMutation({
     mutationFn: async (data: CreateFormValues) => {
-      // description は空文字なら API に渡さない（API 側 schema が optional のため、
-      // 空文字を送ると DB 上の null と挙動が一致しなくなる）。
+      // description は空文字なら API に渡さない（API 側 schema が optional のため）。
       const json: {
         name: string;
         description?: string;
@@ -70,9 +94,7 @@ export function CreateRecurringMeetingDialog({ orgId }: { orgId: string }) {
       return res.json();
     },
     onSuccess: () => {
-      // 組織詳細の recurringMeetings を更新するため、組織詳細クエリを invalidate。
-      // サイドバーの定例リスト用クエリも同じ invalidate で更新できるよう、
-      // 別 hook 側で同じ key プレフィックスを共有する想定。
+      // 組織詳細とサイドバーの定例リスト用クエリを更新する。
       queryClient.invalidateQueries({ queryKey: ["organizations", orgId] });
       queryClient.invalidateQueries({
         queryKey: ["organizations", orgId, "meetings"],
@@ -93,15 +115,19 @@ export function CreateRecurringMeetingDialog({ orgId }: { orgId: string }) {
         }
       }}
     >
-      <DialogTrigger asChild>
-        <Button>定例を作成</Button>
-      </DialogTrigger>
+      {/* 外部から open を制御する場合（サイドバーから開く等）はトリガーを描画しない。
+          ダイアログのトリガー責務を外側に委ねるためのパターン。 */}
+      {openProp === undefined && (
+        <DialogTrigger asChild>
+          {trigger ?? <Button>定例を作成</Button>}
+        </DialogTrigger>
+      )}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>定例を作成</DialogTitle>
           <DialogDescription>
-            開催する定例の情報を入力してください。開催頻度は cron 形式（例:
-            毎週月曜10時なら 0 10 * * 1）で入力します。
+            開催する定例の情報を入力してください。頻度は「毎日 / 毎週 /
+            毎月」から選び、曜日や時刻を指定します。
           </DialogDescription>
         </DialogHeader>
         <form
@@ -129,19 +155,17 @@ export function CreateRecurringMeetingDialog({ orgId }: { orgId: string }) {
               {...register("description")}
             />
           </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={cronId}>開催頻度（cron 形式）</Label>
-            <Input
-              id={cronId}
-              placeholder="0 10 * * 1（毎週月曜10時）"
-              {...register("scheduleCron")}
-            />
-            {errors.scheduleCron && (
-              <p role="alert" className="text-destructive text-sm">
-                {errors.scheduleCron.message}
-              </p>
+          <Controller
+            name="scheduleCron"
+            control={control}
+            render={({ field }) => (
+              <ScheduleCronBuilder
+                value={field.value}
+                onChange={field.onChange}
+                error={errors.scheduleCron?.message}
+              />
             )}
-          </div>
+          />
           {mutation.isError && (
             <p className="text-destructive text-sm">定例の作成に失敗しました</p>
           )}

--- a/apps/web/src/features/recurring-meetings/components/CreateRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/CreateRecurringMeetingDialog.tsx
@@ -1,0 +1,157 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api, authHeaders } from "@/lib/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+// API 側 schema と同様、MVP では「スペース区切り 5 フィールド」のみ検証する。
+// 詳細な妥当性チェックは cron パーサー導入時に厳格化予定。
+const cronFieldFormat = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/;
+
+const createSchema = z.object({
+  name: z.string().min(1, "定例名は必須です"),
+  description: z.string().optional(),
+  scheduleCron: z
+    .string()
+    .min(1, "開催頻度は必須です")
+    .regex(cronFieldFormat, "スペース区切りで 5 フィールドを入力してください"),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+
+export function CreateRecurringMeetingDialog({ orgId }: { orgId: string }) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const nameId = useId();
+  const descriptionId = useId();
+  const cronId = useId();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: { name: "", description: "", scheduleCron: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateFormValues) => {
+      // description は空文字なら API に渡さない（API 側 schema が optional のため、
+      // 空文字を送ると DB 上の null と挙動が一致しなくなる）。
+      const json: {
+        name: string;
+        description?: string;
+        scheduleCron: string;
+      } = { name: data.name, scheduleCron: data.scheduleCron };
+      if (data.description && data.description.length > 0) {
+        json.description = data.description;
+      }
+      const res = await api.organizations[":id"].meetings.$post(
+        { param: { id: orgId }, json },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to create recurring meeting: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      // 組織詳細の recurringMeetings を更新するため、組織詳細クエリを invalidate。
+      // サイドバーの定例リスト用クエリも同じ invalidate で更新できるよう、
+      // 別 hook 側で同じ key プレフィックスを共有する想定。
+      queryClient.invalidateQueries({ queryKey: ["organizations", orgId] });
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", orgId, "meetings"],
+      });
+      reset();
+      setOpen(false);
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          reset();
+          mutation.reset();
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button>定例を作成</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>定例を作成</DialogTitle>
+          <DialogDescription>
+            開催する定例の情報を入力してください。開催頻度は cron 形式（例:
+            毎週月曜10時なら 0 10 * * 1）で入力します。
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit((data) => mutation.mutate(data))}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={nameId}>定例名</Label>
+            <Input
+              id={nameId}
+              placeholder="例: 週次定例"
+              {...register("name")}
+            />
+            {errors.name && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={descriptionId}>説明</Label>
+            <Input
+              id={descriptionId}
+              placeholder="定例の目的・進め方（任意）"
+              {...register("description")}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={cronId}>開催頻度（cron 形式）</Label>
+            <Input
+              id={cronId}
+              placeholder="0 10 * * 1（毎週月曜10時）"
+              {...register("scheduleCron")}
+            />
+            {errors.scheduleCron && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.scheduleCron.message}
+              </p>
+            )}
+          </div>
+          {mutation.isError && (
+            <p className="text-destructive text-sm">定例の作成に失敗しました</p>
+          )}
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              作成
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/components/DeleteRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/DeleteRecurringMeetingDialog.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { RecurringMeeting } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+// 削除権限は API 側で MeetingMember.owner のみに絞られている。
+// 自分が owner かどうかは詳細 API を叩かないと判定できないため、UI ではボタンを
+// 全員に表示し、403 が返った場合に「権限なし」を明示するエラーハンドリングに切る。
+// N+1 リクエストを避けるための割り切り（Issue #89 のコメント参照）。
+class ForbiddenError extends Error {}
+
+export function DeleteRecurringMeetingDialog({
+  meeting,
+}: {
+  meeting: RecurringMeeting;
+}) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const res = await api["recurring-meetings"][":id"].$delete(
+        { param: { id: meeting.id } },
+        authHeaders(),
+      );
+      if (res.status === 403) {
+        throw new ForbiddenError();
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to delete recurring meeting: ${res.status}`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", meeting.organizationId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", meeting.organizationId, "meetings"],
+      });
+      setOpen(false);
+    },
+  });
+
+  const errorMessage = (() => {
+    if (!mutation.isError) return null;
+    if (mutation.error instanceof ForbiddenError) {
+      return "削除権限がありません（定例のオーナーのみ削除可能です）";
+    }
+    return "定例の削除に失敗しました";
+  })();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) mutation.reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          削除
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>定例を削除</DialogTitle>
+          <DialogDescription>
+            {`「${meeting.name}」を削除しますか？この操作は取り消せません。配下の会議データもすべて削除されます。`}
+          </DialogDescription>
+        </DialogHeader>
+        {errorMessage && (
+          <p className="text-destructive text-sm">{errorMessage}</p>
+        )}
+        <DialogFooter>
+          <Button
+            variant="destructive"
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            削除を実行
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
@@ -1,0 +1,173 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { RecurringMeeting } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useId, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+// API 側 schema と同じ：scheduleCron は「スペース区切り 5 フィールド」のみ検証。
+const cronFieldFormat = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/;
+
+const editSchema = z.object({
+  name: z.string().min(1, "定例名は必須です"),
+  // 空文字を許容して「説明をクリア」を表現する。
+  description: z.string(),
+  scheduleCron: z
+    .string()
+    .min(1, "開催頻度は必須です")
+    .regex(cronFieldFormat, "スペース区切りで 5 フィールドを入力してください"),
+});
+
+type EditFormValues = z.infer<typeof editSchema>;
+
+export function EditRecurringMeetingDialog({
+  meeting,
+}: {
+  meeting: RecurringMeeting;
+}) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const nameId = useId();
+  const descriptionId = useId();
+  const cronId = useId();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<EditFormValues>({
+    resolver: zodResolver(editSchema),
+    defaultValues: {
+      name: meeting.name,
+      description: meeting.description ?? "",
+      scheduleCron: meeting.scheduleCron,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: EditFormValues) => {
+      // 変更があったフィールドのみを送る。組織編集と同様、null と "" の混乱を避ける。
+      const json: {
+        name?: string;
+        description?: string;
+        scheduleCron?: string;
+      } = {};
+      if (data.name !== meeting.name) json.name = data.name;
+      const prevDescription = meeting.description ?? "";
+      if (data.description !== prevDescription) {
+        json.description = data.description;
+      }
+      if (data.scheduleCron !== meeting.scheduleCron) {
+        json.scheduleCron = data.scheduleCron;
+      }
+      // 変更が無ければ API を呼ばずに success 扱いで閉じる
+      // （API 側 schema が「1 項目以上」を要求するため、空 PATCH は 400 になる）。
+      if (
+        json.name === undefined &&
+        json.description === undefined &&
+        json.scheduleCron === undefined
+      ) {
+        return null;
+      }
+      const res = await api["recurring-meetings"][":id"].$patch(
+        { param: { id: meeting.id }, json },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to update recurring meeting: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", meeting.organizationId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", meeting.organizationId, "meetings"],
+      });
+      setOpen(false);
+    },
+  });
+
+  // 親が refetch で新しい meeting を渡してきたとき、閉じている間に
+  // フォーム初期値を最新値に合わせる（組織編集ダイアログと同方針）。
+  useEffect(() => {
+    if (!open) {
+      reset({
+        name: meeting.name,
+        description: meeting.description ?? "",
+        scheduleCron: meeting.scheduleCron,
+      });
+    }
+  }, [meeting.name, meeting.description, meeting.scheduleCron, open, reset]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) mutation.reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          編集
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>定例を編集</DialogTitle>
+          <DialogDescription>定例の情報を更新します。</DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit((data) => mutation.mutate(data))}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={nameId}>定例名</Label>
+            <Input id={nameId} {...register("name")} />
+            {errors.name && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={descriptionId}>説明</Label>
+            <Input id={descriptionId} {...register("description")} />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={cronId}>開催頻度（cron 形式）</Label>
+            <Input id={cronId} {...register("scheduleCron")} />
+            {errors.scheduleCron && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.scheduleCron.message}
+              </p>
+            )}
+          </div>
+          {mutation.isError && (
+            <p className="text-destructive text-sm">定例の更新に失敗しました</p>
+          )}
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              保存
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
@@ -14,9 +14,11 @@ import type { RecurringMeeting } from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useId, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect, useId, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
+import { parseCron } from "../scheduleCron";
+import { ScheduleCronBuilder } from "./ScheduleCronBuilder";
 
 // API 側 schema と同じ：scheduleCron は「スペース区切り 5 フィールド」のみ検証。
 const cronFieldFormat = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/;
@@ -42,11 +44,20 @@ export function EditRecurringMeetingDialog({
   const queryClient = useQueryClient();
   const nameId = useId();
   const descriptionId = useId();
-  const cronId = useId();
+  const cronTextId = useId();
+
+  // 既存 cron が builder で表現可能か。表現不可能なら fallback として
+  // 生 cron 文字列のテキスト入力を表示する。
+  const isBuilderCompatible = useMemo(
+    () => parseCron(meeting.scheduleCron) !== null,
+    [meeting.scheduleCron],
+  );
+
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { errors },
   } = useForm<EditFormValues>({
     resolver: zodResolver(editSchema),
@@ -59,7 +70,7 @@ export function EditRecurringMeetingDialog({
 
   const mutation = useMutation({
     mutationFn: async (data: EditFormValues) => {
-      // 変更があったフィールドのみを送る。組織編集と同様、null と "" の混乱を避ける。
+      // 変更があったフィールドのみを送る。null と "" の混乱を避ける。
       const json: {
         name?: string;
         description?: string;
@@ -73,8 +84,6 @@ export function EditRecurringMeetingDialog({
       if (data.scheduleCron !== meeting.scheduleCron) {
         json.scheduleCron = data.scheduleCron;
       }
-      // 変更が無ければ API を呼ばずに success 扱いで閉じる
-      // （API 側 schema が「1 項目以上」を要求するため、空 PATCH は 400 になる）。
       if (
         json.name === undefined &&
         json.description === undefined &&
@@ -102,8 +111,7 @@ export function EditRecurringMeetingDialog({
     },
   });
 
-  // 親が refetch で新しい meeting を渡してきたとき、閉じている間に
-  // フォーム初期値を最新値に合わせる（組織編集ダイアログと同方針）。
+  // 親が refetch で新しい meeting を渡してきたとき、閉じている間にフォームを同期。
   useEffect(() => {
     if (!open) {
       reset({
@@ -149,15 +157,36 @@ export function EditRecurringMeetingDialog({
             <Label htmlFor={descriptionId}>説明</Label>
             <Input id={descriptionId} {...register("description")} />
           </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={cronId}>開催頻度（cron 形式）</Label>
-            <Input id={cronId} {...register("scheduleCron")} />
-            {errors.scheduleCron && (
-              <p role="alert" className="text-destructive text-sm">
-                {errors.scheduleCron.message}
+          {isBuilderCompatible ? (
+            <Controller
+              name="scheduleCron"
+              control={control}
+              render={({ field }) => (
+                <ScheduleCronBuilder
+                  value={field.value}
+                  onChange={field.onChange}
+                  error={errors.scheduleCron?.message}
+                />
+              )}
+            />
+          ) : (
+            // 範囲指定やステップ指定など、ビルダーで表現できない既存 cron は
+            // テキスト入力で編集する。ビルダーに上書きすると元の cron が
+            // 失われるため、本ダイアログでは切替を提供しない。
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={cronTextId}>開催頻度（cron 形式）</Label>
+              <Input id={cronTextId} {...register("scheduleCron")} />
+              <p className="text-xs text-muted-foreground">
+                この定例には範囲・ステップ指定など複雑な cron 式が使われているため、
+                テキスト形式で編集します。
               </p>
-            )}
-          </div>
+              {errors.scheduleCron && (
+                <p role="alert" className="text-destructive text-sm">
+                  {errors.scheduleCron.message}
+                </p>
+              )}
+            </div>
+          )}
           {mutation.isError && (
             <p className="text-destructive text-sm">定例の更新に失敗しました</p>
           )}

--- a/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/EditRecurringMeetingDialog.tsx
@@ -177,8 +177,8 @@ export function EditRecurringMeetingDialog({
               <Label htmlFor={cronTextId}>開催頻度（cron 形式）</Label>
               <Input id={cronTextId} {...register("scheduleCron")} />
               <p className="text-xs text-muted-foreground">
-                この定例には範囲・ステップ指定など複雑な cron 式が使われているため、
-                テキスト形式で編集します。
+                この定例には範囲・ステップ指定など複雑な cron
+                式が使われているため、 テキスト形式で編集します。
               </p>
               {errors.scheduleCron && (
                 <p role="alert" className="text-destructive text-sm">

--- a/apps/web/src/features/recurring-meetings/components/RecurringMeetingCard.tsx
+++ b/apps/web/src/features/recurring-meetings/components/RecurringMeetingCard.tsx
@@ -1,0 +1,41 @@
+import type { RecurringMeeting } from "@/features/organizations/types";
+import type { ReactNode } from "react";
+
+// 作成日表示。日本ロケールで「2026/5/16」のように短く出す。
+// 時刻まで含めると一覧で冗長になるため日付のみ。
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ja-JP");
+}
+
+export function RecurringMeetingCard({
+  meeting,
+  actions,
+}: {
+  meeting: RecurringMeeting;
+  // 編集・削除ボタン等を右肩に差し込むためのスロット。
+  // 各操作の責務はカード本体に持たせず、呼び出し側で組み立てる。
+  actions?: ReactNode;
+}) {
+  return (
+    <li className="flex flex-col gap-2 rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <span className="font-medium truncate">{meeting.name}</span>
+          {meeting.description ? (
+            <span className="text-sm text-muted-foreground line-clamp-2">
+              {meeting.description}
+            </span>
+          ) : null}
+        </div>
+        {actions ? (
+          <div className="flex items-center gap-2 shrink-0">{actions}</div>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="font-mono">{meeting.scheduleCron}</span>
+        <span>作成: {formatDate(meeting.createdAt)}</span>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/components/ScheduleCronBuilder.tsx
+++ b/apps/web/src/features/recurring-meetings/components/ScheduleCronBuilder.tsx
@@ -1,0 +1,170 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useId, useState } from "react";
+import {
+  buildCron,
+  type CronBuilderState,
+  defaultCronBuilderState,
+  describeCron,
+  parseCron,
+} from "../scheduleCron";
+
+const WEEKDAYS: { value: number; label: string }[] = [
+  { value: 1, label: "月" },
+  { value: 2, label: "火" },
+  { value: 3, label: "水" },
+  { value: 4, label: "木" },
+  { value: 5, label: "金" },
+  { value: 6, label: "土" },
+  { value: 0, label: "日" },
+];
+
+function pad(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+// 開催頻度のビルダー UI。
+// React Hook Form と組み合わせるときは Controller でラップし、`value` に現在の cron 文字列を、
+// `onChange` に「次の cron 文字列」を返す。生 cron を直接知る必要があるレビュアーや
+// 開発者向けに、プレビュー欄に cron 表記も併記する。
+export function ScheduleCronBuilder({
+  value,
+  onChange,
+  error,
+}: {
+  value: string;
+  onChange: (cron: string) => void;
+  error?: string;
+}) {
+  // value が既存 cron として復元できない場合（範囲指定など）は既定状態にフォールバック。
+  // 編集ダイアログ等で未対応 cron を受け取ったケースは呼び出し側でカスタム入力へ切り替える想定。
+  const [state, setState] = useState<CronBuilderState>(
+    () => parseCron(value) ?? defaultCronBuilderState,
+  );
+  const dayId = useId();
+  const timeId = useId();
+
+  const update = (next: CronBuilderState) => {
+    setState(next);
+    onChange(buildCron(next));
+  };
+
+  const updateTime = (time: string) => {
+    // HTML time input は "HH:MM" 形式。空 (クリア) も来うる。
+    const [h, m] = time.split(":").map((s) => Number.parseInt(s, 10));
+    if (Number.isNaN(h) || Number.isNaN(m)) return;
+    update({ ...state, hour: h, minute: m });
+  };
+
+  const toggleWeekday = (d: number) => {
+    const next = state.weekdays.includes(d)
+      ? state.weekdays.filter((x) => x !== d)
+      : [...state.weekdays, d];
+    update({ ...state, weekdays: next });
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium">頻度</legend>
+        <div className="flex gap-2" role="radiogroup" aria-label="頻度">
+          {(["daily", "weekly", "monthly"] as const).map((f) => {
+            const active = state.frequency === f;
+            const label =
+              f === "daily" ? "毎日" : f === "weekly" ? "毎週" : "毎月";
+            return (
+              <Button
+                key={f}
+                type="button"
+                variant={active ? "default" : "outline"}
+                size="sm"
+                role="radio"
+                aria-checked={active}
+                onClick={() => update({ ...state, frequency: f })}
+              >
+                {label}
+              </Button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {state.frequency === "weekly" && (
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-sm font-medium">曜日（複数選択可）</legend>
+          <div className="flex gap-1 flex-wrap">
+            {WEEKDAYS.map(({ value: d, label }) => {
+              const active = state.weekdays.includes(d);
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  aria-pressed={active}
+                  aria-label={label}
+                  onClick={() => toggleWeekday(d)}
+                  className={cn(
+                    "h-8 w-9 rounded-md border text-sm transition-colors",
+                    active
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-background text-foreground/70 hover:bg-accent",
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+      )}
+
+      {state.frequency === "monthly" && (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={dayId}>日</Label>
+          <select
+            id={dayId}
+            value={state.dayOfMonth}
+            onChange={(e) =>
+              update({ ...state, dayOfMonth: Number(e.target.value) })
+            }
+            className="border rounded-md p-2 bg-background w-24"
+          >
+            {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+              <option key={d} value={d}>
+                {d} 日
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={timeId}>時刻</Label>
+        <input
+          id={timeId}
+          type="time"
+          value={`${pad(state.hour)}:${pad(state.minute)}`}
+          onChange={(e) => updateTime(e.target.value)}
+          className="border rounded-md p-2 bg-background w-32"
+        />
+      </div>
+
+      <div
+        role="status"
+        aria-label="開催頻度プレビュー"
+        className="rounded-md bg-muted/40 px-3 py-2 text-sm"
+      >
+        <span className="font-medium">{describeCron(state)}</span>
+        <span className="ml-2 font-mono text-xs text-muted-foreground">
+          ({buildCron(state)})
+        </span>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
@@ -1,0 +1,29 @@
+import type { RecurringMeeting } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// 一覧 API は _count.members を付与して返すため、UI 用に型を拡張する。
+export type RecurringMeetingListItem = RecurringMeeting & {
+  _count: { members: number };
+};
+
+// 組織配下の定例一覧を取得する hook。
+// クエリキーは ["organizations", orgId, "meetings"] で固定し、作成・編集・削除ダイアログ側の
+// invalidate と整合させる。orgId が null の場合は API を呼ばずに無効化する。
+export function useOrganizationMeetings(orgId: string | null) {
+  return useQuery<RecurringMeetingListItem[]>({
+    queryKey: ["organizations", orgId ?? "__none__", "meetings"],
+    queryFn: async () => {
+      if (!orgId) return [];
+      const res = await api.organizations[":id"].meetings.$get(
+        { param: { id: orgId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch recurring meetings: ${res.status}`);
+      }
+      return (await res.json()) as RecurringMeetingListItem[];
+    },
+    enabled: orgId !== null,
+  });
+}

--- a/apps/web/src/features/recurring-meetings/scheduleCron.ts
+++ b/apps/web/src/features/recurring-meetings/scheduleCron.ts
@@ -1,0 +1,125 @@
+// 定例の開催頻度を表す UI 上の中間表現。
+// ビルダー UI 側はこの形を編集し、API 送信時に buildCron で cron 文字列へ変換する。
+// 編集ダイアログでは既存 cron 文字列を parseCron でこの形に逆引きする。
+export type CronBuilderState = {
+  frequency: "daily" | "weekly" | "monthly";
+  // 0=日, 1=月, ..., 6=土。frequency==="weekly" のときのみ参照。
+  weekdays: number[];
+  // 1〜31。frequency==="monthly" のときのみ参照。
+  dayOfMonth: number;
+  // 0〜23
+  hour: number;
+  // 0〜59
+  minute: number;
+};
+
+// ビルダーの初期状態。「毎週月曜 10:00」を既定にする（議事プロダクトでの想定が多い時刻帯）。
+export const defaultCronBuilderState: CronBuilderState = {
+  frequency: "weekly",
+  weekdays: [1],
+  dayOfMonth: 1,
+  hour: 10,
+  minute: 0,
+};
+
+export function buildCron(state: CronBuilderState): string {
+  const { frequency, weekdays, dayOfMonth, hour, minute } = state;
+  if (frequency === "daily") {
+    return `${minute} ${hour} * * *`;
+  }
+  if (frequency === "weekly") {
+    // 曜日未選択は cron 上「全曜日」と同義 (毎日) になってしまうため、
+    // ビルダー側で送信を抑制する責務を持つ。ここでは "*" を返さず、
+    // 空配列ならば fall-through で 0 (日曜) として送る安全側のデフォルトとしておく。
+    const days = weekdays.length === 0 ? "0" : [...weekdays].sort().join(",");
+    return `${minute} ${hour} * * ${days}`;
+  }
+  return `${minute} ${hour} ${dayOfMonth} * *`;
+}
+
+function parseIntStrict(s: string): number | null {
+  if (!/^\d+$/.test(s)) return null;
+  return Number.parseInt(s, 10);
+}
+
+// 既存 cron 文字列をビルダー状態に変換する。
+// 表現できない cron（例: 範囲指定 "1-5"、ステップ指定 "*/15"、月指定など）は null を返し、
+// 呼び出し側でカスタム入力フォールバックに切り替えてもらう想定。
+export function parseCron(cron: string): CronBuilderState | null {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const [minStr, hourStr, domStr, monthStr, dowStr] = fields;
+  const minute = parseIntStrict(minStr);
+  const hour = parseIntStrict(hourStr);
+  if (minute === null || hour === null) return null;
+  if (minute < 0 || minute > 59) return null;
+  if (hour < 0 || hour > 23) return null;
+  // 月指定は本ビルダーではサポートしない（毎月実行のみ）。
+  if (monthStr !== "*") return null;
+
+  const domIsWild = domStr === "*";
+  const dowIsWild = dowStr === "*";
+
+  if (domIsWild && dowIsWild) {
+    return {
+      frequency: "daily",
+      weekdays: [],
+      dayOfMonth: 1,
+      hour,
+      minute,
+    };
+  }
+  if (domIsWild && !dowIsWild) {
+    // weekly: 0-6 のカンマ区切り
+    const parts = dowStr.split(",").map(parseIntStrict);
+    if (parts.some((d) => d === null || d < 0 || d > 6)) return null;
+    return {
+      frequency: "weekly",
+      weekdays: parts as number[],
+      dayOfMonth: 1,
+      hour,
+      minute,
+    };
+  }
+  if (!domIsWild && dowIsWild) {
+    const day = parseIntStrict(domStr);
+    if (day === null || day < 1 || day > 31) return null;
+    return {
+      frequency: "monthly",
+      weekdays: [],
+      dayOfMonth: day,
+      hour,
+      minute,
+    };
+  }
+  // dom と dow の両方指定はビルダー UI では扱わない。
+  return null;
+}
+
+const WEEKDAY_LABELS_JA = ["日", "月", "火", "水", "木", "金", "土"];
+
+function formatTime(hour: number, minute: number): string {
+  const h = hour.toString().padStart(2, "0");
+  const m = minute.toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+// プレビュー欄に表示する人間向け表記。
+// 例: 「毎週 月・水 10:00」「毎月 1 日 09:00」「毎日 10:00」。
+export function describeCron(state: CronBuilderState): string {
+  const time = formatTime(state.hour, state.minute);
+  if (state.frequency === "daily") {
+    return `毎日 ${time}`;
+  }
+  if (state.frequency === "weekly") {
+    if (state.weekdays.length === 0) {
+      return `毎週（曜日未選択） ${time}`;
+    }
+    const labels = [...state.weekdays]
+      .sort()
+      .map((d) => WEEKDAY_LABELS_JA[d])
+      .join("・");
+    return `毎週 ${labels} ${time}`;
+  }
+  return `毎月 ${state.dayOfMonth} 日 ${time}`;
+}

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -16,6 +16,7 @@ import type {
   OrganizationDetail,
 } from "@/features/organizations/types";
 import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
+import { DeleteRecurringMeetingDialog } from "@/features/recurring-meetings/components/DeleteRecurringMeetingDialog";
 import { EditRecurringMeetingDialog } from "@/features/recurring-meetings/components/EditRecurringMeetingDialog";
 import { RecurringMeetingCard } from "@/features/recurring-meetings/components/RecurringMeetingCard";
 import { api, authHeaders } from "@/lib/api";
@@ -543,7 +544,12 @@ export function OrganizationDetailView({
               <RecurringMeetingCard
                 key={meeting.id}
                 meeting={meeting}
-                actions={<EditRecurringMeetingDialog meeting={meeting} />}
+                actions={
+                  <>
+                    <EditRecurringMeetingDialog meeting={meeting} />
+                    <DeleteRecurringMeetingDialog meeting={meeting} />
+                  </>
+                }
               />
             ))}
           </ul>

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -16,6 +16,7 @@ import type {
   OrganizationDetail,
 } from "@/features/organizations/types";
 import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
+import { RecurringMeetingCard } from "@/features/recurring-meetings/components/RecurringMeetingCard";
 import { api, authHeaders } from "@/lib/api";
 import { authAtom } from "@/lib/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -533,16 +534,12 @@ export function OrganizationDetailView({
         {org.recurringMeetings.length === 0 ? (
           <p className="text-muted-foreground">定例はまだありません</p>
         ) : (
-          <ul aria-label="定例一覧" className="divide-y rounded-md border">
+          <ul
+            aria-label="定例一覧"
+            className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+          >
             {org.recurringMeetings.map((meeting) => (
-              <li key={meeting.id} className="px-4 py-3">
-                <span className="font-medium">{meeting.name}</span>
-                {meeting.description ? (
-                  <span className="ml-2 text-sm text-muted-foreground">
-                    {meeting.description}
-                  </span>
-                ) : null}
-              </li>
+              <RecurringMeetingCard key={meeting.id} meeting={meeting} />
             ))}
           </ul>
         )}

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -16,6 +16,7 @@ import type {
   OrganizationDetail,
 } from "@/features/organizations/types";
 import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
+import { EditRecurringMeetingDialog } from "@/features/recurring-meetings/components/EditRecurringMeetingDialog";
 import { RecurringMeetingCard } from "@/features/recurring-meetings/components/RecurringMeetingCard";
 import { api, authHeaders } from "@/lib/api";
 import { authAtom } from "@/lib/auth";
@@ -539,7 +540,11 @@ export function OrganizationDetailView({
             className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
           >
             {org.recurringMeetings.map((meeting) => (
-              <RecurringMeetingCard key={meeting.id} meeting={meeting} />
+              <RecurringMeetingCard
+                key={meeting.id}
+                meeting={meeting}
+                actions={<EditRecurringMeetingDialog meeting={meeting} />}
+              />
             ))}
           </ul>
         )}

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -15,6 +15,7 @@ import type {
   Member,
   OrganizationDetail,
 } from "@/features/organizations/types";
+import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
 import { api, authHeaders } from "@/lib/api";
 import { authAtom } from "@/lib/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -525,7 +526,10 @@ export function OrganizationDetailView({
       </section>
 
       <section aria-label="定例" className="space-y-3">
-        <h2 className="text-lg font-semibold">定例</h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">定例</h2>
+          <CreateRecurringMeetingDialog orgId={id} />
+        </div>
         {org.recurringMeetings.length === 0 ? (
           <p className="text-muted-foreground">定例はまだありません</p>
         ) : (

--- a/apps/web/src/test/EditRecurringMeetingDialog.test.tsx
+++ b/apps/web/src/test/EditRecurringMeetingDialog.test.tsx
@@ -1,0 +1,112 @@
+import type { RecurringMeeting } from "@/features/organizations/types";
+import { EditRecurringMeetingDialog } from "@/features/recurring-meetings/components/EditRecurringMeetingDialog";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    "recurring-meetings": {
+      ":id": {
+        $patch: vi.fn(),
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+const sampleMeeting: RecurringMeeting = {
+  id: "meet-1",
+  organizationId: "org-1",
+  name: "週次定例",
+  description: null,
+  scheduleCron: "0 10 * * 1",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// rerender 時に QueryClientProvider のラップを失わせないよう、wrapper でラップした
+// ui を渡す。renderWithQuery の rerender ではラップが剥がれてしまうため。
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrap = (node: React.ReactElement) => (
+    <QueryClientProvider client={client}>{node}</QueryClientProvider>
+  );
+  const utils = render(wrap(ui));
+  return {
+    ...utils,
+    rerender: (next: React.ReactElement) => utils.rerender(wrap(next)),
+  };
+}
+
+describe("EditRecurringMeetingDialog の refetch 同期", () => {
+  it("ダイアログを閉じている間に meeting prop が更新されると、次回開いた時にフォームが新値で初期化される", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithClient(
+      <EditRecurringMeetingDialog meeting={sampleMeeting} />,
+    );
+
+    // 初回オープン: 既存値が表示されることを確認
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    let dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    expect(within(dialog).getByLabelText("定例名")).toHaveValue("週次定例");
+    // close（ESC キーで閉じる）
+    await user.keyboard("{Escape}");
+
+    // ダイアログが閉じている間に親が新しい meeting を渡してくる
+    // （実環境では refetch 後の useQuery が新値を返した状態）
+    const updated: RecurringMeeting = {
+      ...sampleMeeting,
+      name: "別の名前",
+      description: "親が更新した説明",
+      scheduleCron: "0 14 * * 5",
+    };
+    rerender(<EditRecurringMeetingDialog meeting={updated} />);
+
+    // 再オープン: フォームが新値で初期化されている
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    expect(within(dialog).getByLabelText("定例名")).toHaveValue("別の名前");
+    expect(within(dialog).getByLabelText("説明")).toHaveValue(
+      "親が更新した説明",
+    );
+    // builder のプレビューも新 cron に追従（金曜 14:00）
+    expect(
+      within(dialog).getByLabelText("開催頻度プレビュー"),
+    ).toHaveTextContent("毎週 金 14:00");
+  });
+
+  it("ダイアログを開いている間に meeting prop が変わっても、入力中の値は破壊されない", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithClient(
+      <EditRecurringMeetingDialog meeting={sampleMeeting} />,
+    );
+
+    // ダイアログを開いて name を編集途中の状態にする
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    const nameInput = within(dialog).getByLabelText("定例名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "編集中の名前");
+
+    // 開いている最中に親 (refetch 等) が別の値を渡してきても
+    // フォームの編集中の値は維持される（useEffect が open===true の間は走らない）
+    rerender(
+      <EditRecurringMeetingDialog
+        meeting={{ ...sampleMeeting, name: "外部からの上書き" }}
+      />,
+    );
+    expect(within(dialog).getByLabelText("定例名")).toHaveValue("編集中の名前");
+  });
+});

--- a/apps/web/src/test/ScheduleCronBuilder.test.tsx
+++ b/apps/web/src/test/ScheduleCronBuilder.test.tsx
@@ -1,0 +1,108 @@
+import { ScheduleCronBuilder } from "@/features/recurring-meetings/components/ScheduleCronBuilder";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// React Hook Form を介さずに使うため、薄いラッパで value/onChange を保持する。
+// 実際のフォームでは Controller でバインドする。
+function Harness({
+  initial,
+  onChange,
+}: {
+  initial: string;
+  onChange?: (cron: string) => void;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ScheduleCronBuilder
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe("ScheduleCronBuilder", () => {
+  it("曜日（月）を解除すると cron の曜日リストから外れる", async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Harness initial="0 10 * * 1,3" onChange={handle} />);
+
+    // 月を解除すると残りは「水（3）」のみ
+    await user.click(screen.getByRole("button", { name: "月" }));
+    expect(handle).toHaveBeenLastCalledWith("0 10 * * 3");
+  });
+
+  it("毎月モードに切り替えると日選択 UI が現れて cron が monthly 形式になる", async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Harness initial="0 10 * * 1" onChange={handle} />);
+
+    await user.click(screen.getByRole("radio", { name: "毎月" }));
+    // 日選択 select が出る
+    const daySelect = screen.getByLabelText("日");
+    expect(daySelect).toBeInTheDocument();
+    // 既定の day=1 で cron が組み立てられる
+    expect(handle).toHaveBeenLastCalledWith("0 10 1 * *");
+
+    // 日を 15 に変更
+    await user.selectOptions(daySelect, "15");
+    expect(handle).toHaveBeenLastCalledWith("0 10 15 * *");
+  });
+
+  it("時刻入力を変更すると cron の分・時が更新される", () => {
+    const handle = vi.fn();
+    render(<Harness initial="0 10 * * 1" onChange={handle} />);
+
+    const timeInput = screen.getByLabelText("時刻");
+    // time input の userEvent.type は jsdom 上で文字単位の挙動が安定しないため、
+    // fireEvent.change で完了状態のみを発火させる。実 UI では time picker から
+    // 値を選ぶ操作に相当する。
+    fireEvent.change(timeInput, { target: { value: "14:30" } });
+    expect(handle).toHaveBeenLastCalledWith("30 14 * * 1");
+  });
+
+  it("parseCron で復元できない値が来た場合は既定値（毎週月曜 10:00）にフォールバックする", () => {
+    // 範囲指定はビルダー非対応。初回レンダリング時に defaultCronBuilderState が使われ、
+    // プレビューが「毎週 月 10:00」になる。onChange は描画時点では呼ばれない（再操作で初めて出る）。
+    render(<Harness initial="0 10 * * 1-5" />);
+    const preview = screen.getByLabelText("開催頻度プレビュー");
+    expect(preview).toHaveTextContent("毎週 月 10:00");
+  });
+
+  it("頻度を毎日に切り替えると曜日 UI が消える", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="0 10 * * 1" />);
+
+    expect(screen.getByRole("button", { name: "月" })).toBeInTheDocument();
+    await user.click(screen.getByRole("radio", { name: "毎日" }));
+    // 曜日ボタン群は消える
+    expect(
+      screen.queryByRole("button", { name: "月" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("エラー文字列を渡すと alert として表示される", () => {
+    render(
+      <Harness
+        initial="0 10 * * 1"
+        // onChange は使わない。error を別途差し込むため、Harness ではなく直接利用する。
+      />,
+    );
+    // Harness 経由では error を渡せないため、直接 ScheduleCronBuilder を使ったレンダリングで検証する。
+    render(
+      <ScheduleCronBuilder
+        value="0 10 * * 1"
+        onChange={() => {}}
+        error="開催頻度が不正です"
+      />,
+    );
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts.some((el) => el.textContent === "開催頻度が不正です")).toBe(
+      true,
+    );
+  });
+});

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -1199,3 +1199,94 @@ describe("組織詳細ページ - 定例編集ダイアログ", () => {
     ).toBeInTheDocument();
   });
 });
+
+// ===== 定例削除ダイアログ =====
+
+describe("組織詳細ページ - 定例削除ダイアログ", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson(ownerOrgDetail),
+    );
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("定例カードに「削除」ボタンが表示され、押すと確認ダイアログが開く", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const card = list.querySelector("li") as HTMLElement;
+    await user.click(within(card).getByRole("button", { name: "削除" }));
+    expect(
+      await screen.findByRole("dialog", { name: "定例を削除" }),
+    ).toBeInTheDocument();
+  });
+
+  it("確認ダイアログで「削除を実行」を押すと API が呼ばれてダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$delete).mockResolvedValue(
+      mockJson(null, 204),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const card = list.querySelector("li") as HTMLElement;
+    await user.click(within(card).getByRole("button", { name: "削除" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を削除" });
+    await user.click(
+      within(dialog).getByRole("button", { name: "削除を実行" }),
+    );
+    await waitFor(() => {
+      expect(api["recurring-meetings"][":id"].$delete).toHaveBeenCalledWith(
+        { param: { id: "meet-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "定例を削除" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("403 が返った場合は「削除権限がありません」を表示する", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$delete).mockResolvedValue(
+      mockJson({ error: "削除権限がありません" }, 403),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const card = list.querySelector("li") as HTMLElement;
+    await user.click(within(card).getByRole("button", { name: "削除" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を削除" });
+    await user.click(
+      within(dialog).getByRole("button", { name: "削除を実行" }),
+    );
+    expect(
+      await within(dialog).findByText(
+        "削除権限がありません（定例のオーナーのみ削除可能です）",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "定例を削除" }),
+    ).toBeInTheDocument();
+  });
+
+  it("403 以外のエラーは汎用メッセージを表示する", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$delete).mockResolvedValue(
+      mockJson({ error: "internal" }, 500),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const card = list.querySelector("li") as HTMLElement;
+    await user.click(within(card).getByRole("button", { name: "削除" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を削除" });
+    await user.click(
+      within(dialog).getByRole("button", { name: "削除を実行" }),
+    );
+    expect(
+      await within(dialog).findByText("定例の削除に失敗しました"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -1073,3 +1073,129 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
     ).toBeInTheDocument();
   });
 });
+
+// ===== 定例編集ダイアログ =====
+
+describe("組織詳細ページ - 定例編集ダイアログ", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson(ownerOrgDetail),
+    );
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("定例カードの「編集」ボタンを押すとダイアログが開き、現在の値が初期表示される", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    const card = (
+      await screen.findByRole("list", { name: "定例一覧" })
+    ).querySelector("li");
+    if (!card) throw new Error("card not found");
+    await user.click(
+      within(card as HTMLElement).getByRole("button", { name: "編集" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    expect(within(dialog).getByLabelText("定例名")).toHaveValue("週次定例");
+    expect(within(dialog).getByLabelText("開催頻度（cron 形式）")).toHaveValue(
+      "0 10 * * 1",
+    );
+  });
+
+  it("name のみ変更して保存すると差分のみが送信される", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$patch).mockResolvedValue(
+      mockJson({
+        ...ownerOrgDetail.recurringMeetings[0],
+        name: "新しい定例名",
+      }),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    await user.click(
+      within(list.querySelector("li") as HTMLElement).getByRole("button", {
+        name: "編集",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    const nameInput = within(dialog).getByLabelText("定例名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "新しい定例名");
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    await waitFor(() => {
+      expect(api["recurring-meetings"][":id"].$patch).toHaveBeenCalledWith(
+        { param: { id: "meet-1" }, json: { name: "新しい定例名" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "定例を編集" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("変更が無い場合は API を呼ばずに閉じる", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    await user.click(
+      within(list.querySelector("li") as HTMLElement).getByRole("button", {
+        name: "編集",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "定例を編集" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(api["recurring-meetings"][":id"].$patch).not.toHaveBeenCalled();
+  });
+
+  it("scheduleCron を不正な形式に変更するとバリデーションエラー", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    await user.click(
+      within(list.querySelector("li") as HTMLElement).getByRole("button", {
+        name: "編集",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    const cronInput = within(dialog).getByLabelText("開催頻度（cron 形式）");
+    await user.clear(cronInput);
+    await user.type(cronInput, "invalid");
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    expect(
+      await within(dialog).findByText(
+        "スペース区切りで 5 フィールドを入力してください",
+      ),
+    ).toBeInTheDocument();
+    expect(api["recurring-meetings"][":id"].$patch).not.toHaveBeenCalled();
+  });
+
+  it("API エラー時はダイアログ内にエラーメッセージを表示する", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$patch).mockResolvedValue(
+      mockJson({ error: "サーバーエラー" }, 500),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    await user.click(
+      within(list.querySelector("li") as HTMLElement).getByRole("button", {
+        name: "編集",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    const nameInput = within(dialog).getByLabelText("定例名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "別の名前");
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    expect(
+      await within(dialog).findByText("定例の更新に失敗しました"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -22,6 +22,13 @@ vi.mock("@/lib/api", () => ({
           $get: vi.fn(),
           ":userId": { $delete: vi.fn() },
         },
+        meetings: { $post: vi.fn() },
+      },
+    },
+    "recurring-meetings": {
+      ":id": {
+        $patch: vi.fn(),
+        $delete: vi.fn(),
       },
     },
   },
@@ -873,5 +880,173 @@ describe("組織詳細ページ - 組織削除ダイアログ", () => {
       screen.getByRole("dialog", { name: "組織を削除" }),
     ).toBeInTheDocument();
     expect(onOrganizationDeleted).not.toHaveBeenCalled();
+  });
+});
+
+// ===== 定例作成ダイアログ =====
+
+describe("組織詳細ページ - 定例作成ダイアログ", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson(ownerOrgDetail),
+    );
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("「定例を作成」ボタンを押すとダイアログが開く", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    expect(
+      await screen.findByRole("dialog", { name: "定例を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("定例作成ボタンは member ロールでも表示される（API 仕様: 組織メンバー全員可）", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "member" }),
+    );
+    renderDetail();
+    expect(
+      await screen.findByRole("button", { name: "定例を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("name 未入力で送信するとバリデーションエラー", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(
+      within(dialog).getByLabelText("開催頻度（cron 形式）"),
+      "0 10 * * 1",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    expect(
+      await within(dialog).findByText("定例名は必須です"),
+    ).toBeInTheDocument();
+    expect(api.organizations[":id"].meetings.$post).not.toHaveBeenCalled();
+  });
+
+  it("scheduleCron が 5 フィールドでない場合はバリデーションエラー", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "テスト定例");
+    await user.type(
+      within(dialog).getByLabelText("開催頻度（cron 形式）"),
+      "invalid",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    expect(
+      await within(dialog).findByText(
+        "スペース区切りで 5 フィールドを入力してください",
+      ),
+    ).toBeInTheDocument();
+    expect(api.organizations[":id"].meetings.$post).not.toHaveBeenCalled();
+  });
+
+  it("正常送信で $post が呼ばれてダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
+      mockJson(
+        {
+          id: "meet-new",
+          organizationId: "org-1",
+          name: "新規定例",
+          description: null,
+          scheduleCron: "0 10 * * 1",
+          createdAt: "2026-05-15T00:00:00.000Z",
+          updatedAt: "2026-05-15T00:00:00.000Z",
+        },
+        201,
+      ),
+    );
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    await user.type(
+      within(dialog).getByLabelText("開催頻度（cron 形式）"),
+      "0 10 * * 1",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    await waitFor(() => {
+      expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
+        {
+          param: { id: "org-1" },
+          json: { name: "新規定例", scheduleCron: "0 10 * * 1" },
+        },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "定例を作成" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("description を入力するとペイロードに含まれる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
+      mockJson(
+        {
+          id: "meet-new",
+          organizationId: "org-1",
+          name: "新規定例",
+          description: "毎週月曜",
+          scheduleCron: "0 10 * * 1",
+          createdAt: "2026-05-15T00:00:00.000Z",
+          updatedAt: "2026-05-15T00:00:00.000Z",
+        },
+        201,
+      ),
+    );
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    await user.type(within(dialog).getByLabelText("説明"), "毎週月曜");
+    await user.type(
+      within(dialog).getByLabelText("開催頻度（cron 形式）"),
+      "0 10 * * 1",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    await waitFor(() => {
+      expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
+        {
+          param: { id: "org-1" },
+          json: {
+            name: "新規定例",
+            description: "毎週月曜",
+            scheduleCron: "0 10 * * 1",
+          },
+        },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+
+  it("API エラー時はダイアログ内にエラーメッセージを表示する", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
+      mockJson({ error: "サーバーエラー" }, 500),
+    );
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    await user.type(
+      within(dialog).getByLabelText("開催頻度（cron 形式）"),
+      "0 10 * * 1",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    expect(
+      await within(dialog).findByText("定例の作成に失敗しました"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -142,9 +142,32 @@ describe("組織詳細ページ - 基本表示", () => {
     expect(within(memberList).getByText("メンバー")).toBeInTheDocument();
   });
 
-  it("定例一覧が表示される", async () => {
+  it("定例一覧がカードで表示され、定例名・scheduleCron・作成日を含む", async () => {
     renderDetail();
-    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const cards = within(list).getAllByRole("listitem");
+    expect(cards).toHaveLength(1);
+    const card = cards[0];
+    expect(within(card).getByText("週次定例")).toBeInTheDocument();
+    expect(within(card).getByText("0 10 * * 1")).toBeInTheDocument();
+    // 作成日は ISO ではなくロケール表示するため、年が含まれていれば OK
+    expect(within(card).getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("定例カードに description があれば表示される", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({
+        ...ownerOrgDetail,
+        recurringMeetings: [
+          {
+            ...ownerOrgDetail.recurringMeetings[0],
+            description: "毎週月曜の進捗共有",
+          },
+        ],
+      }),
+    );
+    renderDetail();
+    expect(await screen.findByText("毎週月曜の進捗共有")).toBeInTheDocument();
   });
 
   it("定例が 0 件のときは空状態メッセージが表示される", async () => {

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -942,10 +942,6 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
     renderDetail();
     await user.click(await screen.findByRole("button", { name: "定例を作成" }));
     const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
-    await user.type(
-      within(dialog).getByLabelText("開催頻度（cron 形式）"),
-      "0 10 * * 1",
-    );
     await user.click(within(dialog).getByRole("button", { name: "作成" }));
     expect(
       await within(dialog).findByText("定例名は必須です"),
@@ -953,26 +949,7 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
     expect(api.organizations[":id"].meetings.$post).not.toHaveBeenCalled();
   });
 
-  it("scheduleCron が 5 フィールドでない場合はバリデーションエラー", async () => {
-    const user = userEvent.setup();
-    renderDetail();
-    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
-    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
-    await user.type(within(dialog).getByLabelText("定例名"), "テスト定例");
-    await user.type(
-      within(dialog).getByLabelText("開催頻度（cron 形式）"),
-      "invalid",
-    );
-    await user.click(within(dialog).getByRole("button", { name: "作成" }));
-    expect(
-      await within(dialog).findByText(
-        "スペース区切りで 5 フィールドを入力してください",
-      ),
-    ).toBeInTheDocument();
-    expect(api.organizations[":id"].meetings.$post).not.toHaveBeenCalled();
-  });
-
-  it("正常送信で $post が呼ばれてダイアログが閉じる", async () => {
+  it("既定の開催頻度（毎週月曜 10:00）で送信される", async () => {
     const user = userEvent.setup();
     vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
       mockJson(
@@ -992,10 +969,6 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
     await user.click(await screen.findByRole("button", { name: "定例を作成" }));
     const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
     await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
-    await user.type(
-      within(dialog).getByLabelText("開催頻度（cron 形式）"),
-      "0 10 * * 1",
-    );
     await user.click(within(dialog).getByRole("button", { name: "作成" }));
     await waitFor(() => {
       expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
@@ -1006,38 +979,63 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
         expect.objectContaining({ headers: expect.any(Object) }),
       );
     });
+  });
+
+  it("頻度を毎日に切り替えると cron が '0 10 * * *' に変わる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
+      mockJson({ id: "meet-new" }, 201),
+    );
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    await user.click(within(dialog).getByRole("radio", { name: "毎日" }));
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
     await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "定例を作成" }),
-      ).not.toBeInTheDocument();
+      expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
+        {
+          param: { id: "org-1" },
+          json: { name: "新規定例", scheduleCron: "0 10 * * *" },
+        },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+
+  it("曜日（水）を追加すると cron に 3 が加わる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
+      mockJson({ id: "meet-new" }, 201),
+    );
+    renderDetail();
+    await user.click(await screen.findByRole("button", { name: "定例を作成" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    // 既定で月（1）は選択済み。水（3）を追加で押す。
+    await user.click(within(dialog).getByRole("button", { name: "水" }));
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+    await waitFor(() => {
+      expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
+        {
+          param: { id: "org-1" },
+          json: { name: "新規定例", scheduleCron: "0 10 * * 1,3" },
+        },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
     });
   });
 
   it("description を入力するとペイロードに含まれる", async () => {
     const user = userEvent.setup();
     vi.mocked(api.organizations[":id"].meetings.$post).mockResolvedValue(
-      mockJson(
-        {
-          id: "meet-new",
-          organizationId: "org-1",
-          name: "新規定例",
-          description: "毎週月曜",
-          scheduleCron: "0 10 * * 1",
-          createdAt: "2026-05-15T00:00:00.000Z",
-          updatedAt: "2026-05-15T00:00:00.000Z",
-        },
-        201,
-      ),
+      mockJson({ id: "meet-new" }, 201),
     );
     renderDetail();
     await user.click(await screen.findByRole("button", { name: "定例を作成" }));
     const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
     await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
     await user.type(within(dialog).getByLabelText("説明"), "毎週月曜");
-    await user.type(
-      within(dialog).getByLabelText("開催頻度（cron 形式）"),
-      "0 10 * * 1",
-    );
     await user.click(within(dialog).getByRole("button", { name: "作成" }));
     await waitFor(() => {
       expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
@@ -1063,10 +1061,6 @@ describe("組織詳細ページ - 定例作成ダイアログ", () => {
     await user.click(await screen.findByRole("button", { name: "定例を作成" }));
     const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
     await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
-    await user.type(
-      within(dialog).getByLabelText("開催頻度（cron 形式）"),
-      "0 10 * * 1",
-    );
     await user.click(within(dialog).getByRole("button", { name: "作成" }));
     expect(
       await within(dialog).findByText("定例の作成に失敗しました"),

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -1080,7 +1080,7 @@ describe("組織詳細ページ - 定例編集ダイアログ", () => {
     );
   });
 
-  it("定例カードの「編集」ボタンを押すとダイアログが開き、現在の値が初期表示される", async () => {
+  it("定例カードの「編集」ボタンを押すとダイアログが開き、ビルダー UI に既存値が反映される", async () => {
     const user = userEvent.setup();
     renderDetail();
     const card = (
@@ -1092,9 +1092,9 @@ describe("組織詳細ページ - 定例編集ダイアログ", () => {
     );
     const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
     expect(within(dialog).getByLabelText("定例名")).toHaveValue("週次定例");
-    expect(within(dialog).getByLabelText("開催頻度（cron 形式）")).toHaveValue(
-      "0 10 * * 1",
-    );
+    // 既存 cron "0 10 * * 1" は「毎週 月曜 10:00」として復元される
+    const preview = within(dialog).getByLabelText("開催頻度プレビュー");
+    expect(preview).toHaveTextContent("毎週 月 10:00");
   });
 
   it("name のみ変更して保存すると差分のみが送信される", async () => {
@@ -1149,7 +1149,46 @@ describe("組織詳細ページ - 定例編集ダイアログ", () => {
     expect(api["recurring-meetings"][":id"].$patch).not.toHaveBeenCalled();
   });
 
-  it("scheduleCron を不正な形式に変更するとバリデーションエラー", async () => {
+  it("頻度を毎日に切り替えて保存すると scheduleCron が差分送信される", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api["recurring-meetings"][":id"].$patch).mockResolvedValue(
+      mockJson({
+        ...ownerOrgDetail.recurringMeetings[0],
+        scheduleCron: "0 10 * * *",
+      }),
+    );
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    await user.click(
+      within(list.querySelector("li") as HTMLElement).getByRole("button", {
+        name: "編集",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
+    await user.click(within(dialog).getByRole("radio", { name: "毎日" }));
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    await waitFor(() => {
+      expect(api["recurring-meetings"][":id"].$patch).toHaveBeenCalledWith(
+        { param: { id: "meet-1" }, json: { scheduleCron: "0 10 * * *" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+
+  it("ビルダーで表現できない cron はカスタム入力フィールドで編集できる", async () => {
+    // 範囲指定 "1-5" のような未対応 cron。ビルダーで構築できないため
+    // テキスト入力フィールドを fallback として描画する。
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({
+        ...ownerOrgDetail,
+        recurringMeetings: [
+          {
+            ...ownerOrgDetail.recurringMeetings[0],
+            scheduleCron: "0 10 * * 1-5",
+          },
+        ],
+      }),
+    );
     const user = userEvent.setup();
     renderDetail();
     const list = await screen.findByRole("list", { name: "定例一覧" });
@@ -1159,16 +1198,12 @@ describe("組織詳細ページ - 定例編集ダイアログ", () => {
       }),
     );
     const dialog = await screen.findByRole("dialog", { name: "定例を編集" });
-    const cronInput = within(dialog).getByLabelText("開催頻度（cron 形式）");
-    await user.clear(cronInput);
-    await user.type(cronInput, "invalid");
-    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    const fallback = within(dialog).getByLabelText("開催頻度（cron 形式）");
+    expect(fallback).toHaveValue("0 10 * * 1-5");
+    // ビルダーのプレビュー欄は表示されない
     expect(
-      await within(dialog).findByText(
-        "スペース区切りで 5 フィールドを入力してください",
-      ),
-    ).toBeInTheDocument();
-    expect(api["recurring-meetings"][":id"].$patch).not.toHaveBeenCalled();
+      within(dialog).queryByLabelText("開催頻度プレビュー"),
+    ).not.toBeInTheDocument();
   });
 
   it("API エラー時はダイアログ内にエラーメッセージを表示する", async () => {

--- a/apps/web/src/test/scheduleCron.test.ts
+++ b/apps/web/src/test/scheduleCron.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCron,
+  type CronBuilderState,
+  describeCron,
+  parseCron,
+} from "../features/recurring-meetings/scheduleCron";
+
+describe("buildCron", () => {
+  it("毎日 10:00 は '0 10 * * *' を生成する", () => {
+    const state: CronBuilderState = {
+      frequency: "daily",
+      weekdays: [],
+      dayOfMonth: 1,
+      hour: 10,
+      minute: 0,
+    };
+    expect(buildCron(state)).toBe("0 10 * * *");
+  });
+
+  it("毎週月曜 10:00 は '0 10 * * 1' を生成する", () => {
+    const state: CronBuilderState = {
+      frequency: "weekly",
+      weekdays: [1],
+      dayOfMonth: 1,
+      hour: 10,
+      minute: 0,
+    };
+    expect(buildCron(state)).toBe("0 10 * * 1");
+  });
+
+  it("複数曜日は昇順カンマ区切りで出力される", () => {
+    const state: CronBuilderState = {
+      frequency: "weekly",
+      weekdays: [3, 1, 5],
+      dayOfMonth: 1,
+      hour: 9,
+      minute: 30,
+    };
+    expect(buildCron(state)).toBe("30 9 * * 1,3,5");
+  });
+
+  it("毎月 15 日 09:00 は '0 9 15 * *' を生成する", () => {
+    const state: CronBuilderState = {
+      frequency: "monthly",
+      weekdays: [],
+      dayOfMonth: 15,
+      hour: 9,
+      minute: 0,
+    };
+    expect(buildCron(state)).toBe("0 9 15 * *");
+  });
+});
+
+describe("parseCron", () => {
+  it("'0 10 * * *' は daily 10:00 として復元される", () => {
+    expect(parseCron("0 10 * * *")).toEqual({
+      frequency: "daily",
+      weekdays: [],
+      dayOfMonth: 1,
+      hour: 10,
+      minute: 0,
+    });
+  });
+
+  it("'0 10 * * 1' は weekly 月曜 10:00 として復元される", () => {
+    expect(parseCron("0 10 * * 1")).toEqual({
+      frequency: "weekly",
+      weekdays: [1],
+      dayOfMonth: 1,
+      hour: 10,
+      minute: 0,
+    });
+  });
+
+  it("'30 9 * * 1,3,5' は複数曜日として復元される", () => {
+    expect(parseCron("30 9 * * 1,3,5")).toEqual({
+      frequency: "weekly",
+      weekdays: [1, 3, 5],
+      dayOfMonth: 1,
+      hour: 9,
+      minute: 30,
+    });
+  });
+
+  it("'0 9 15 * *' は monthly 15 日 09:00 として復元される", () => {
+    expect(parseCron("0 9 15 * *")).toEqual({
+      frequency: "monthly",
+      weekdays: [],
+      dayOfMonth: 15,
+      hour: 9,
+      minute: 0,
+    });
+  });
+
+  it("範囲指定 '1-5' のような未対応形式は null を返す", () => {
+    expect(parseCron("0 10 * * 1-5")).toBeNull();
+  });
+
+  it("ステップ指定 '*/15' のような未対応形式は null を返す", () => {
+    expect(parseCron("*/15 * * * *")).toBeNull();
+  });
+
+  it("月指定は未対応として null を返す", () => {
+    expect(parseCron("0 10 1 4 *")).toBeNull();
+  });
+
+  it("dom と dow の同時指定は null を返す", () => {
+    expect(parseCron("0 10 1 * 1")).toBeNull();
+  });
+
+  it("フィールド数が 5 でない場合は null を返す", () => {
+    expect(parseCron("0 10 * *")).toBeNull();
+    expect(parseCron("0 10 * * * *")).toBeNull();
+  });
+
+  it("時刻範囲外は null を返す", () => {
+    expect(parseCron("0 24 * * *")).toBeNull();
+    expect(parseCron("60 10 * * *")).toBeNull();
+  });
+});
+
+describe("describeCron", () => {
+  it("毎日のプレビュー", () => {
+    expect(
+      describeCron({
+        frequency: "daily",
+        weekdays: [],
+        dayOfMonth: 1,
+        hour: 10,
+        minute: 0,
+      }),
+    ).toBe("毎日 10:00");
+  });
+
+  it("毎週 単一曜日のプレビュー", () => {
+    expect(
+      describeCron({
+        frequency: "weekly",
+        weekdays: [1],
+        dayOfMonth: 1,
+        hour: 10,
+        minute: 0,
+      }),
+    ).toBe("毎週 月 10:00");
+  });
+
+  it("毎週 複数曜日のプレビュー", () => {
+    expect(
+      describeCron({
+        frequency: "weekly",
+        weekdays: [5, 1, 3],
+        dayOfMonth: 1,
+        hour: 9,
+        minute: 30,
+      }),
+    ).toBe("毎週 月・水・金 09:30");
+  });
+
+  it("毎月のプレビュー", () => {
+    expect(
+      describeCron({
+        frequency: "monthly",
+        weekdays: [],
+        dayOfMonth: 15,
+        hour: 9,
+        minute: 0,
+      }),
+    ).toBe("毎月 15 日 09:00");
+  });
+});

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -21,6 +21,9 @@ vi.mock("@/lib/api", () => ({
     organizations: {
       $get: vi.fn(),
       $post: vi.fn(),
+      ":id": {
+        meetings: { $get: vi.fn() },
+      },
     },
   },
   authHeaders: () => ({ headers: {} }),
@@ -124,6 +127,11 @@ beforeEach(() => {
   // 使わないため、明示的にリセットしておくだけで十分。
   (api.organizations.$get as Mock).mockReset();
   (api.organizations.$post as Mock).mockReset();
+  (api.organizations[":id"].meetings.$get as Mock).mockReset();
+  // 定例 GET は組織選択直後に走るため、デフォルトでは空配列を返しておく。
+  (api.organizations[":id"].meetings.$get as Mock).mockResolvedValue(
+    mockJson([]),
+  );
   // ルーターモックの状態もデフォルト (ダッシュボード) に戻す。
   currentPathnameRef.value = "/";
   navigateMock.mockReset();
@@ -404,6 +412,95 @@ describe("Sidebar 組織セレクター", () => {
 
     await waitFor(() => {
       expect(localStorage.getItem("current_organization_id")).toBe("org-new");
+    });
+  });
+});
+
+describe("Sidebar 定例リスト", () => {
+  it("選択中の組織配下の定例が表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    (api.organizations[":id"].meetings.$get as Mock).mockResolvedValue(
+      mockJson([
+        {
+          id: "meet-1",
+          organizationId: "org-1",
+          name: "週次定例",
+          description: null,
+          scheduleCron: "0 10 * * 1",
+          createdAt: "2026-05-03T00:00:00.000Z",
+          updatedAt: "2026-05-03T00:00:00.000Z",
+          _count: { members: 2 },
+        },
+        {
+          id: "meet-2",
+          organizationId: "org-1",
+          name: "月次レビュー",
+          description: null,
+          scheduleCron: "0 9 1 * *",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+          _count: { members: 3 },
+        },
+      ]),
+    );
+
+    renderSidebar();
+
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(screen.getByText("月次レビュー")).toBeInTheDocument();
+    // クリックは組織詳細画面へリンクする（定例詳細画面は将来 Issue）
+    const links = screen.getAllByRole("link", {
+      name: /週次定例|月次レビュー/,
+    });
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "/organizations/org-1");
+    }
+  });
+
+  it("選択中組織の定例が 0 件のとき「定例はまだありません」を表示する", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    (api.organizations[":id"].meetings.$get as Mock).mockResolvedValue(
+      mockJson([]),
+    );
+
+    renderSidebar();
+
+    expect(await screen.findByText("定例はまだありません")).toBeInTheDocument();
+  });
+
+  it("組織が 0 件のときは定例 API を叩かない", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson([]));
+
+    renderSidebar();
+
+    // 組織 CTA が出るまで待ち、定例 API が叩かれないことを確認
+    await screen.findByRole("button", { name: /新しい組織を作成/ });
+    expect(api.organizations[":id"].meetings.$get).not.toHaveBeenCalled();
+  });
+
+  it("組織を切り替えると別組織の定例 API が叩かれる", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    // 別組織に切り替え
+    await user.click(
+      await screen.findByRole("button", { name: "組織を切り替え" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: /別の組織/ }),
+    );
+
+    await waitFor(() => {
+      expect(api.organizations[":id"].meetings.$get).toHaveBeenCalledWith(
+        { param: { id: "org-2" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
     });
   });
 });

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -534,6 +534,33 @@ describe("Sidebar 定例リスト", () => {
     ).toBeInTheDocument();
   });
 
+  it("定例取得中は読み込みスケルトンが表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    // 解決しない Promise でローディング状態に固定
+    (api.organizations[":id"].meetings.$get as Mock).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    renderSidebar();
+
+    expect(
+      await screen.findByLabelText("定例一覧を読み込み中"),
+    ).toBeInTheDocument();
+  });
+
+  it("定例取得に失敗すると専用のエラー表示が出る", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    (api.organizations[":id"].meetings.$get as Mock).mockRejectedValue(
+      new Error("network"),
+    );
+
+    renderSidebar();
+
+    expect(
+      await screen.findByText("定例の取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
   it("サイドバーから作成すると現在組織配下に POST される", async () => {
     (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
     (api.organizations[":id"].meetings.$post as Mock).mockResolvedValue(

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/lib/api", () => ({
       $get: vi.fn(),
       $post: vi.fn(),
       ":id": {
-        meetings: { $get: vi.fn() },
+        meetings: { $get: vi.fn(), $post: vi.fn() },
       },
     },
   },
@@ -128,6 +128,7 @@ beforeEach(() => {
   (api.organizations.$get as Mock).mockReset();
   (api.organizations.$post as Mock).mockReset();
   (api.organizations[":id"].meetings.$get as Mock).mockReset();
+  (api.organizations[":id"].meetings.$post as Mock).mockReset();
   // 定例 GET は組織選択直後に走るため、デフォルトでは空配列を返しておく。
   (api.organizations[":id"].meetings.$get as Mock).mockResolvedValue(
     mockJson([]),
@@ -499,6 +500,72 @@ describe("Sidebar 定例リスト", () => {
     await waitFor(() => {
       expect(api.organizations[":id"].meetings.$get).toHaveBeenCalledWith(
         { param: { id: "org-2" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+
+  it("組織選択時は定例セクションに「定例を追加」ボタンが表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    renderSidebar();
+    expect(
+      await screen.findByRole("button", { name: "定例を追加" }),
+    ).toBeInTheDocument();
+  });
+
+  it("組織が 0 件のときは「定例を追加」ボタンを表示しない", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson([]));
+    renderSidebar();
+    await screen.findByRole("button", { name: /新しい組織を作成/ });
+    expect(
+      screen.queryByRole("button", { name: "定例を追加" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("「定例を追加」ボタンを押すと作成ダイアログが開く", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await user.click(await screen.findByRole("button", { name: "定例を追加" }));
+    expect(
+      await screen.findByRole("dialog", { name: "定例を作成" }),
+    ).toBeInTheDocument();
+  });
+
+  it("サイドバーから作成すると現在組織配下に POST される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+    (api.organizations[":id"].meetings.$post as Mock).mockResolvedValue(
+      mockJson({
+        id: "meet-new",
+        organizationId: "org-1",
+        name: "新規定例",
+        description: null,
+        scheduleCron: "0 10 * * 1",
+        createdAt: "2026-05-16T00:00:00.000Z",
+        updatedAt: "2026-05-16T00:00:00.000Z",
+      }),
+    );
+    const user = userEvent.setup();
+
+    renderSidebar();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("current_organization_id")).toBe("org-1");
+    });
+
+    await user.click(await screen.findByRole("button", { name: "定例を追加" }));
+    const dialog = await screen.findByRole("dialog", { name: "定例を作成" });
+    await user.type(within(dialog).getByLabelText("定例名"), "新規定例");
+    await user.click(within(dialog).getByRole("button", { name: "作成" }));
+
+    await waitFor(() => {
+      expect(api.organizations[":id"].meetings.$post).toHaveBeenCalledWith(
+        {
+          param: { id: "org-1" },
+          json: { name: "新規定例", scheduleCron: "0 10 * * 1" },
+        },
         expect.objectContaining({ headers: expect.any(Object) }),
       );
     });


### PR DESCRIPTION
## 関連Issue
Closes #89

## 概要・目的
* 組織詳細画面に定例（RecurringMeeting）の作成・編集・削除 UI を追加し、サイドバーからも作成・一覧表示できるようにした。cron 文字列を直接書かせるのは現実的でないため、頻度と曜日・時刻を選ぶビルダー UI を用意。

## 背景
* PR #152（Issue #86）で定例 CRUD API を実装済みだが、フロント側に作成・編集・削除導線が無くサイドバーもモック表示のままだった。
* Issue #89 本文の「ownerのみ編集・削除ボタンを表示」については、API 側の権限仕様（編集は組織メンバー全員、削除のみ `MeetingMember.owner`）に合わせて UI 表示も全員可とし、削除のみ 403 を捉えてエラー表示する方針を Issue にコメント済み。
* レビュー中に出た追加要件として「サイドバーから定例追加」「cron 入力を親切な UI に」を本 PR スコープに取り込んだ（Issue #89 へコメント追記）。

## 変更内容
* **定例カード一覧**：組織詳細画面 `/organizations/:id` の素のリスト表示をカード一覧（1〜3 列グリッド）に置換。`RecurringMeetingCard` に定例名・説明（line-clamp-2）・scheduleCron・作成日を表示
* **定例作成ダイアログ**：`CreateRecurringMeetingDialog` を新設。組織詳細画面の「定例を作成」ボタンとサイドバーの「+ 定例を追加」ボタンの双方から開く（既存 `CreateOrganizationDialog` と同じ制御モード対応）
* **定例編集ダイアログ**：`EditRecurringMeetingDialog`。差分送信、refetch 同期、ビルダー非対応 cron はテキスト入力に fallback
* **定例削除ダイアログ**：`DeleteRecurringMeetingDialog`。API 仕様に合わせ全員にボタン表示し、403 は「削除権限がありません（定例のオーナーのみ削除可能）」、それ以外は「定例の削除に失敗しました」を表示
* **cron ビルダー UI**：`ScheduleCronBuilder` + `scheduleCron.ts`（`buildCron` / `parseCron` / `describeCron` の純関数）。頻度（毎日/毎週/毎月）+ 曜日複数選択 + 時刻入力で cron を生成し、「毎週 月・水 10:00 (`0 10 * * 1,3`)」のような人間表記と cron をプレビュー表示
* **サイドバー実データ化**：従来モック表示だった定例セクションを `useOrganizationMeetings` で現在組織配下の実データに置換。各リンクは組織詳細画面へ遷移
* **サイドバーから作成**：定例セクション右肩に「+」ボタンを設置、`CreateRecurringMeetingDialog` の制御モードで開閉

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-89-recurring-meeting-ui`
2. 依存をインストール: `make install`
3. 自動テスト・lint を実行: `make test && make lint`
   - api 118 件 / web 166 件 / ai 10 件 すべて PASS、Biome / Ruff エラーなしを確認
4. Docker Compose 起動: `make dev-build`（初回または依存変更後）
5. 別ターミナルでマイグレーション状況を確認: `make migrate-status`（必要なら `make migrate`）
6. FakeAuth でログインしてブラウザで `http://localhost:3000` を開く
7. 以下を順に確認:
   - 組織を作成 → 組織詳細画面の「定例」セクションに「定例を作成」ボタン表示
   - 作成ダイアログを開き、頻度「毎週」を選んで曜日「月」「水」をトグル → プレビューに「毎週 月・水 10:00 (`0 10 * * 1,3`)」が表示される
   - 「作成」→ 定例カードがグリッドに追加され、サイドバーにもリンクが現れる
   - 定例カードの「編集」→ ビルダーに既存値が反映され、頻度切替で cron が変化、保存で updatedAt が進む
   - 定例カードの「削除」→ 確認ダイアログ → 削除成功でカードとサイドバーから消える
   - サイドバーの「+ 定例を追加」→ ダイアログ開閉、作成成功でリストに追加
   - 別ユーザーで参加 → 自分が `MeetingMember.owner` でない定例を削除すると「削除権限がありません（定例のオーナーのみ削除可能です）」が表示

## スクリーンショット
<img width="859" height="801" alt="image" src="https://github.com/user-attachments/assets/954ea418-e824-4be3-b680-613f23230f7f" />
<img width="852" height="559" alt="image" src="https://github.com/user-attachments/assets/b9804fe1-a577-4b11-b61f-833c372b7f19" />
