### PR TITLE
Meeting に recurringMeetingId を追加し、定例配下の会議一覧 API を提供

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -14,8 +14,10 @@ Table Meeting {
   previousMeetingId String
   estimatedDurationMinutes Int
   estimationNote String
+  recurringMeetingId String
   previousMeeting Meeting
   nextMeetings Meeting [not null]
+  recurringMeeting RecurringMeeting
   speakers MeetingSpeaker [not null]
   estimationBreakdowns MeetingEstimationBreakdown [not null]
   ragDocument RagDocument
@@ -98,6 +100,7 @@ Table RecurringMeeting {
   updatedAt DateTime [not null]
   organization Organization [not null]
   members MeetingMember [not null]
+  meetings Meeting [not null]
 }
 
 Table MeetingMember {
@@ -399,6 +402,8 @@ Enum MeetingRole {
 }
 
 Ref: Meeting.previousMeetingId - Meeting.id
+
+Ref: Meeting.recurringMeetingId > RecurringMeeting.id [delete: Set Null]
 
 Ref: OrganizationMembership.userId > User.id [delete: Cascade]
 

--- a/apps/api/prisma/migrations/20260516195833_add_recurring_meeting_id_to_meeting/migration.sql
+++ b/apps/api/prisma/migrations/20260516195833_add_recurring_meeting_id_to_meeting/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN     "recurringMeetingId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Meeting_recurringMeetingId_idx" ON "Meeting"("recurringMeetingId");
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_recurringMeetingId_fkey" FOREIGN KEY ("recurringMeetingId") REFERENCES "RecurringMeeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -25,9 +25,16 @@ model Meeting {
   estimatedDurationMinutes Int?
   estimationNote String?
 
+  // 紐付く定例。単発会議の場合は null。
+  // 定例が削除されても本会議の議事録メタ・タスク・決定事項を残すため SetNull とする。
+  recurringMeetingId String?
+
   // 自己参照リレーション
   previousMeeting Meeting? @relation("MeetingChain", fields: [previousMeetingId], references: [id])
   nextMeetings Meeting[] @relation("MeetingChain")
+
+  // 定例リレーション
+  recurringMeeting RecurringMeeting? @relation(fields: [recurringMeetingId], references: [id], onDelete: SetNull)
 
   // リレーション
   speakers             MeetingSpeaker[]
@@ -43,6 +50,7 @@ model Meeting {
   // インデックス
   @@index([previousMeetingId])
   @@index([heldAt])
+  @@index([recurringMeetingId])
 }
 
 // OIDC 認証で取得したユーザー情報。externalId は IdP の sub を保存する。
@@ -237,6 +245,8 @@ model RecurringMeeting {
 
   organization Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   members      MeetingMember[]
+  // 配下に開催される個別 Meeting 群。定例削除時は SetNull で紐付け解除のみ。
+  meetings     Meeting[]
 
   @@index([organizationId])
 }

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -45,6 +45,32 @@ const meetingRoleOrder: Record<MeetingRole, number> = {
 
 export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
+  .get("/:id/meetings", async (c) => {
+    const id = c.req.param("id");
+
+    // 定例存在チェック → 組織所属確認の順で 404 短絡。
+    // members を取らない軽量クエリで認可だけ通す。
+    const meeting = await prisma.recurringMeeting.findUnique({
+      where: { id },
+    });
+    const guard = await requireRecurringAccess(c, meeting);
+    if (!guard.ok) return guard.res;
+
+    // レスポンスは「会議一覧」用途に必要な 5 フィールドに限定する。
+    // 議事録メタ・タスク・話者などは詳細エンドポイントの責務（別 Issue）。
+    const meetings = await prisma.meeting.findMany({
+      where: { recurringMeetingId: id },
+      orderBy: { heldAt: "desc" },
+      select: {
+        id: true,
+        title: true,
+        heldAt: true,
+        estimatedDurationMinutes: true,
+        recurringMeetingId: true,
+      },
+    });
+    return c.json(meetings);
+  })
   .get("/:id", async (c) => {
     const id = c.req.param("id");
 

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -15,6 +15,9 @@ vi.mock("../src/lib/prisma.js", () => ({
     meetingMember: {
       findUnique: vi.fn(),
     },
+    meeting: {
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -59,6 +62,7 @@ const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockRecurringUpdate = vi.mocked(prisma.recurringMeeting.update);
 const mockRecurringDelete = vi.mocked(prisma.recurringMeeting.delete);
 const mockMeetingMemberFindUnique = vi.mocked(prisma.meetingMember.findUnique);
+const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -610,5 +614,89 @@ describe("DELETE /recurring-meetings/:id", () => {
     });
     expect(res.status).toBe(404);
     expect(mockRecurringDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /recurring-meetings/:id/meetings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const sampleMeetings = [
+    {
+      id: "mtg-2",
+      title: "週次定例 2026-05-13",
+      heldAt: new Date("2026-05-13T01:00:00Z"),
+      estimatedDurationMinutes: 60,
+      recurringMeetingId: "rmtg-1",
+    },
+    {
+      id: "mtg-1",
+      title: "週次定例 2026-05-06",
+      heldAt: new Date("2026-05-06T01:00:00Z"),
+      estimatedDurationMinutes: 60,
+      recurringMeetingId: "rmtg-1",
+    },
+  ];
+
+  it("組織メンバーは配下の Meeting を heldAt 降順で取得できる", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingFindMany.mockResolvedValue(sampleMeetings as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      title: string;
+      heldAt: string;
+      estimatedDurationMinutes: number | null;
+      recurringMeetingId: string | null;
+    }>;
+    expect(body).toHaveLength(2);
+    expect(body[0].id).toBe("mtg-2");
+    expect(body[1].id).toBe("mtg-1");
+
+    // レスポンスは指定 5 フィールドに限定し、recurringMeetingId フィルタを
+    // かけて heldAt 降順で取得する。
+    expect(mockMeetingFindMany).toHaveBeenCalledWith({
+      where: { recurringMeetingId: "rmtg-1" },
+      orderBy: { heldAt: "desc" },
+      select: {
+        id: true,
+        title: true,
+        heldAt: true,
+        estimatedDurationMinutes: true,
+        recurringMeetingId: true,
+      },
+    });
+  });
+
+  it("配下に Meeting が無ければ空配列を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockMeetingFindMany.mockResolvedValue([] as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("定例が存在しない場合は 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/missing/meetings");
+    expect(res.status).toBe(404);
+    // 組織所属チェックに進む前に短絡する。
+    expect(mockMembershipFindUnique).not.toHaveBeenCalled();
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("定例所属組織のメンバーでない場合は 404 を返す", async () => {
+    // 組織存在を露出させないため、所属していない場合も 404 で統一する。
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings");
+    expect(res.status).toBe(404);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #156

## 概要・目的
* `Meeting` と `RecurringMeeting` を多対一でリレーションし、`GET /recurring-meetings/:id/meetings` で定例配下の個別会議を取得できるようにした。Issue #157（Frontend 会議一覧表示）の前提となる API 提供。

## 背景
* 現状の `Meeting` テーブルには `RecurringMeeting` への外部キーが無く、定例配下の会議を取得する手段がなかった。
* Issue #155 で「定例の下に複数の Meeting が紐付き、個別の日程・所要時間を持つ」という設計が確認され、その紐付け部分を本 Issue で対応。
* 個別 Meeting には議事録メタ・タスク・決定事項が紐付くため、定例削除時に Meeting 本体を巻き込むと履歴が失われる。`onDelete: SetNull` を採用し「紐付け解除」に留めた。

## 変更内容
* **Prisma スキーマ**: `Meeting.recurringMeetingId String?` + `recurringMeeting RecurringMeeting? @relation(onDelete: SetNull)` を追加
* **逆リレーション**: `RecurringMeeting.meetings Meeting[]` を追加（Prisma 上の往復参照を成立）
* **インデックス**: `@@index([recurringMeetingId])` を Meeting に追加
* **Migration**: `20260516195833_add_recurring_meeting_id_to_meeting`（カラム追加 + 外部キー + index、`ON DELETE SET NULL`）
* **API**: `GET /recurring-meetings/:id/meetings` を新設
  - `requireRecurringAccess` で「定例不存在 → 404 / 組織未所属 → 404」を統一
  - `findMany` の `select` で 5 フィールド（`id` / `title` / `heldAt` / `estimatedDurationMinutes` / `recurringMeetingId`）に絞ったレスポンス
  - 並び順は `heldAt` 降順
* **テスト**: 正常系 / 0 件 / 定例不存在 404 / 未所属 404 の 4 ケースを追加

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-156-recurring-meeting-id-on-meeting`
2. 依存をインストール: `make install`
3. マイグレーション適用: `make migrate-status`（未適用なら `make migrate`）
4. **Prisma Client をコンテナへ反映**: `make refresh SVC=api`（migration 後はコンテナ内 Client が古いため必須）
5. 自動テスト・lint を実行: `make test && make lint`
   - api 127 件 / web 178 件 / ai 10 件 すべて PASS
6. FakeAuth でログインしてトークンを取得 → 既存定例を 1 つ用意し、DB から定例 ID を控える
7. DB に test 用 Meeting を 2 件挿入して紐付け（例）:
   ```sql
   make db-shell
   INSERT INTO "Meeting" (id, title, "heldAt", "createdAt", "meetingType", "recurringMeetingId")
   VALUES
     ('mtg-test-1', '週次定例 2026-05-13', '2026-05-13 01:00:00', NOW(), 'one_time', '<RECURRING_ID>'),
     ('mtg-test-2', '週次定例 2026-05-06', '2026-05-06 01:00:00', NOW(), 'one_time', '<RECURRING_ID>');
   ```
8. API を叩いて配下の会議が降順で返ることを確認:
   ```sh
   curl -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3001/recurring-meetings/<RECURRING_ID>/meetings"
   ```
9. 定例を削除しても Meeting レコードが残り、`recurringMeetingId` が null に書き換わることを確認:
   ```sh
   curl -i -X DELETE -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3001/recurring-meetings/<RECURRING_ID>"
   # その後 DB で
   SELECT id, title, "recurringMeetingId" FROM "Meeting" WHERE id IN ('mtg-test-1','mtg-test-2');
   ```

## スクリーンショット
* GET レスポンス例（200）:
  ```json
  [
    {
      "id": "mtg-test-1",
      "title": "週次定例 2026-05-13",
      "heldAt": "2026-05-13T01:00:00.000Z",
      "estimatedDurationMinutes": null,
      "recurringMeetingId": "<RECURRING_ID>"
    },
    {
      "id": "mtg-test-2",
      "title": "週次定例 2026-05-06",
      "heldAt": "2026-05-06T01:00:00.000Z",
      "estimatedDurationMinutes": null,
      "recurringMeetingId": "<RECURRING_ID>"
    }
  ]
  ```
* 404 レスポンス（定例不存在 / 組織未所属）:
  ```json
  { "error": "定例が見つかりません" }
  ```