### PR TITLE
定例配下に Meeting を作成する API を追加

### DIFF
--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -2,9 +2,26 @@ import { zValidator } from "@hono/zod-validator";
 import type { MeetingRole, RecurringMeeting } from "@prisma/client";
 import { Hono } from "hono";
 import type { Context } from "hono";
+import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { recurringMeetingUpdateSchema } from "../lib/schemas/recurring-meeting.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
+
+// 定例配下に紐付ける Meeting 作成リクエストの schema。
+// estimatedDurationMinutes 未指定なら定例の defaultDurationMinutes を採用する。
+// 範囲は RecurringMeeting.defaultDurationMinutes と同じ 1〜480 分。
+const createMeetingSchema = z.object({
+  title: z.string().min(1, "title は必須です"),
+  heldAt: z
+    .string()
+    .datetime({ message: "heldAt は ISO8601 で指定してください" }),
+  estimatedDurationMinutes: z
+    .number()
+    .int()
+    .min(1, "estimatedDurationMinutes は 1 分以上で指定してください")
+    .max(480, "estimatedDurationMinutes は 480 分以下で指定してください")
+    .optional(),
+});
 
 // 認証ユーザーが定例の所属組織のメンバーであるかを確認する共通ガード。
 // 定例不存在・所属なしいずれも 404 で統一し、組織や定例の存在自体を
@@ -45,6 +62,42 @@ const meetingRoleOrder: Record<MeetingRole, number> = {
 
 export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
+  .post("/:id/meetings", zValidator("json", createMeetingSchema), async (c) => {
+    const id = c.req.param("id");
+    const { title, heldAt, estimatedDurationMinutes } = c.req.valid("json");
+
+    const meeting = await prisma.recurringMeeting.findUnique({
+      where: { id },
+    });
+    const guard = await requireRecurringAccess(c, meeting);
+    if (!guard.ok) return guard.res;
+
+    // estimatedDurationMinutes 未指定なら定例のデフォルト所要時間を採用する。
+    // 定例ごとに「だいたい N 分」が決まっている前提のもと、個別 Meeting 側で
+    // 必要に応じて上書きできる設計（Issue #155 の設計コンテキスト）。
+    const duration =
+      estimatedDurationMinutes ?? guard.meeting.defaultDurationMinutes;
+
+    // Service Bus 通知（meeting.created）はここでは送らない。
+    // AI 処理（議事録解析）のトリガーは「文字起こし入力時」が正しいトリガーで、
+    // 本エンドポイントは「会議の枠」を確保するだけ。Issue #55 で再設計する。
+    const created = await prisma.meeting.create({
+      data: {
+        title,
+        heldAt: new Date(heldAt),
+        estimatedDurationMinutes: duration,
+        recurringMeetingId: id,
+      },
+      select: {
+        id: true,
+        title: true,
+        heldAt: true,
+        estimatedDurationMinutes: true,
+        recurringMeetingId: true,
+      },
+    });
+    return c.json(created, 201);
+  })
   .get("/:id/meetings", async (c) => {
     const id = c.req.param("id");
 

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -17,6 +17,7 @@ vi.mock("../src/lib/prisma.js", () => ({
     },
     meeting: {
       findMany: vi.fn(),
+      create: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -63,6 +64,7 @@ const mockRecurringUpdate = vi.mocked(prisma.recurringMeeting.update);
 const mockRecurringDelete = vi.mocked(prisma.recurringMeeting.delete);
 const mockMeetingMemberFindUnique = vi.mocked(prisma.meetingMember.findUnique);
 const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
+const mockMeetingCreate = vi.mocked(prisma.meeting.create);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -698,5 +700,173 @@ describe("GET /recurring-meetings/:id/meetings", () => {
     const res = await app.request("/recurring-meetings/rmtg-1/meetings");
     expect(res.status).toBe(404);
     expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /recurring-meetings/:id/meetings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const createdMeeting = {
+    id: "mtg-new",
+    title: "週次定例 2026-05-20",
+    heldAt: new Date("2026-05-20T01:00:00Z"),
+    estimatedDurationMinutes: 60,
+    recurringMeetingId: "rmtg-1",
+  };
+
+  it("組織メンバーは Meeting を作成でき、estimatedDurationMinutes 指定値を採用する", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingCreate.mockResolvedValue({
+      ...createdMeeting,
+      estimatedDurationMinutes: 90,
+    } as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例 2026-05-20",
+        heldAt: "2026-05-20T01:00:00.000Z",
+        estimatedDurationMinutes: 90,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      id: string;
+      title: string;
+      estimatedDurationMinutes: number;
+      recurringMeetingId: string;
+    };
+    expect(body.id).toBe("mtg-new");
+    expect(body.estimatedDurationMinutes).toBe(90);
+    expect(body.recurringMeetingId).toBe("rmtg-1");
+
+    expect(mockMeetingCreate).toHaveBeenCalledWith({
+      data: {
+        title: "週次定例 2026-05-20",
+        heldAt: new Date("2026-05-20T01:00:00.000Z"),
+        estimatedDurationMinutes: 90,
+        recurringMeetingId: "rmtg-1",
+      },
+      select: {
+        id: true,
+        title: true,
+        heldAt: true,
+        estimatedDurationMinutes: true,
+        recurringMeetingId: true,
+      },
+    });
+  });
+
+  it("estimatedDurationMinutes 未指定なら定例の defaultDurationMinutes を採用する", async () => {
+    // sampleRecurring.defaultDurationMinutes は 60。
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingCreate.mockResolvedValue(createdMeeting as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例 2026-05-20",
+        heldAt: "2026-05-20T01:00:00.000Z",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockMeetingCreate).toHaveBeenCalledWith({
+      data: {
+        title: "週次定例 2026-05-20",
+        heldAt: new Date("2026-05-20T01:00:00.000Z"),
+        estimatedDurationMinutes: 60,
+        recurringMeetingId: "rmtg-1",
+      },
+      select: expect.any(Object),
+    });
+  });
+
+  it("title 欠落は 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ heldAt: "2026-05-20T01:00:00.000Z" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMeetingCreate).not.toHaveBeenCalled();
+  });
+
+  it("heldAt 欠落は 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "週次定例" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("heldAt が ISO8601 でない場合は 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "週次定例", heldAt: "not-a-date" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("estimatedDurationMinutes が 0 以下なら 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例",
+        heldAt: "2026-05-20T01:00:00.000Z",
+        estimatedDurationMinutes: 0,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("estimatedDurationMinutes が 480 を超えると 400 を返す", async () => {
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例",
+        heldAt: "2026-05-20T01:00:00.000Z",
+        estimatedDurationMinutes: 481,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("定例が存在しない場合は 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/missing/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例",
+        heldAt: "2026-05-20T01:00:00.000Z",
+      }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockMeetingCreate).not.toHaveBeenCalled();
+  });
+
+  it("組織メンバーでなければ 404 を返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例",
+        heldAt: "2026-05-20T01:00:00.000Z",
+      }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockMeetingCreate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #160

## 概要・目的
* 定例（RecurringMeeting）配下に紐付いた個別 Meeting を作成する API を追加。PR #159 で提供した一覧取得 API の対となる作成手段で、フロント側で「次回会議を予定する」導線や、Issue #157（Frontend 会議一覧）の実機確認に必要。

## 背景
* PR #159 で `GET /recurring-meetings/:id/meetings` を提供したが、対応する作成 API が無く、定例配下に Meeting を増やす手段が SQL 直挿入のみだった。
* 既存 `POST /meetings` は単発専用で `recurringMeetingId` を受け付けない。
* `estimatedDurationMinutes` のデフォルト値は Issue #155 の設計コンテキスト通り「定例の `defaultDurationMinutes`」を採用し、個別 Meeting 側で必要に応じて上書きできる構造に揃えた。
* **Service Bus 通知は送らない**。Issue #55 の指摘通り、AI 処理（議事録解析）の正しいトリガーは「文字起こし入力時の `POST /meetings/:id/process`」であり、本エンドポイントは「会議の枠」を確保するだけ。既存 `POST /meetings` の `sendMeetingCreatedEvent` も #55 の再設計対象として残してある。

## 変更内容
* `apps/api/src/routes/recurring-meetings.ts` に `POST /:id/meetings` を追加
* zod schema:
  * `title: z.string().min(1)`
  * `heldAt: z.string().datetime()`（ISO8601 必須）
  * `estimatedDurationMinutes: z.number().int().min(1).max(480).optional()`
* `estimatedDurationMinutes` 未指定時は `guard.meeting.defaultDurationMinutes` を採用するフォールバックロジック
* 認可は `requireRecurringAccess` を流用：定例不存在・組織未所属いずれも 404 で統一
* `prisma.meeting.create` の `select` で 5 フィールド（`id` / `title` / `heldAt` / `estimatedDurationMinutes` / `recurringMeetingId`）に限定し、GET と型を揃える
* 既存 `POST /meetings`（単発）、`sendMeetingCreatedEvent` には触らない
* テスト 9 ケース追加（正常系 2 / バリデーション 5 / 認可 2）

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-160-create-meeting-under-recurring`
2. 依存をインストール: `make install`
3. 自動テスト・lint を実行: `make test && make lint`
   - api 136 件 / web 178 件 / ai 10 件 すべて PASS
4. Docker 起動: `make dev-build`（マイグレーション追加は無いので `make refresh` は不要）
5. FakeAuth でログインしてトークンを取得 → 既存定例を 1 つ用意し、定例 ID を控える
6. 作成 API を叩く（estimatedDurationMinutes 指定あり）:
   ```sh
   curl -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"title":"週次定例 2026-05-20","heldAt":"2026-05-20T01:00:00.000Z","estimatedDurationMinutes":90}' \
     "http://localhost:3001/recurring-meetings/<RECURRING_ID>/meetings"
   ```
7. `estimatedDurationMinutes` を省略して、定例の `defaultDurationMinutes`（60）が採用されることを確認:
   ```sh
   curl -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"title":"週次定例 2026-05-27","heldAt":"2026-05-27T01:00:00.000Z"}' \
     "http://localhost:3001/recurring-meetings/<RECURRING_ID>/meetings"
   ```
8. GET 一覧 API で作成した Meeting が降順で返ることを確認:
   ```sh
   curl -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3001/recurring-meetings/<RECURRING_ID>/meetings"
   ```
9. バリデーションエラー（heldAt 不正 / estimatedDurationMinutes が 0 / 481 など）が 400 を返すことを確認

## スクリーンショット
* 作成レスポンス例（201・estimatedDurationMinutes 指定あり）:
  ```json
  {
    "id": "<新規Meeting ID>",
    "title": "週次定例 2026-05-20",
    "heldAt": "2026-05-20T01:00:00.000Z",
    "estimatedDurationMinutes": 90,
    "recurringMeetingId": "<RECURRING_ID>"
  }
  ```
* 作成レスポンス例（201・estimatedDurationMinutes 未指定、定例の defaultDurationMinutes=60 が採用される）:
  ```json
  {
    "id": "<新規Meeting ID>",
    "title": "週次定例 2026-05-27",
    "heldAt": "2026-05-27T01:00:00.000Z",
    "estimatedDurationMinutes": 60,
    "recurringMeetingId": "<RECURRING_ID>"
  }
  ```
* 404 レスポンス（定例不存在 / 組織未所属）:
  ```json
  { "error": "定例が見つかりません" }
  ```