### PR TITLE
定例配下の会議一覧画面と作成 UI を追加

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -143,7 +143,7 @@ export function Sidebar() {
         </Link>
 
         {/* 定例セクション。選択中組織配下の定例を一覧表示する。
-            クリック時の遷移先は組織詳細画面（定例詳細画面は将来 Issue）。
+            クリック時の遷移先は定例詳細画面（/recurring-meetings/$id）で配下の会議一覧へ。
             組織が選択されているときだけ「+ 定例を追加」ボタンを表示する。 */}
         <div className="flex items-center justify-between pt-4 pb-1 pl-2.5 pr-1">
           <p className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
@@ -214,8 +214,8 @@ function SidebarMeetingList({ orgId }: { orgId: string | null }) {
       {data.map((m) => (
         <li key={m.id}>
           <Link
-            to="/organizations/$id"
-            params={{ id: orgId }}
+            to="/recurring-meetings/$id"
+            params={{ id: m.id }}
             className="flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
           >
             <CalendarDays size={15} className="shrink-0" />

--- a/apps/web/src/features/recurring-meetings/components/CreateMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/CreateMeetingDialog.tsx
@@ -1,0 +1,173 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api, authHeaders } from "@/lib/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+import { DurationMinutesPicker } from "./DurationMinutesPicker";
+
+const createSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  // datetime-local の値は "YYYY-MM-DDTHH:mm" 形式（タイムゾーンなし）。
+  // 送信時に new Date(value).toISOString() で UTC ISO8601 に変換する。
+  heldAt: z.string().min(1, "日時は必須です"),
+  estimatedDurationMinutes: z
+    .number()
+    .int()
+    .min(1, "所要時間は 1 分以上で指定してください")
+    .max(480, "所要時間は 480 分以下で指定してください"),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+
+export function CreateMeetingDialog({
+  recurringMeetingId,
+  defaultDurationMinutes,
+}: {
+  recurringMeetingId: string;
+  // 定例の defaultDurationMinutes を初期値として使う。
+  defaultDurationMinutes: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const titleId = useId();
+  const heldAtId = useId();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: {
+      title: "",
+      heldAt: "",
+      estimatedDurationMinutes: defaultDurationMinutes,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateFormValues) => {
+      // datetime-local の文字列をローカル時刻として解釈し、UTC ISO8601 に変換。
+      const heldAtIso = new Date(data.heldAt).toISOString();
+      const res = await api["recurring-meetings"][":id"].meetings.$post(
+        {
+          param: { id: recurringMeetingId },
+          json: {
+            title: data.title,
+            heldAt: heldAtIso,
+            estimatedDurationMinutes: data.estimatedDurationMinutes,
+          },
+        },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to create meeting: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["recurring-meetings", recurringMeetingId, "meetings"],
+      });
+      reset({
+        title: "",
+        heldAt: "",
+        estimatedDurationMinutes: defaultDurationMinutes,
+      });
+      setOpen(false);
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          reset({
+            title: "",
+            heldAt: "",
+            estimatedDurationMinutes: defaultDurationMinutes,
+          });
+          mutation.reset();
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button>会議を追加</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>会議を追加</DialogTitle>
+          <DialogDescription>
+            この定例配下に紐付ける個別会議の情報を入力してください。
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit((data) => mutation.mutate(data))}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={titleId}>タイトル</Label>
+            <Input
+              id={titleId}
+              placeholder="例: 週次定例 2026-05-20"
+              {...register("title")}
+            />
+            {errors.title && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.title.message}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={heldAtId}>開催日時</Label>
+            <Input
+              id={heldAtId}
+              type="datetime-local"
+              {...register("heldAt")}
+            />
+            {errors.heldAt && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.heldAt.message}
+              </p>
+            )}
+          </div>
+          <Controller
+            name="estimatedDurationMinutes"
+            control={control}
+            render={({ field }) => (
+              <DurationMinutesPicker
+                value={field.value}
+                onChange={field.onChange}
+                error={errors.estimatedDurationMinutes?.message}
+              />
+            )}
+          />
+          {mutation.isError && (
+            <p className="text-destructive text-sm">会議の追加に失敗しました</p>
+          )}
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              追加
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/components/MeetingCard.tsx
+++ b/apps/web/src/features/recurring-meetings/components/MeetingCard.tsx
@@ -1,0 +1,29 @@
+import type { MeetingListItem } from "../hooks/useRecurringMeetingMeetings";
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  // ロケール表示で「2026/5/20 10:00」のように出す。
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// 個別 Meeting を表示するカード。タイトル / 開催日時 / 所要時間の最小情報を出す。
+// 議事録メタや話者などの詳細は将来の Meeting 詳細ページで提供する想定。
+export function MeetingCard({ meeting }: { meeting: MeetingListItem }) {
+  return (
+    <li className="flex flex-col gap-1 rounded-md border bg-card p-4 shadow-sm">
+      <span className="font-medium truncate">{meeting.title}</span>
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span>{formatDateTime(meeting.heldAt)}</span>
+        {meeting.estimatedDurationMinutes !== null && (
+          <span>{meeting.estimatedDurationMinutes} 分</span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingDetail.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingDetail.ts
@@ -1,0 +1,34 @@
+import type { RecurringMeeting } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// 定例詳細レスポンス。GET /recurring-meetings/:id は members 一覧も返すが、
+// 本 hook は会議一覧画面のヘッダ用なので最小限の型に絞っておく。
+export type RecurringMeetingDetail = RecurringMeeting & {
+  members: Array<{
+    userId: string;
+    name: string;
+    displayName: string;
+    email: string;
+    role: "owner" | "member";
+    joinedAt: string;
+  }>;
+};
+
+// 単一定例の詳細を取得する hook。
+// クエリキーは ["recurring-meetings", id, "detail"] とし、配下会議一覧と区別する。
+export function useRecurringMeetingDetail(id: string) {
+  return useQuery<RecurringMeetingDetail>({
+    queryKey: ["recurring-meetings", id, "detail"],
+    queryFn: async () => {
+      const res = await api["recurring-meetings"][":id"].$get(
+        { param: { id } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch recurring meeting: ${res.status}`);
+      }
+      return (await res.json()) as RecurringMeetingDetail;
+    },
+  });
+}

--- a/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingMeetings.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingMeetings.ts
@@ -1,0 +1,30 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// 定例配下の Meeting 一覧（GET /recurring-meetings/:id/meetings のレスポンス型）。
+// API 側は select で 5 フィールドに限定して返している。
+export type MeetingListItem = {
+  id: string;
+  title: string;
+  heldAt: string;
+  estimatedDurationMinutes: number | null;
+  recurringMeetingId: string | null;
+};
+
+// 定例配下の会議一覧を取得する hook。
+// クエリキーは ["recurring-meetings", id, "meetings"] で、作成ダイアログから invalidate される。
+export function useRecurringMeetingMeetings(id: string) {
+  return useQuery<MeetingListItem[]>({
+    queryKey: ["recurring-meetings", id, "meetings"],
+    queryFn: async () => {
+      const res = await api["recurring-meetings"][":id"].meetings.$get(
+        { param: { id } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch meetings: ${res.status}`);
+      }
+      return (await res.json()) as MeetingListItem[];
+    },
+  });
+}

--- a/apps/web/src/features/recurring-meetings/meetingSections.ts
+++ b/apps/web/src/features/recurring-meetings/meetingSections.ts
@@ -1,0 +1,41 @@
+// 会議一覧をセクション分けするための最小型。
+// 実際の API レスポンスは追加フィールドを持つが、関数は heldAt しか使わないので
+// ジェネリックで上位フィールドを保ったまま返せるようにする。
+export type MeetingForSection = {
+  id: string;
+  heldAt: string;
+};
+
+export type MeetingSections<T extends MeetingForSection> = {
+  upcoming: T[];
+  past: T[];
+};
+
+// 会議一覧を「今後」と「過去」に分割する。
+// 仕様:
+// - upcoming: heldAt >= now → heldAt 昇順（近い順）
+// - past:    heldAt <  now → heldAt 降順（直近順）
+// 現在時刻ちょうどは upcoming 側に含めて「これから」のセクションで扱いやすくする。
+export function partitionMeetings<T extends MeetingForSection>(
+  meetings: T[],
+  now: Date = new Date(),
+): MeetingSections<T> {
+  const nowMs = now.getTime();
+  const upcoming: T[] = [];
+  const past: T[] = [];
+  for (const m of meetings) {
+    const heldMs = new Date(m.heldAt).getTime();
+    if (heldMs >= nowMs) {
+      upcoming.push(m);
+    } else {
+      past.push(m);
+    }
+  }
+  upcoming.sort(
+    (a, b) => new Date(a.heldAt).getTime() - new Date(b.heldAt).getTime(),
+  );
+  past.sort(
+    (a, b) => new Date(b.heldAt).getTime() - new Date(a.heldAt).getTime(),
+  );
+  return { upcoming, past };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
+import { Route as RecurringMeetingsIdRouteImport } from './routes/recurring-meetings.$id'
 import { Route as OrganizationsIdRouteImport } from './routes/organizations.$id'
 
 const OrganizationsRoute = OrganizationsRouteImport.update({
@@ -35,6 +36,11 @@ const OrganizationsIndexRoute = OrganizationsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => OrganizationsRoute,
 } as any)
+const RecurringMeetingsIdRoute = RecurringMeetingsIdRouteImport.update({
+  id: '/recurring-meetings/$id',
+  path: '/recurring-meetings/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OrganizationsIdRoute = OrganizationsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -46,12 +52,14 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/organizations/$id': typeof OrganizationsIdRoute
+  '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/organizations/$id': typeof OrganizationsIdRoute
+  '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations': typeof OrganizationsIndexRoute
 }
 export interface FileRoutesById {
@@ -60,6 +68,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/organizations/$id': typeof OrganizationsIdRoute
+  '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
 }
 export interface FileRouteTypes {
@@ -69,15 +78,22 @@ export interface FileRouteTypes {
     | '/login'
     | '/organizations'
     | '/organizations/$id'
+    | '/recurring-meetings/$id'
     | '/organizations/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/organizations/$id' | '/organizations'
+  to:
+    | '/'
+    | '/login'
+    | '/organizations/$id'
+    | '/recurring-meetings/$id'
+    | '/organizations'
   id:
     | '__root__'
     | '/'
     | '/login'
     | '/organizations'
     | '/organizations/$id'
+    | '/recurring-meetings/$id'
     | '/organizations/'
   fileRoutesById: FileRoutesById
 }
@@ -85,6 +101,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
+  RecurringMeetingsIdRoute: typeof RecurringMeetingsIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -117,6 +134,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrganizationsIndexRouteImport
       parentRoute: typeof OrganizationsRoute
     }
+    '/recurring-meetings/$id': {
+      id: '/recurring-meetings/$id'
+      path: '/recurring-meetings/$id'
+      fullPath: '/recurring-meetings/$id'
+      preLoaderRoute: typeof RecurringMeetingsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/organizations/$id': {
       id: '/organizations/$id'
       path: '/$id'
@@ -145,6 +169,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
+  RecurringMeetingsIdRoute: RecurringMeetingsIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -23,7 +23,7 @@ import { api, authHeaders } from "@/lib/api";
 import { authAtom } from "@/lib/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
 import { useEffect, useId, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -546,6 +546,13 @@ export function OrganizationDetailView({
                 meeting={meeting}
                 actions={
                   <>
+                    <Link
+                      to="/recurring-meetings/$id"
+                      params={{ id: meeting.id }}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      会議一覧
+                    </Link>
                     <EditRecurringMeetingDialog meeting={meeting} />
                     <DeleteRecurringMeetingDialog meeting={meeting} />
                   </>

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -1,0 +1,120 @@
+import { MeetingCard } from "@/features/recurring-meetings/components/MeetingCard";
+import { useRecurringMeetingDetail } from "@/features/recurring-meetings/hooks/useRecurringMeetingDetail";
+import { useRecurringMeetingMeetings } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
+import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
+import {
+  describeCron,
+  parseCron,
+} from "@/features/recurring-meetings/scheduleCron";
+import { Link, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/recurring-meetings/$id")({
+  component: RecurringMeetingDetailPage,
+});
+
+function RecurringMeetingDetailPage() {
+  const { id } = Route.useParams();
+  return <RecurringMeetingDetailView id={id} />;
+}
+
+// route コンポーネントから分離したビュー。テストでは props で id を渡して直接 render する
+// （既存 OrganizationDetailView と同じ流儀）。
+// now はセクション分け用の現在時刻。本番では未指定（new Date() が使われる）、
+// テストでは固定値を渡すことで TanStack Query の内部処理と fake timer が
+// 衝突するのを避ける。
+export function RecurringMeetingDetailView({
+  id,
+  now,
+}: {
+  id: string;
+  now?: Date;
+}) {
+  const detailQuery = useRecurringMeetingDetail(id);
+  const meetingsQuery = useRecurringMeetingMeetings(id);
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="container mx-auto p-8">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+  if (detailQuery.isError || !detailQuery.data) {
+    return (
+      <div className="container mx-auto p-8">
+        <p>定例の取得に失敗しました</p>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+  // scheduleCron をビルダーで復元できるなら人間表記。範囲指定など未対応 cron は
+  // 生 cron をフォールバックとして表示する。
+  const cronState = parseCron(detail.scheduleCron);
+  const cronLabel = cronState ? describeCron(cronState) : detail.scheduleCron;
+
+  const meetings = meetingsQuery.data ?? [];
+  const { upcoming, past } = partitionMeetings(meetings, now);
+
+  return (
+    <section
+      aria-labelledby="recurring-meeting-title"
+      className="container mx-auto p-8 space-y-6"
+    >
+      <header className="space-y-2">
+        <Link
+          to="/organizations/$id"
+          params={{ id: detail.organizationId }}
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← 組織詳細に戻る
+        </Link>
+        <h1 id="recurring-meeting-title" className="text-2xl font-bold">
+          {detail.name}
+        </h1>
+        {detail.description ? (
+          <p className="text-muted-foreground">{detail.description}</p>
+        ) : null}
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <span>{cronLabel}</span>
+          <span>デフォルト {detail.defaultDurationMinutes} 分</span>
+        </div>
+      </header>
+
+      {meetingsQuery.isError ? (
+        // 会議取得だけ失敗したケース。定例ヘッダは見せ続けたいので分離して表示。
+        <p className="text-destructive text-sm">会議一覧の取得に失敗しました</p>
+      ) : (
+        <>
+          <section aria-label="今後の会議" className="space-y-3">
+            <h2 className="text-lg font-semibold">今後の会議</h2>
+            {upcoming.length === 0 ? (
+              <p className="text-muted-foreground">予定はまだありません</p>
+            ) : (
+              <ul aria-label="今後の会議一覧" className="grid gap-3">
+                {upcoming.map((m) => (
+                  <MeetingCard key={m.id} meeting={m} />
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section aria-label="過去の会議" className="space-y-3">
+            <h2 className="text-lg font-semibold">過去の会議</h2>
+            {past.length === 0 ? (
+              <p className="text-muted-foreground">
+                過去の開催はまだありません
+              </p>
+            ) : (
+              <ul aria-label="過去の会議一覧" className="grid gap-3">
+                {past.map((m) => (
+                  <MeetingCard key={m.id} meeting={m} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -1,3 +1,4 @@
+import { CreateMeetingDialog } from "@/features/recurring-meetings/components/CreateMeetingDialog";
 import { MeetingCard } from "@/features/recurring-meetings/components/MeetingCard";
 import { useRecurringMeetingDetail } from "@/features/recurring-meetings/hooks/useRecurringMeetingDetail";
 import { useRecurringMeetingMeetings } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
@@ -87,7 +88,13 @@ export function RecurringMeetingDetailView({
       ) : (
         <>
           <section aria-label="今後の会議" className="space-y-3">
-            <h2 className="text-lg font-semibold">今後の会議</h2>
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-lg font-semibold">今後の会議</h2>
+              <CreateMeetingDialog
+                recurringMeetingId={detail.id}
+                defaultDurationMinutes={detail.defaultDurationMinutes}
+              />
+            </div>
             {upcoming.length === 0 ? (
               <p className="text-muted-foreground">予定はまだありません</p>
             ) : (

--- a/apps/web/src/test/meetingSections.test.ts
+++ b/apps/web/src/test/meetingSections.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MeetingForSection,
+  partitionMeetings,
+} from "../features/recurring-meetings/meetingSections";
+
+function meeting(id: string, heldAt: string): MeetingForSection {
+  return { id, heldAt };
+}
+
+describe("partitionMeetings", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("未来は heldAt 昇順、過去は heldAt 降順で分割される", () => {
+    const result = partitionMeetings([
+      meeting("a", "2026-05-20T01:00:00Z"), // 未来
+      meeting("b", "2026-05-10T01:00:00Z"), // 過去
+      meeting("c", "2026-05-25T01:00:00Z"), // 未来（より遠い）
+      meeting("d", "2026-05-15T01:00:00Z"), // 過去（より直近）
+    ]);
+    expect(result.upcoming.map((m) => m.id)).toEqual(["a", "c"]);
+    expect(result.past.map((m) => m.id)).toEqual(["d", "b"]);
+  });
+
+  it("現在時刻ちょうど（heldAt === now）は upcoming に含める", () => {
+    const result = partitionMeetings([
+      meeting("now", "2026-05-17T00:00:00Z"),
+      meeting("past", "2026-05-16T23:59:59Z"),
+    ]);
+    expect(result.upcoming.map((m) => m.id)).toEqual(["now"]);
+    expect(result.past.map((m) => m.id)).toEqual(["past"]);
+  });
+
+  it("空配列は空の upcoming / past を返す", () => {
+    const result = partitionMeetings([]);
+    expect(result.upcoming).toEqual([]);
+    expect(result.past).toEqual([]);
+  });
+
+  it("全件未来なら past は空、未来は昇順", () => {
+    const result = partitionMeetings([
+      meeting("c", "2026-06-01T00:00:00Z"),
+      meeting("a", "2026-05-18T00:00:00Z"),
+      meeting("b", "2026-05-25T00:00:00Z"),
+    ]);
+    expect(result.upcoming.map((m) => m.id)).toEqual(["a", "b", "c"]);
+    expect(result.past).toEqual([]);
+  });
+
+  it("全件過去なら upcoming は空、過去は降順", () => {
+    const result = partitionMeetings([
+      meeting("a", "2026-05-01T00:00:00Z"),
+      meeting("c", "2026-05-15T00:00:00Z"),
+      meeting("b", "2026-05-10T00:00:00Z"),
+    ]);
+    expect(result.past.map((m) => m.id)).toEqual(["c", "b", "a"]);
+    expect(result.upcoming).toEqual([]);
+  });
+});

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -35,6 +35,34 @@ vi.mock("@/lib/api", () => ({
   authHeaders: () => ({ headers: {} }),
 }));
 
+// 定例カードに /recurring-meetings/$id への Link が含まれるようになったため、
+// router モックを追加する。href を持つ <a> として描画して href の検証ができる形に。
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  type MockLinkProps = {
+    to: string;
+    params?: Record<string, string>;
+    children?: React.ReactNode;
+    className?: string;
+  };
+  return {
+    ...actual,
+    Link: ({ to, params, children, className }: MockLinkProps) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+  };
+});
+
 import { api } from "@/lib/api";
 
 function mockJson<T>(data: T, status = 200) {
@@ -154,6 +182,14 @@ describe("組織詳細ページ - 基本表示", () => {
     expect(within(card).getByText("60 分")).toBeInTheDocument();
     // 作成日は ISO ではなくロケール表示するため、年が含まれていれば OK
     expect(within(card).getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("定例カードに「会議一覧」リンクが表示され、/recurring-meetings/:id へ遷移する", async () => {
+    renderDetail();
+    const list = await screen.findByRole("list", { name: "定例一覧" });
+    const card = within(list).getAllByRole("listitem")[0];
+    const link = within(card).getByRole("link", { name: "会議一覧" });
+    expect(link).toHaveAttribute("href", "/recurring-meetings/meet-1");
   });
 
   it("定例カードに description があれば表示される", async () => {

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -1,0 +1,236 @@
+import type { MeetingListItem } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
+import { screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    "recurring-meetings": {
+      ":id": {
+        $get: vi.fn(),
+        meetings: {
+          $get: vi.fn(),
+          $post: vi.fn(),
+        },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+// Link は RouterProvider 配下でないと useRouter で落ちる。
+// 既存 sidebar.test と同じく href を持つ <a> として描画するモックに差し替える。
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  type MockLinkProps = {
+    to: string;
+    params?: Record<string, string>;
+    children?: React.ReactNode;
+    className?: string;
+  };
+  return {
+    ...actual,
+    Link: ({ to, params, children, className }: MockLinkProps) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+    createFileRoute: () => () => ({}),
+  };
+});
+
+import { api } from "@/lib/api";
+import { RecurringMeetingDetailView } from "../routes/recurring-meetings.$id";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const detail = {
+  id: "rmtg-1",
+  organizationId: "org-1",
+  name: "週次定例",
+  description: "毎週月曜の進捗共有",
+  scheduleCron: "0 10 * * 1",
+  defaultDurationMinutes: 60,
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+  members: [],
+};
+
+const meetings: MeetingListItem[] = [
+  {
+    id: "mtg-future-1",
+    title: "週次定例 2026-05-20",
+    heldAt: "2026-05-20T01:00:00.000Z",
+    estimatedDurationMinutes: 60,
+    recurringMeetingId: "rmtg-1",
+  },
+  {
+    id: "mtg-future-2",
+    title: "週次定例 2026-05-27",
+    heldAt: "2026-05-27T01:00:00.000Z",
+    estimatedDurationMinutes: 90,
+    recurringMeetingId: "rmtg-1",
+  },
+  {
+    id: "mtg-past-1",
+    title: "週次定例 2026-05-13",
+    heldAt: "2026-05-13T01:00:00.000Z",
+    estimatedDurationMinutes: 60,
+    recurringMeetingId: "rmtg-1",
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// partitionMeetings の「現在時刻」を固定するため、now を props で注入する。
+// fake timer は TanStack Query 内部と相性が悪いため使わない。
+const NOW = new Date("2026-05-17T00:00:00Z");
+
+function render(opts?: { id?: string }) {
+  return renderWithQuery(
+    <RecurringMeetingDetailView id={opts?.id ?? "rmtg-1"} now={NOW} />,
+  );
+}
+
+describe("定例詳細ページ - ヘッダ表示", () => {
+  beforeEach(() => {
+    vi.mocked(api["recurring-meetings"][":id"].$get).mockResolvedValue(
+      mockJson(detail),
+    );
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+  });
+
+  it("定例名・説明・cron 人間表記・デフォルト所要時間を表示する", async () => {
+    render();
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(screen.getByText("毎週月曜の進捗共有")).toBeInTheDocument();
+    // cron は describeCron で人間表記される。月曜は "月" 表示
+    expect(screen.getByText(/毎週 月 10:00/)).toBeInTheDocument();
+    expect(screen.getByText("デフォルト 60 分")).toBeInTheDocument();
+  });
+
+  it("組織詳細への戻るリンクが存在する", async () => {
+    render();
+    expect(
+      await screen.findByRole("link", { name: /組織詳細に戻る/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("定例取得失敗時はエラー表示にフォールバックする", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].$get).mockRejectedValue(
+      new Error("network"),
+    );
+    render();
+    expect(
+      await screen.findByText("定例の取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("定例詳細ページ - 会議のセクション分け", () => {
+  beforeEach(() => {
+    vi.mocked(api["recurring-meetings"][":id"].$get).mockResolvedValue(
+      mockJson(detail),
+    );
+  });
+
+  it("未来の会議は「今後の会議」に昇順、過去の会議は「過去の会議」に降順で表示される", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson(meetings),
+    );
+
+    render();
+
+    const upcoming = await screen.findByRole("list", {
+      name: "今後の会議一覧",
+    });
+    const upcomingTitles = within(upcoming)
+      .getAllByRole("listitem")
+      .map((li) => li.textContent ?? "");
+    expect(upcomingTitles[0]).toContain("週次定例 2026-05-20");
+    expect(upcomingTitles[1]).toContain("週次定例 2026-05-27");
+
+    const past = await screen.findByRole("list", { name: "過去の会議一覧" });
+    const pastTitles = within(past)
+      .getAllByRole("listitem")
+      .map((li) => li.textContent ?? "");
+    expect(pastTitles[0]).toContain("週次定例 2026-05-13");
+  });
+
+  it("会議カードに所要時間が表示される", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson(meetings),
+    );
+
+    render();
+    const upcoming = await screen.findByRole("list", {
+      name: "今後の会議一覧",
+    });
+    const firstCard = within(upcoming).getAllByRole("listitem")[0];
+    // 未来 1 件目は 60 分のはず
+    expect(within(firstCard).getByText("60 分")).toBeInTheDocument();
+  });
+
+  it("未来 0 件のとき「予定はまだありません」を表示する", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson(meetings.filter((m) => m.id === "mtg-past-1")),
+    );
+
+    render();
+    expect(await screen.findByText("予定はまだありません")).toBeInTheDocument();
+  });
+
+  it("過去 0 件のとき「過去の開催はまだありません」を表示する", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson(meetings.filter((m) => m.id.startsWith("mtg-future"))),
+    );
+
+    render();
+    expect(
+      await screen.findByText("過去の開催はまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("会議 0 件のときも両セクションが描画される", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+
+    render();
+    expect(await screen.findByText("予定はまだありません")).toBeInTheDocument();
+    expect(screen.getByText("過去の開催はまだありません")).toBeInTheDocument();
+  });
+
+  it("会議取得だけ失敗した場合はエラー表示し、ヘッダは残る", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockRejectedValue(
+      new Error("network"),
+    );
+
+    render();
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(
+      await screen.findByText("会議一覧の取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("list", { name: "今後の会議一覧" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -1,5 +1,6 @@
 import type { MeetingListItem } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithQuery } from "./test-utils";
 
@@ -217,6 +218,69 @@ describe("定例詳細ページ - 会議のセクション分け", () => {
     render();
     expect(await screen.findByText("予定はまだありません")).toBeInTheDocument();
     expect(screen.getByText("過去の開催はまだありません")).toBeInTheDocument();
+  });
+
+  it("「会議を追加」ボタンを押すとダイアログが開き、defaultDurationMinutes が初期値になる", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    const user = userEvent.setup();
+    render();
+    await user.click(await screen.findByRole("button", { name: "会議を追加" }));
+    const dialog = await screen.findByRole("dialog", { name: "会議を追加" });
+    // 既定で 60 分プリセットがアクティブ（aria-checked="true"）
+    const preset60 = within(dialog).getByRole("radio", { name: "60 分" });
+    expect(preset60).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("会議を追加して POST が呼ばれる", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    vi.mocked(
+      api["recurring-meetings"][":id"].meetings.$post,
+    ).mockResolvedValue(
+      mockJson(
+        {
+          id: "mtg-new",
+          title: "新規会議",
+          heldAt: "2026-05-20T01:00:00.000Z",
+          estimatedDurationMinutes: 60,
+          recurringMeetingId: "rmtg-1",
+        },
+        201,
+      ),
+    );
+    const user = userEvent.setup();
+    render();
+    await user.click(await screen.findByRole("button", { name: "会議を追加" }));
+    const dialog = await screen.findByRole("dialog", { name: "会議を追加" });
+    await user.type(within(dialog).getByLabelText("タイトル"), "新規会議");
+    // datetime-local の値は "YYYY-MM-DDTHH:mm" 形式。fireEvent.change を使う方が
+    // jsdom 上で安定するが、userEvent.type でも入力できる。
+    const heldAtInput = within(dialog).getByLabelText("開催日時");
+    await user.type(heldAtInput, "2026-05-20T10:00");
+    await user.click(within(dialog).getByRole("button", { name: "追加" }));
+    await waitFor(() => {
+      expect(
+        api["recurring-meetings"][":id"].meetings.$post,
+      ).toHaveBeenCalled();
+    });
+    // ペイロード検証: title / estimatedDurationMinutes は確実な値、
+    // heldAt はローカル時刻からの ISO 変換なのでテスト環境タイムゾーン依存になり得るが、
+    // ISO8601 文字列であることだけ確認する。
+    const call = vi.mocked(api["recurring-meetings"][":id"].meetings.$post).mock
+      .calls[0];
+    expect(call[0]).toMatchObject({
+      param: { id: "rmtg-1" },
+      json: {
+        title: "新規会議",
+        estimatedDurationMinutes: 60,
+      },
+    });
+    expect((call[0] as { json: { heldAt: string } }).json.heldAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
   });
 
   it("会議取得だけ失敗した場合はエラー表示し、ヘッダは残る", async () => {

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -451,13 +451,15 @@ describe("Sidebar 定例リスト", () => {
 
     expect(await screen.findByText("週次定例")).toBeInTheDocument();
     expect(screen.getByText("月次レビュー")).toBeInTheDocument();
-    // クリックは組織詳細画面へリンクする（定例詳細画面は将来 Issue）
-    const links = screen.getAllByRole("link", {
-      name: /週次定例|月次レビュー/,
-    });
-    for (const link of links) {
-      expect(link).toHaveAttribute("href", "/organizations/org-1");
-    }
+    // クリックで各定例の詳細画面（会議一覧）へ遷移する
+    expect(screen.getByRole("link", { name: /週次定例/ })).toHaveAttribute(
+      "href",
+      "/recurring-meetings/meet-1",
+    );
+    expect(screen.getByRole("link", { name: /月次レビュー/ })).toHaveAttribute(
+      "href",
+      "/recurring-meetings/meet-2",
+    );
   });
 
   it("選択中組織の定例が 0 件のとき「定例はまだありません」を表示する", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #157

## 概要・目的
* 定例配下の個別会議を一覧表示する画面 `/recurring-meetings/$id` を新設。「今後の会議」「過去の会議」のセクションで振り分けつつ、その場で会議を追加できる導線も用意した。サイドバーと組織詳細の定例カードからの遷移も合わせて切り替え、「定例 → 配下の会議」のナビゲーションを成立させた。

## 背景
* PR #154（Issue #89）で定例 UI が揃ったが、定例の中身（個別会議の予定・履歴）を確認する画面が無かった。サイドバーの定例リンクも仮で組織詳細に飛ばしており、コメント上「定例詳細画面は将来 Issue」として保留中だった。
* PR #159（GET 会議一覧）と PR #161（POST 会議追加）の Backend API が揃ったため、対応する Frontend を本 PR で実装。
* `defaultDurationMinutes`（Issue #155）の設計コンテキストに従い、会議追加ダイアログの所要時間初期値は定例のデフォルトを採用し、個別会議側で必要時に上書きする流れに揃えた。

## 変更内容
* **新規ルート** `apps/web/src/routes/recurring-meetings.$id.tsx`
  - ヘッダ: 定例名・description・scheduleCron の人間表記（`describeCron`）・`defaultDurationMinutes`・組織詳細へ戻るリンク
  - 「今後の会議」「過去の会議」セクション分け
* **`partitionMeetings`** (`apps/web/src/features/recurring-meetings/meetingSections.ts`): `heldAt` と現在時刻を比較して `upcoming`（昇順）/ `past`（降順）に分割する pure 関数
* **`MeetingCard`**: タイトル / 開催日時（ロケール表示）/ 所要時間を表示
* **`CreateMeetingDialog`**: タイトル + `<input type="datetime-local">` + `DurationMinutesPicker`。送信時に `new Date(value).toISOString()` で UTC ISO8601 に変換。初期値は定例の `defaultDurationMinutes`
* **`useRecurringMeetingDetail` / `useRecurringMeetingMeetings`** hook を新設し、`["recurring-meetings", id, "detail"]` と `["recurring-meetings", id, "meetings"]` のクエリキーで管理
* **サイドバー定例リンク**を `/recurring-meetings/$id` に切り替え（既存「将来 Issue」コメントを回収）
* **組織詳細カード**の `actions` スロットに「会議一覧」リンクを追加（編集・削除ボタンと並列）
* **テスト** 17 件追加: `partitionMeetings` 5 件、定例詳細ページ 11 件、組織詳細の会議一覧リンク 1 件。サイドバーテストは href 期待値を更新
* `now` を `RecurringMeetingDetailView` の props として注入可能にし、テストでは固定値を渡すことで TanStack Query 内部処理と fake timer の衝突を回避

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-157-recurring-meeting-detail-page`
2. 依存をインストール: `make install`
3. 自動テスト・lint を実行: `make test && make lint`
   - api 136 件 / web 195 件 / ai 10 件 すべて PASS
4. Docker 起動: `make dev-build`（DB マイグレーション追加なし、Prisma Client 再生成も不要）
5. FakeAuth でログインしてブラウザで `http://localhost:3000` を開く
6. 以下を順に確認:
   - 定例を作成 → サイドバーの定例リンクをクリック → 定例詳細画面 `/recurring-meetings/<id>` に遷移する
   - ヘッダに定例名・「毎週 月 10:00」のような人間表記・「デフォルト 60 分」が表示される
   - 「今後の会議」「過去の会議」セクションが両方表示され、空件時は「予定はまだありません」「過去の開催はまだありません」が出る
   - 「会議を追加」を開く → 60 分プリセットがアクティブ、未来日時を入力して追加 → 「今後の会議」に追加される
   - 過去日時で追加 → 「過去の会議」に追加される
   - 組織詳細の定例カードにある「会議一覧」リンクからも同じ画面に遷移できる
   - 「組織詳細に戻る」リンクで `/organizations/<orgId>` に戻る

## スクリーンショット
<img width="1157" height="763" alt="image" src="https://github.com/user-attachments/assets/92292682-a36a-4119-bc6a-948880d74828" />
<img width="863" height="431" alt="image" src="https://github.com/user-attachments/assets/cdb744b0-02b4-4ba0-a005-295141cc96c5" />