### PR TITLE
feat(db): Task を組織スコープ化し定例との M:N 中間テーブルを追加

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -25,7 +25,7 @@ Table Meeting {
   relatedMeetingRefs RelatedPastMeeting [not null]
   decisionItems DecisionItem [not null]
   decisionItemsPlanned DecisionItem [not null]
-  tasks Task [not null]
+  originTasks Task [not null]
   ambiguousInfos AmbiguousInfo [not null]
 }
 
@@ -57,6 +57,7 @@ Table Organization {
   memberships OrganizationMembership [not null]
   invitations OrganizationInvitation [not null]
   recurringMeetings RecurringMeeting [not null]
+  tasks Task [not null]
 }
 
 Table OrganizationMembership {
@@ -101,6 +102,7 @@ Table RecurringMeeting {
   organization Organization [not null]
   members MeetingMember [not null]
   meetings Meeting [not null]
+  taskAttachments TaskRecurringMeeting [not null]
 }
 
 Table MeetingMember {
@@ -218,7 +220,8 @@ Table DecisionItemAssignee {
 
 Table Task {
   id String [pk]
-  meetingId String [not null]
+  organizationId String [not null]
+  originMeetingId String
   decisionItemId String
   title String [not null]
   body String
@@ -232,16 +235,19 @@ Table Task {
   blockingItemId String
   carriedOverCount Int
   ambiguityFlags Json
+  progressNote String
   dueDate DateTime
   startDate DateTime
   followUpDate DateTime
   version Int [not null, default: 0]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
-  meeting Meeting [not null]
+  organization Organization [not null]
+  originMeeting Meeting
   decisionItem DecisionItem
   assignees TaskAssignee [not null]
   ambiguousInfos AmbiguousInfo [not null]
+  recurringMeetings TaskRecurringMeeting [not null]
 }
 
 Table TaskAssignee {
@@ -253,6 +259,17 @@ Table TaskAssignee {
 
   indexes {
     (taskId, userId) [unique]
+  }
+}
+
+Table TaskRecurringMeeting {
+  taskId String [not null]
+  recurringMeetingId String [not null]
+  task Task [not null]
+  recurringMeeting RecurringMeeting [not null]
+
+  indexes {
+    (taskId, recurringMeetingId) [pk]
   }
 }
 
@@ -441,13 +458,19 @@ Ref: DecisionItemAssignee.decisionItemId > DecisionItem.id [delete: Cascade]
 
 Ref: DecisionItemAssignee.userId > User.id [delete: Cascade]
 
-Ref: Task.meetingId > Meeting.id [delete: Cascade]
+Ref: Task.organizationId > Organization.id [delete: Cascade]
+
+Ref: Task.originMeetingId > Meeting.id [delete: Set Null]
 
 Ref: Task.decisionItemId > DecisionItem.id [delete: Set Null]
 
 Ref: TaskAssignee.taskId > Task.id [delete: Cascade]
 
 Ref: TaskAssignee.userId > User.id [delete: Cascade]
+
+Ref: TaskRecurringMeeting.taskId > Task.id [delete: Cascade]
+
+Ref: TaskRecurringMeeting.recurringMeetingId > RecurringMeeting.id [delete: Cascade]
 
 Ref: AmbiguousInfo.meetingId > Meeting.id [delete: Cascade]
 

--- a/apps/api/prisma/migrations/20260517105812_task_schema_extension/migration.sql
+++ b/apps/api/prisma/migrations/20260517105812_task_schema_extension/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `meetingId` on the `Task` table. All the data in the column will be lost.
+  - Added the required column `organizationId` to the `Task` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Task" DROP CONSTRAINT "Task_meetingId_fkey";
+
+-- DropIndex
+DROP INDEX "Task_meetingId_idx";
+
+-- AlterTable
+ALTER TABLE "Task" DROP COLUMN "meetingId",
+ADD COLUMN     "organizationId" TEXT NOT NULL,
+ADD COLUMN     "originMeetingId" TEXT,
+ADD COLUMN     "progressNote" TEXT;
+
+-- CreateTable
+CREATE TABLE "TaskRecurringMeeting" (
+    "taskId" TEXT NOT NULL,
+    "recurringMeetingId" TEXT NOT NULL,
+
+    CONSTRAINT "TaskRecurringMeeting_pkey" PRIMARY KEY ("taskId","recurringMeetingId")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskRecurringMeeting_recurringMeetingId_idx" ON "TaskRecurringMeeting"("recurringMeetingId");
+
+-- CreateIndex
+CREATE INDEX "Task_organizationId_idx" ON "Task"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "Task_originMeetingId_idx" ON "Task"("originMeetingId");
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_originMeetingId_fkey" FOREIGN KEY ("originMeetingId") REFERENCES "Meeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskRecurringMeeting" ADD CONSTRAINT "TaskRecurringMeeting_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskRecurringMeeting" ADD CONSTRAINT "TaskRecurringMeeting_recurringMeetingId_fkey" FOREIGN KEY ("recurringMeetingId") REFERENCES "RecurringMeeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -44,7 +44,8 @@ model Meeting {
   relatedMeetingRefs   RelatedPastMeeting[] @relation("RelatedMeeting")
   decisionItems        DecisionItem[]
   decisionItemsPlanned DecisionItem[]       @relation("PlannedMeeting")
-  tasks                Task[]
+  // 当該会議を発生源 (originMeetingId) とするタスク。会議削除時は Task 側 SetNull。
+  originTasks          Task[]
   ambiguousInfos       AmbiguousInfo[]
 
   // インデックス
@@ -194,6 +195,8 @@ model Organization {
   memberships       OrganizationMembership[]
   invitations       OrganizationInvitation[]
   recurringMeetings RecurringMeeting[]
+  // 組織スコープのタスク群。組織削除時はタスクごと削除する。
+  tasks             Task[]
 }
 
 // 組織への所属。userId × organizationId を複合主キーとする。
@@ -247,6 +250,9 @@ model RecurringMeeting {
   members      MeetingMember[]
   // 配下に開催される個別 Meeting 群。定例削除時は SetNull で紐付け解除のみ。
   meetings     Meeting[]
+  // 定例に attach されたタスク（M:N 中間テーブル）。定例削除時は中間レコードのみ削除し、
+  // タスク本体は Task.organizationId で組織スコープが保たれる限り残す。
+  taskAttachments TaskRecurringMeeting[]
 
   @@index([organizationId])
 }
@@ -382,10 +388,19 @@ model DecisionItemAssignee {
   @@index([decisionItemId])
 }
 
-// 会議から抽出されたタスク。
+// 会議から抽出された / 手動作成されたタスク。
+// 組織スコープ必須 (organizationId)・発生源会議は任意 (originMeetingId)・
+// 複数の定例（Project 相当）に M:N で紐付け可能 (TaskRecurringMeeting)。
+// 将来 #153 で Project 層を導入する際は TaskRecurringMeeting の参照先を
+// RecurringMeeting → Project に張り替えるだけで吸収できる構造としている。
 model Task {
   id               String    @id @default(cuid())
-  meetingId        String
+  // 組織スコープ。recurringMeetings / originMeeting から派生可能だが、
+  // 認可・フィルタの単純化のため非正規化で保持する。組織削除時はカスケード削除。
+  organizationId   String
+  // 発生源会議。AI 抽出タスクは抽出元の会議 ID が入る。手動作成タスクは null。
+  // 会議が削除されてもタスク本体は残したいので SetNull。
+  originMeetingId  String?
   decisionItemId   String?
   title            String
   body             String?
@@ -399,6 +414,9 @@ model Task {
   blockingItemId   String?
   carriedOverCount Int?
   ambiguityFlags   Json?
+  // AI フェーズ2 の進捗メモ。前回タスクが次回会議で言及・進捗報告された場合に記録する。
+  // 手動経路では使用しない（API 層で書き込み禁止）。
+  progressNote     String?
   dueDate          DateTime?
   startDate        DateTime?
   followUpDate     DateTime?
@@ -406,12 +424,15 @@ model Task {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 
-  meeting      Meeting       @relation(fields: [meetingId], references: [id], onDelete: Cascade)
-  decisionItem DecisionItem? @relation(fields: [decisionItemId], references: [id], onDelete: SetNull)
-  assignees    TaskAssignee[]
-  ambiguousInfos AmbiguousInfo[]
+  organization     Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  originMeeting    Meeting?      @relation(fields: [originMeetingId], references: [id], onDelete: SetNull)
+  decisionItem     DecisionItem? @relation(fields: [decisionItemId], references: [id], onDelete: SetNull)
+  assignees        TaskAssignee[]
+  ambiguousInfos   AmbiguousInfo[]
+  recurringMeetings TaskRecurringMeeting[]
 
-  @@index([meetingId])
+  @@index([organizationId])
+  @@index([originMeetingId])
   @@index([decisionItemId])
   @@index([dueDate])
   @@index([startDate])
@@ -429,6 +450,23 @@ model TaskAssignee {
 
   @@unique([taskId, userId])
   @@index([taskId])
+}
+
+// タスクと定例（Project 相当）の M:N 紐付け中間テーブル。
+// Asana ライクに 1 つのタスクを複数の定例に attach 可能とする。
+// 将来 #153 で Project 層を導入する場合、本テーブルの recurringMeetingId を
+// projectId に張り替える（または TaskProject テーブルに移行する）方針。
+// 中間レコードの整合性: task.organizationId と recurringMeeting.organizationId が
+// 一致することを API 層で必須バリデーションとする（クロス組織アタッチ禁止）。
+model TaskRecurringMeeting {
+  taskId             String
+  recurringMeetingId String
+
+  task             Task             @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  recurringMeeting RecurringMeeting @relation(fields: [recurringMeetingId], references: [id], onDelete: Cascade)
+
+  @@id([taskId, recurringMeetingId])
+  @@index([recurringMeetingId])
 }
 
 // 会議中に発生した曖昧な情報。

--- a/apps/api/test/task.test.ts
+++ b/apps/api/test/task.test.ts
@@ -1,0 +1,43 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { afterAll, describe, expect, it } from "vitest";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/decision_loop";
+
+// Prisma 7 は接続にアダプターが必要
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// schema.prisma で定義したタスク関連モデルが PrismaClient にデリゲートされているかを検証する。
+// 手動 CRUD と AI 受入の両経路に向けて organizationId / originMeetingId / progressNote /
+// TaskRecurringMeeting 中間テーブルを保持する構造である前提。
+describe("Task モデル", () => {
+  it("PrismaClient に task プロパティが存在する", () => {
+    expect(prisma.task).toBeDefined();
+    expect(typeof prisma.task.findMany).toBe("function");
+    expect(typeof prisma.task.create).toBe("function");
+    expect(typeof prisma.task.findUnique).toBe("function");
+  });
+});
+
+describe("TaskAssignee モデル", () => {
+  it("PrismaClient に taskAssignee プロパティが存在する", () => {
+    expect(prisma.taskAssignee).toBeDefined();
+    expect(typeof prisma.taskAssignee.findMany).toBe("function");
+    expect(typeof prisma.taskAssignee.create).toBe("function");
+  });
+});
+
+describe("TaskRecurringMeeting モデル", () => {
+  it("PrismaClient に taskRecurringMeeting プロパティが存在する", () => {
+    expect(prisma.taskRecurringMeeting).toBeDefined();
+    expect(typeof prisma.taskRecurringMeeting.findMany).toBe("function");
+    expect(typeof prisma.taskRecurringMeeting.create).toBe("function");
+  });
+});

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -197,9 +197,10 @@ Table decision_item_assignees {
 }
 
 Table tasks {
-  Note: '会議から抽出されたタスク'
+  Note: '会議から抽出された / 手動作成されたタスク。組織スコープ必須・発生源会議は任意・複数の定例（Project相当）に M:N で紐付け可能'
   id               varchar  [pk]
-  meetingId        varchar  [ref: > meetings.id]
+  organizationId   varchar  [ref: > organizations.id, note: '組織スコープ。認可・フィルタの単純化のため非正規化で保持']
+  originMeetingId  varchar  [ref: > meetings.id, note: 'NULLの場合は手動作成タスク。会議削除時は SetNull でタスク本体は残す']
   decisionItemId   varchar  [ref: > decision_items.id, note: 'NULLの場合は独立したタスク']
   title            varchar
   body             text
@@ -213,6 +214,7 @@ Table tasks {
   blockingItemId   varchar  [note: 'ブロッキング対象のアイテムID']
   carriedOverCount int      [note: '累計持ち越し回数']
   ambiguityFlags   json
+  progressNote     text     [note: 'AI フェーズ2 の進捗メモ。手動経路では使用しない']
   dueDate          timestamp
   startDate        timestamp
   followUpDate     timestamp
@@ -221,10 +223,12 @@ Table tasks {
   updatedAt        timestamp
 
   indexes {
-    meetingId
+    organizationId
+    originMeetingId
     decisionItemId
     dueDate
     startDate
+    status
   }
 }
 
@@ -237,6 +241,17 @@ Table task_assignees {
   indexes {
     (taskId, userId) [unique]
     taskId
+  }
+}
+
+Table task_recurring_meetings {
+  Note: 'タスクと定例（Project相当）の M:N 紐付け中間テーブル。1 タスクを複数の定例に attach 可能。将来 #153 で Project 層を導入する際は recurringMeetingId を projectId に張り替える。task.organizationId と recurringMeeting.organizationId の一致は API 層で必須バリデーション'
+  taskId             varchar [ref: > tasks.id]
+  recurringMeetingId varchar [ref: > recurring_meetings.id]
+
+  indexes {
+    (taskId, recurringMeetingId) [pk]
+    recurringMeetingId
   }
 }
 


### PR DESCRIPTION
## 関連Issue
Closes #163

## 概要・目的
* Asana ライクに「Task は組織必須・複数の定例（Project 相当）に M:N で紐付け可能・発生源会議は任意」という構造に Task モデルを拡張する
* 後続の Task CRUD API・一覧 API（#164 / #165）と AI 受入経路の整合性を取れる土台を作る

## 背景
* 既存 `Task` モデル（PR #111）は `meetingId` NOT NULL で特定の会議に必ず紐付く前提だった
* 手動作成タスクは「特定の会議に紐付かないが組織には属する」が主流になる見込み
* 将来 #153 で Project 層を導入する際は、中間テーブルの参照先を張り替えるだけで吸収できる構造にしておきたい

## 変更内容
* `apps/api/prisma/schema.prisma`:
  * `Task.meetingId` (NOT NULL, Cascade) を `originMeetingId` (nullable, SetNull) に変更
  * `Task.organizationId` (NOT NULL, Cascade) を追加（認可・フィルタの単純化のため非正規化で保持）
  * `Task.progressNote` (nullable text) を追加（AI フェーズ2 の進捗メモ用の枠）
  * `TaskRecurringMeeting (taskId, recurringMeetingId)` を新設（複合 PK、双方向 Cascade、`recurringMeetingId` index）
  * `Organization.tasks` / `Meeting.originTasks` / `RecurringMeeting.taskAttachments` リレーション追加
  * Task index を `[organizationId]` `[originMeetingId]` `[decisionItemId]` `[dueDate]` `[startDate]` `[status]` に整理
  * 将来 Project 層導入時の方針を schema コメントに記載
* `apps/api/prisma/migrations/20260517105812_task_schema_extension/migration.sql`: 上記スキーマに対応するマイグレーション SQL を生成
* `apps/api/prisma/dbml/schema.dbml`: `prisma generate` で自動再生成
* `database/schema.dbml`: 手書きの設計ドキュメントを Note 付きで同期
* `apps/api/test/task.test.ts`: 既存パターンに揃えた Task / TaskAssignee / TaskRecurringMeeting の存在確認テストを追加

## 動作確認手順
1. `git checkout issue-163-task-schema-extension`
2. 既存 Task テーブルにデータがある開発環境では一度 reset が必要: `make dev-reset` または `pnpm --filter api exec prisma migrate reset`
3. `make migrate-status` で `Database schema is up to date!` が表示されることを確認
4. `pnpm --filter api test test/task.test.ts` で 3 件すべて pass することを確認
5. `pnpm turbo run lint typecheck test` で全タスク success を確認

## スクリーンショット
*（DB スキーマ変更のみ・UI 変更なし）*

API レスポンス例: 本 PR では API は未実装。後続 #164 / #165 を参照。

## 補足
* 破壊的マイグレーションだが PR #111 後に Task を参照するコードはゼロのため安全
* `originMeetingId` への変更は Prisma migrate dev 仕様により drop+add で生成されている（データ無し前提のため許容）
* 手書き dbml と自動生成 dbml の Note 充実度の差は Issue #148 のスコープで別途扱う