### PR TITLE
feat(api): Task CRUD API（POST/GET/PATCH/DELETE）と楽観的ロックを実装

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { healthRoute } from "./routes/health.js";
 import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
 import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
+import { tasksRoute } from "./routes/tasks.js";
 
 const app = new Hono();
 
@@ -10,7 +11,8 @@ const routes = app
   .route("/health", healthRoute)
   .route("/meetings", meetingsRoute)
   .route("/organizations", organizationsRoute)
-  .route("/recurring-meetings", recurringMeetingsRoute);
+  .route("/recurring-meetings", recurringMeetingsRoute)
+  .route("/tasks", tasksRoute);
 
 export { app };
 export type AppType = typeof routes;

--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+// 手動経路で受け付ける status 値（draft / reviewing は AI 専用なので除外）。
+// POST では指定不可（サーバ側で todo 固定）、PATCH でのみ変更可能。
+const manualTaskStatusSchema = z.enum([
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+]);
+
+const taskPrioritySchema = z.enum(["required", "optional"]);
+
+// ID 配列は重複を排除する。zod 側で dedupe しておけば、
+// 中間テーブル ユニーク制約での P2002 を待たずに整合できる。
+const idArraySchema = z
+  .array(z.string().min(1))
+  .transform((arr) => [...new Set(arr)]);
+
+// 共通の入力可能フィールド（POST/PATCH で共有）。
+// AI 由来 (sourceQuote / dueDateRaw / ambiguityFlags 等) や decisionItemId は受け付けない。
+const taskInputBaseSchema = z.object({
+  title: z.string().min(1, "title は必須です"),
+  body: z.string().optional(),
+  priority: taskPrioritySchema.optional(),
+  assigneeUserIds: idArraySchema.optional(),
+  recurringMeetingIds: idArraySchema.optional(),
+  originMeetingId: z.string().min(1).optional(),
+  dueDate: z
+    .string()
+    .datetime({ message: "dueDate は ISO8601 で指定してください" })
+    .optional(),
+  startDate: z
+    .string()
+    .datetime({ message: "startDate は ISO8601 で指定してください" })
+    .optional(),
+  followUpDate: z
+    .string()
+    .datetime({ message: "followUpDate は ISO8601 で指定してください" })
+    .optional(),
+});
+
+// 作成リクエスト。組織は必須。status は受け付けず、サーバが todo 固定で書き込む。
+export const taskCreateSchema = taskInputBaseSchema.extend({
+  organizationId: z.string().min(1, "organizationId は必須です"),
+});
+
+// 更新リクエスト。全フィールド optional だが、version は必須で楽観的ロックに用いる。
+// 何も指定しない更新は意図不明瞭なため 400 で弾く。
+// assigneeUserIds / recurringMeetingIds: undefined = 変更なし、空配列 = 全削除。
+export const taskUpdateSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    title: z.string().min(1).optional(),
+    body: z.string().optional(),
+    status: manualTaskStatusSchema.optional(),
+    priority: taskPrioritySchema.optional(),
+    assigneeUserIds: idArraySchema.optional(),
+    recurringMeetingIds: idArraySchema.optional(),
+    originMeetingId: z.string().min(1).nullable().optional(),
+    dueDate: z.string().datetime().nullable().optional(),
+    startDate: z.string().datetime().nullable().optional(),
+    followUpDate: z.string().datetime().nullable().optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.title !== undefined ||
+      d.body !== undefined ||
+      d.status !== undefined ||
+      d.priority !== undefined ||
+      d.assigneeUserIds !== undefined ||
+      d.recurringMeetingIds !== undefined ||
+      d.originMeetingId !== undefined ||
+      d.dueDate !== undefined ||
+      d.startDate !== undefined ||
+      d.followUpDate !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type TaskCreateInput = z.infer<typeof taskCreateSchema>;
+export type TaskUpdateInput = z.infer<typeof taskUpdateSchema>;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,0 +1,182 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { taskCreateSchema } from "../lib/schemas/task.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+
+// GET / POST / PATCH のレスポンス整形で共通利用する include 設定。
+// 中間テーブル経由の関連は user / recurringMeeting / originMeeting を最小フィールドで取得する。
+const taskInclude = {
+  assignees: {
+    include: {
+      user: {
+        select: { id: true, name: true, displayName: true, email: true },
+      },
+    },
+  },
+  recurringMeetings: {
+    include: {
+      recurringMeeting: { select: { id: true, name: true } },
+    },
+  },
+  originMeeting: {
+    select: { id: true, title: true, heldAt: true, recurringMeetingId: true },
+  },
+  organization: { select: { id: true, name: true } },
+} as const;
+
+// Prisma が返す中間テーブル経由の構造をフロント向けに平坦化する。
+// biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
+function serializeTask(task: any) {
+  const { assignees, recurringMeetings, ...rest } = task;
+  return {
+    ...rest,
+    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
+    assignees: assignees.map((a: any) => a.user),
+    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
+    recurringMeetings: recurringMeetings.map((r: any) => r.recurringMeeting),
+  };
+}
+
+// 認証ユーザーが対象組織に所属しているか確認する。
+// 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
+async function requireOrgMembership(
+  c: Context<{ Variables: AuthVariables }>,
+  organizationId: string,
+): Promise<{ ok: true } | { ok: false; res: Response }> {
+  const user = c.var.user;
+  const membership = await prisma.organizationMembership.findUnique({
+    where: {
+      userId_organizationId: { userId: user.id, organizationId },
+    },
+  });
+  if (!membership) {
+    return { ok: false, res: c.json({ error: "組織が見つかりません" }, 404) };
+  }
+  return { ok: true };
+}
+
+// assigneeUserIds が全員 organizationId のメンバーであるかを検証する。
+// 一括 findMany → 件数比較で OK / NG を判定する。
+async function validateAssigneesInOrg(
+  organizationId: string,
+  userIds: string[],
+): Promise<boolean> {
+  if (userIds.length === 0) return true;
+  const members = await prisma.organizationMembership.findMany({
+    where: { organizationId, userId: { in: userIds } },
+    select: { userId: true },
+  });
+  return members.length === userIds.length;
+}
+
+// recurringMeetingIds が全件 organizationId 配下に属するかを検証する。
+async function validateRecurringMeetingsInOrg(
+  organizationId: string,
+  recurringMeetingIds: string[],
+): Promise<boolean> {
+  if (recurringMeetingIds.length === 0) return true;
+  const rms = await prisma.recurringMeeting.findMany({
+    where: { id: { in: recurringMeetingIds }, organizationId },
+    select: { id: true },
+  });
+  return rms.length === recurringMeetingIds.length;
+}
+
+// originMeetingId が指定された場合、その会議が当該組織に属することを確認する。
+// 紐付く recurringMeeting 経由で組織判定する（単発会議は MVP では 400 で拒否）。
+async function validateOriginMeetingInOrg(
+  organizationId: string,
+  meetingId: string,
+): Promise<boolean> {
+  const meeting = await prisma.meeting.findUnique({
+    where: { id: meetingId },
+    include: { recurringMeeting: { select: { organizationId: true } } },
+  });
+  if (!meeting) return false;
+  if (!meeting.recurringMeeting) return false;
+  return meeting.recurringMeeting.organizationId === organizationId;
+}
+
+export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .post("/", zValidator("json", taskCreateSchema), async (c) => {
+    const input = c.req.valid("json");
+
+    const guard = await requireOrgMembership(c, input.organizationId);
+    if (!guard.ok) return guard.res;
+
+    const assigneeUserIds = input.assigneeUserIds ?? [];
+    const recurringMeetingIds = input.recurringMeetingIds ?? [];
+
+    // クロス組織アタッチを防ぐ各バリデーション。
+    // assignees / recurringMeetings / originMeeting それぞれで組織整合を確認する。
+    if (
+      !(await validateAssigneesInOrg(input.organizationId, assigneeUserIds))
+    ) {
+      return c.json(
+        { error: "担当者は組織のメンバーである必要があります" },
+        400,
+      );
+    }
+    if (
+      !(await validateRecurringMeetingsInOrg(
+        input.organizationId,
+        recurringMeetingIds,
+      ))
+    ) {
+      return c.json({ error: "定例は組織に属している必要があります" }, 400);
+    }
+    if (input.originMeetingId) {
+      const ok = await validateOriginMeetingInOrg(
+        input.organizationId,
+        input.originMeetingId,
+      );
+      if (!ok) {
+        return c.json(
+          { error: "発生源会議が見つからないか組織に属していません" },
+          400,
+        );
+      }
+    }
+
+    // Task 本体 + 中間テーブル 2 つを原子的に作成する。
+    // 手動経路の status は常に "todo" 固定（入力値があっても無視）。
+    const created = await prisma.$transaction(async (tx) => {
+      const task = await tx.task.create({
+        data: {
+          organizationId: input.organizationId,
+          title: input.title,
+          body: input.body,
+          status: "todo",
+          priority: input.priority,
+          originMeetingId: input.originMeetingId,
+          dueDate: input.dueDate ? new Date(input.dueDate) : undefined,
+          startDate: input.startDate ? new Date(input.startDate) : undefined,
+          followUpDate: input.followUpDate
+            ? new Date(input.followUpDate)
+            : undefined,
+        },
+      });
+      if (assigneeUserIds.length > 0) {
+        await tx.taskAssignee.createMany({
+          data: assigneeUserIds.map((userId) => ({ taskId: task.id, userId })),
+        });
+      }
+      if (recurringMeetingIds.length > 0) {
+        await tx.taskRecurringMeeting.createMany({
+          data: recurringMeetingIds.map((recurringMeetingId) => ({
+            taskId: task.id,
+            recurringMeetingId,
+          })),
+        });
+      }
+      return tx.task.findUnique({
+        where: { id: task.id },
+        include: taskInclude,
+      });
+    });
+
+    return c.json(serializeTask(created), 201);
+  });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -99,6 +99,27 @@ async function validateOriginMeetingInOrg(
   return meeting.recurringMeeting.organizationId === organizationId;
 }
 
+// task を ID から取得し、当該組織のメンバーであることを確認する。
+// Task 不存在・組織非所属いずれも 404 で統一し、存在自体を露出させない。
+async function requireTaskAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  taskId: string,
+): Promise<
+  // biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
+  { ok: true; task: any } | { ok: false; res: Response }
+> {
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    include: taskInclude,
+  });
+  if (!task) {
+    return { ok: false, res: c.json({ error: "タスクが見つかりません" }, 404) };
+  }
+  const guard = await requireOrgMembership(c, task.organizationId);
+  if (!guard.ok) return guard;
+  return { ok: true, task };
+}
+
 export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
   .post("/", zValidator("json", taskCreateSchema), async (c) => {
@@ -179,4 +200,10 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     });
 
     return c.json(serializeTask(created), 201);
+  })
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    const guard = await requireTaskAccess(c, id);
+    if (!guard.ok) return guard.res;
+    return c.json(serializeTask(guard.task));
   });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -319,4 +319,14 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
       );
     }
     return c.json(serializeTask(result.task));
+  })
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const guard = await requireTaskAccess(c, id);
+    if (!guard.ok) return guard.res;
+
+    // 配下の TaskAssignee / TaskRecurringMeeting は schema 側で onDelete: Cascade のため
+    // delete 一発で連鎖削除される。削除済みボディは返さず 204 で統一。
+    await prisma.task.delete({ where: { id } });
+    return c.body(null, 204);
   });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
-import { taskCreateSchema } from "../lib/schemas/task.js";
+import { taskCreateSchema, taskUpdateSchema } from "../lib/schemas/task.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 // GET / POST / PATCH のレスポンス整形で共通利用する include 設定。
@@ -206,4 +206,117 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     const guard = await requireTaskAccess(c, id);
     if (!guard.ok) return guard.res;
     return c.json(serializeTask(guard.task));
+  })
+  .patch("/:id", zValidator("json", taskUpdateSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const guard = await requireTaskAccess(c, id);
+    if (!guard.ok) return guard.res;
+
+    const organizationId = guard.task.organizationId as string;
+
+    // assignees / recurringMeetings の置換が指定されたら、クロス組織を再検証する。
+    // 作成時と同じ整合性ルール（同一組織内のみ許可）。
+    if (input.assigneeUserIds !== undefined) {
+      if (
+        !(await validateAssigneesInOrg(organizationId, input.assigneeUserIds))
+      ) {
+        return c.json(
+          { error: "担当者は組織のメンバーである必要があります" },
+          400,
+        );
+      }
+    }
+    if (input.recurringMeetingIds !== undefined) {
+      if (
+        !(await validateRecurringMeetingsInOrg(
+          organizationId,
+          input.recurringMeetingIds,
+        ))
+      ) {
+        return c.json({ error: "定例は組織に属している必要があります" }, 400);
+      }
+    }
+    if (input.originMeetingId) {
+      const ok = await validateOriginMeetingInOrg(
+        organizationId,
+        input.originMeetingId,
+      );
+      if (!ok) {
+        return c.json(
+          { error: "発生源会議が見つからないか組織に属していません" },
+          400,
+        );
+      }
+    }
+
+    // 楽観的ロック: where に id + version を指定して updateMany し、
+    // count === 0 なら version 不一致として 409。Prisma の単一 update は
+    // id + version の AND を unique 制約として扱えないため updateMany を使う。
+    const updateData = {
+      ...(input.title !== undefined && { title: input.title }),
+      ...(input.body !== undefined && { body: input.body }),
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.priority !== undefined && { priority: input.priority }),
+      ...(input.originMeetingId !== undefined && {
+        originMeetingId: input.originMeetingId,
+      }),
+      ...(input.dueDate !== undefined && {
+        dueDate: input.dueDate ? new Date(input.dueDate) : null,
+      }),
+      ...(input.startDate !== undefined && {
+        startDate: input.startDate ? new Date(input.startDate) : null,
+      }),
+      ...(input.followUpDate !== undefined && {
+        followUpDate: input.followUpDate ? new Date(input.followUpDate) : null,
+      }),
+      version: { increment: 1 },
+    };
+
+    const result = await prisma.$transaction(async (tx) => {
+      const { count } = await tx.task.updateMany({
+        where: { id, version: input.version },
+        data: updateData,
+      });
+      if (count === 0) {
+        return { kind: "version_conflict" as const };
+      }
+      // assignees / recurringMeetings の全置換。undefined ならスキップ。
+      if (input.assigneeUserIds !== undefined) {
+        await tx.taskAssignee.deleteMany({ where: { taskId: id } });
+        if (input.assigneeUserIds.length > 0) {
+          await tx.taskAssignee.createMany({
+            data: input.assigneeUserIds.map((userId) => ({
+              taskId: id,
+              userId,
+            })),
+          });
+        }
+      }
+      if (input.recurringMeetingIds !== undefined) {
+        await tx.taskRecurringMeeting.deleteMany({ where: { taskId: id } });
+        if (input.recurringMeetingIds.length > 0) {
+          await tx.taskRecurringMeeting.createMany({
+            data: input.recurringMeetingIds.map((recurringMeetingId) => ({
+              taskId: id,
+              recurringMeetingId,
+            })),
+          });
+        }
+      }
+      const task = await tx.task.findUnique({
+        where: { id },
+        include: taskInclude,
+      });
+      return { kind: "ok" as const, task };
+    });
+
+    if (result.kind === "version_conflict") {
+      return c.json(
+        { error: "他のユーザーが先に更新しました。最新を取得してください" },
+        409,
+      );
+    }
+    return c.json(serializeTask(result.task));
   });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -71,6 +71,7 @@ const mockMembershipFindMany = vi.mocked(
 );
 const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
+const mockTaskFindUnique = vi.mocked(prisma.task.findUnique);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member" = "member") {
@@ -347,5 +348,55 @@ describe("POST /tasks", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as { status: string };
     expect(body.status).toBe("todo");
+  });
+});
+
+describe("GET /tasks/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは関連を含む 200 を取得できる", async () => {
+    mockTaskFindUnique.mockResolvedValue({
+      ...sampleTask,
+      assignees: [
+        {
+          user: {
+            id: "user-1",
+            name: "alice",
+            displayName: "alice",
+            email: "a@example.com",
+          },
+        },
+      ],
+      recurringMeetings: [
+        { recurringMeeting: { id: "rmtg-1", name: "週次定例" } },
+      ],
+    } as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/tasks/task-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      assignees: { id: string }[];
+      recurringMeetings: { id: string }[];
+    };
+    expect(body.id).toBe("task-1");
+    expect(body.assignees).toHaveLength(1);
+    expect(body.assignees[0].id).toBe("user-1");
+    expect(body.recurringMeetings).toHaveLength(1);
+    expect(body.recurringMeetings[0].id).toBe("rmtg-1");
+  });
+
+  it("タスクが存在しない場合は 404", async () => {
+    mockTaskFindUnique.mockResolvedValue(null);
+    const res = await app.request("/tasks/missing");
+    expect(res.status).toBe(404);
+  });
+
+  it("タスク所属組織の非メンバーは 404", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/tasks/task-1");
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -601,3 +601,31 @@ describe("PATCH /tasks/:id", () => {
     expect(deletedAssignees).toBe(true);
   });
 });
+
+describe("DELETE /tasks/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは 204 でタスクを削除できる", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const mockTaskDelete = vi.mocked(prisma.task.delete);
+    mockTaskDelete.mockResolvedValue(sampleTask as never);
+
+    const res = await app.request("/tasks/task-1", { method: "DELETE" });
+    expect(res.status).toBe(204);
+    expect(mockTaskDelete).toHaveBeenCalledWith({ where: { id: "task-1" } });
+  });
+
+  it("タスク不存在は 404", async () => {
+    mockTaskFindUnique.mockResolvedValue(null);
+    const res = await app.request("/tasks/missing", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+
+  it("非メンバーは 404", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/tasks/task-1", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma を全モックして tasks ルートのロジックのみを検証する。
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    recurringMeeting: {
+      findMany: vi.fn(),
+    },
+    meeting: {
+      findUnique: vi.fn(),
+    },
+    task: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    taskAssignee: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    taskRecurringMeeting: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+// auth ミドルウェアを差し替え、認証済みユーザーを c.var.user に注入する。
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return {
+    defaultUser,
+    current: { ...defaultUser },
+  };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: {
+      set: (key: string, value: unknown) => void;
+    },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockMembershipFindMany = vi.mocked(
+  prisma.organizationMembership.findMany,
+);
+const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
+const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+const sampleTask = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: new Date("2026-05-17T00:00:00Z"),
+  updatedAt: new Date("2026-05-17T00:00:00Z"),
+  organization: { id: "org-1", name: "Org 1" },
+  originMeeting: null,
+  assignees: [],
+  recurringMeetings: [],
+};
+
+describe("POST /tasks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("最小パラメータで 201 と status=todo を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue(sampleTask);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; status: string };
+    expect(body.id).toBe("task-1");
+    expect(body.status).toBe("todo");
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("assignees / recurringMeetings / originMeeting を含む 201", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 担当候補が全員 org メンバーであることの検証
+    mockMembershipFindMany.mockResolvedValue([
+      membership(),
+      { ...membership(), userId: "user-2" },
+    ]);
+    // attached 定例が同一組織に属することの検証
+    mockRecurringFindMany.mockResolvedValue([
+      { id: "rmtg-1", organizationId: "org-1" },
+      { id: "rmtg-2", organizationId: "org-1" },
+    ] as never);
+    // originMeeting の組織判定（紐付く recurringMeeting 経由）
+    mockMeetingFindUnique.mockResolvedValue({
+      id: "mtg-1",
+      recurringMeetingId: "rmtg-1",
+      recurringMeeting: { organizationId: "org-1" },
+    } as never);
+    mockTransaction.mockResolvedValue({
+      ...sampleTask,
+      originMeetingId: "mtg-1",
+      assignees: [
+        {
+          user: {
+            id: "user-1",
+            name: "alice",
+            displayName: "alice",
+            email: "a@example.com",
+          },
+        },
+        {
+          user: {
+            id: "user-2",
+            name: "bob",
+            displayName: "bob",
+            email: "b@example.com",
+          },
+        },
+      ],
+      recurringMeetings: [
+        { recurringMeeting: { id: "rmtg-1", name: "週次定例" } },
+        { recurringMeeting: { id: "rmtg-2", name: "月次定例" } },
+      ],
+    });
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        assigneeUserIds: ["user-1", "user-2"],
+        recurringMeetingIds: ["rmtg-1", "rmtg-2"],
+        originMeetingId: "mtg-1",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("組織非所属の場合は 404", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("title 欠落は 400", async () => {
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organizationId: "org-1" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("organizationId 欠落は 400", async () => {
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "資料作成" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("assignee に他組織のメンバーが混在する場合は 400", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 2 名指定したが 1 名しか組織メンバーとして見つからない
+    mockMembershipFindMany.mockResolvedValue([membership()]);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        assigneeUserIds: ["user-1", "user-2"],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("recurringMeeting に他組織のものが混在する場合は 400", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 指定した 2 件のうち 1 件が他組織
+    mockRecurringFindMany.mockResolvedValue([
+      { id: "rmtg-1", organizationId: "org-1" },
+    ] as never);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        recurringMeetingIds: ["rmtg-1", "rmtg-other"],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("originMeeting が他組織なら 400", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindUnique.mockResolvedValue({
+      id: "mtg-1",
+      recurringMeetingId: "rmtg-other",
+      recurringMeeting: { organizationId: "org-other" },
+    } as never);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        originMeetingId: "mtg-1",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("originMeeting が単発会議（recurringMeetingId=null）なら 400", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindUnique.mockResolvedValue({
+      id: "mtg-1",
+      recurringMeetingId: null,
+      recurringMeeting: null,
+    } as never);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        originMeetingId: "mtg-1",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("originMeeting 不存在は 400", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        originMeetingId: "mtg-x",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("ユーザーは status を指定できない（受け付けても無視され todo になる）", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue(sampleTask);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        status: "done",
+      }),
+    });
+
+    // status は受け付けないため、リクエストに含めても 201 で status=todo になる。
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("todo");
+  });
+});

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -400,3 +400,204 @@ describe("GET /tasks/:id", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("PATCH /tasks/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("title 更新が 200、version は updateMany でインクリメントされる", async () => {
+    // 認可は requireTaskAccess の findUnique + membership で通す
+    mockTaskFindUnique
+      .mockResolvedValueOnce(sampleTask as never) // requireTaskAccess の初回呼び出し
+      .mockResolvedValueOnce({
+        ...sampleTask,
+        title: "更新後",
+        version: 1,
+      } as never); // 再取得
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUnique: vi
+            .fn()
+            .mockResolvedValue({ ...sampleTask, title: "更新後", version: 1 }),
+        },
+        taskAssignee: {
+          deleteMany: vi.fn(),
+          createMany: vi.fn(),
+        },
+        taskRecurringMeeting: {
+          deleteMany: vi.fn(),
+          createMany: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      const result = await (fn as (t: any) => Promise<unknown>)(tx);
+      expect(tx.task.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "task-1", version: 0 },
+          data: expect.objectContaining({
+            title: "更新後",
+            version: { increment: 1 },
+          }),
+        }),
+      );
+      return result;
+    });
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { version: number; title: string };
+    expect(body.version).toBe(1);
+    expect(body.title).toBe("更新後");
+  });
+
+  it("version 不一致は 409", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: {
+          // updateMany が 0 件返るのが version 不一致のシグナル
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+          findUnique: vi.fn(),
+        },
+        taskAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+        taskRecurringMeeting: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("status を todo→in_progress に変更できる", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUnique: vi.fn().mockResolvedValue({
+            ...sampleTask,
+            status: "in_progress",
+            version: 1,
+          }),
+        },
+        taskAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+        taskRecurringMeeting: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "in_progress" }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("status=draft は 400（AI 専用なので手動 PATCH で受け付けない）", async () => {
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("全フィールド未指定の更新は 400", async () => {
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("version 欠落は 400", async () => {
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "更新後" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("タスクが存在しない場合は 404", async () => {
+    mockTaskFindUnique.mockResolvedValue(null);
+    const res = await app.request("/tasks/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("assigneeUserIds の置換で他組織混入は 400", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 2 名指定したが 1 名しか組織メンバーとして見つからない
+    mockMembershipFindMany.mockResolvedValue([membership()]);
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        assigneeUserIds: ["user-1", "user-outside"],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("assigneeUserIds:[] は全削除を行う", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    let deletedAssignees = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUnique: vi.fn().mockResolvedValue(sampleTask),
+        },
+        taskAssignee: {
+          deleteMany: vi.fn(() => {
+            deletedAssignees = true;
+            return Promise.resolve({ count: 0 });
+          }),
+          createMany: vi.fn(),
+        },
+        taskRecurringMeeting: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, assigneeUserIds: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deletedAssignees).toBe(true);
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #164

## 概要・目的
* 手動でのタスク作成・取得・更新・削除エンドポイントを提供し、フロントエンドからタスク管理 UI を構築できる状態にする
* `version` による楽観的ロックを最初から導入し、複数ユーザー同時編集を安全に扱う
* AI 由来フィールドは入力で受け付けず、後の AI 受入経路と整合性を取れる "受け皿" として機能させる

## 背景
* Issue #163（Task スキーマ拡張）の上に、CRUD エンドポイントを構築するスコープ
* 既存 `recurring-meetings.ts` / `organizations.ts` の認可・404 短絡方針に揃える
* 既存に楽観的ロック実装は無く、Task の `version` カラムが本 PR で初導入

## 変更内容
* `apps/api/src/lib/schemas/task.ts` (新規):
  * `taskCreateSchema`: title / organizationId 必須、AI 由来フィールドは含まず
  * `taskUpdateSchema`: version 必須、全フィールド optional、`status` は手動経路用 enum（draft/reviewing は拒否）、`.strict() + .refine(≥1 field)`
* `apps/api/src/routes/tasks.ts` (新規):
  * `requireOrgMembership` / `requireTaskAccess` ヘルパーで認可を統一
  * `validateAssigneesInOrg` / `validateRecurringMeetingsInOrg` / `validateOriginMeetingInOrg` でクロス組織アタッチを禁止
  * **POST**: `$transaction` で Task + TaskAssignee + TaskRecurringMeeting を原子作成、status は常に todo 固定
  * **GET**: `taskInclude` で assignees / recurringMeetings / originMeeting / organization を最小フィールドで取得し、中間テーブル経由は `serializeTask` で平坦化
  * **PATCH**: `updateMany({ where: { id, version } })` で楽観的ロックを検証、count=0 で 409、配列は undefined=変更なし / 空配列=全削除
  * **DELETE**: requireTaskAccess → prisma.task.delete → 204（Cascade で連鎖削除）
* `apps/api/src/app.ts`: `/tasks` ルートを登録
* `apps/api/test/tasks.test.ts` (新規, 26 件):
  * POST 11 / GET 3 / PATCH 9 / DELETE 3 件のテスト
  * prisma 全モック + auth 差し替え（既存 recurring-meetings.test.ts と同パターン）

## 動作確認手順
1. `git checkout issue-164-task-crud-api`
2. `make install`（依存関係セットアップ）
3. `make dev` で全サービスを起動し、`make migrate-status` で `Database schema is up to date!` を確認
4. `make test` で全テスト pass（API 13 ファイル / 165 件、うち本 PR で 26 件追加）を確認
5. `make lint` で警告ゼロを確認
6. API 動作確認（curl 例）:
   - 作成: `curl -X POST http://localhost:3001/tasks -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"organizationId":"<orgId>","title":"資料作成"}'`
   - 取得: `curl http://localhost:3001/tasks/<taskId> -H 'Authorization: Bearer <token>'`
   - 更新: `curl -X PATCH http://localhost:3001/tasks/<taskId> -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"version":0,"title":"更新後"}'`
   - 削除: `curl -X DELETE http://localhost:3001/tasks/<taskId> -H 'Authorization: Bearer <token>'`

## スクリーンショット
APIレスポンス例（POST /tasks 成功時、status=201）:
```json
{
  "id": "ckxx...",
  "organizationId": "<orgId>",
  "originMeetingId": null,
  "title": "資料作成",
  "status": "todo",
  "version": 0,
  "assignees": [],
  "recurringMeetings": [],
  "originMeeting": null,
  "organization": { "id": "<orgId>", "name": "Org 1" }
}
```

楽観的ロック競合時（PATCH、status=409）:
```json
{ "error": "他のユーザーが先に更新しました。最新を取得してください" }
```

## 補足
* 単発会議（`Meeting.recurringMeetingId=null`）を originMeetingId に指定した場合は 400 で拒否（組織判定不能のため、MVP スコープ外）
* `decisionItemId` は POST/PATCH で受け付けない（AI 専用、GET ではフィールド含む）
* assignees / recurringMeetings は配列全置換セマンティクス（個別追加/削除エンドポイントは作らない）
* `auditLogs` への書き込みは MVP では行わない（別 Issue で後追い）
