### PR TITLE
feat(api): タスク一覧 API（4 種の scoped エンドポイント）を実装

### DIFF
--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -80,3 +80,57 @@ export const taskUpdateSchema = z
 
 export type TaskCreateInput = z.infer<typeof taskCreateSchema>;
 export type TaskUpdateInput = z.infer<typeof taskUpdateSchema>;
+
+// 一覧 API 共通のクエリパラメータ。
+// status: カンマ区切りで複数指定可（例: ?status=todo,in_progress）
+// assigneeId / dueBefore / dueAfter: 単一値
+const taskStatusValuesSchema = z
+  .string()
+  .transform((s) =>
+    s
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean),
+  )
+  .pipe(
+    z.array(
+      z.enum(["draft", "reviewing", "todo", "in_progress", "done", "rejected"]),
+    ),
+  );
+
+export const taskListQuerySchema = z.object({
+  status: taskStatusValuesSchema.optional(),
+  assigneeId: z.string().min(1).optional(),
+  dueBefore: z
+    .string()
+    .datetime({ message: "dueBefore は ISO8601 で指定してください" })
+    .optional(),
+  dueAfter: z
+    .string()
+    .datetime({ message: "dueAfter は ISO8601 で指定してください" })
+    .optional(),
+});
+
+export type TaskListQuery = z.infer<typeof taskListQuerySchema>;
+
+// 一覧 API のクエリフィルタを Prisma の where 句に変換する。
+// スコープ別の where 条件（例: organizationId 等）と AND 合成する想定。
+export function buildTaskListWhere(filters: TaskListQuery) {
+  const where: {
+    status?: { in: TaskListQuery["status"] };
+    assignees?: { some: { userId: string } };
+    dueDate?: { gte?: Date; lte?: Date };
+  } = {};
+  if (filters.status && filters.status.length > 0) {
+    where.status = { in: filters.status };
+  }
+  if (filters.assigneeId) {
+    where.assignees = { some: { userId: filters.assigneeId } };
+  }
+  if (filters.dueBefore || filters.dueAfter) {
+    where.dueDate = {};
+    if (filters.dueAfter) where.dueDate.gte = new Date(filters.dueAfter);
+    if (filters.dueBefore) where.dueDate.lte = new Date(filters.dueBefore);
+  }
+  return where;
+}

--- a/apps/api/src/lib/task-serialization.ts
+++ b/apps/api/src/lib/task-serialization.ts
@@ -1,0 +1,62 @@
+import type { Prisma } from "@prisma/client";
+
+// タスク詳細 (GET /tasks/:id, POST /tasks, PATCH /tasks/:id) 用の include。
+// 担当者ユーザーは email まで含めて返す。
+export const taskDetailInclude = {
+  assignees: {
+    include: {
+      user: {
+        select: { id: true, name: true, displayName: true, email: true },
+      },
+    },
+  },
+  recurringMeetings: {
+    include: {
+      recurringMeeting: { select: { id: true, name: true } },
+    },
+  },
+  originMeeting: {
+    select: { id: true, title: true, heldAt: true, recurringMeetingId: true },
+  },
+  organization: { select: { id: true, name: true } },
+} as const satisfies Prisma.TaskInclude;
+
+// 一覧 API 用の include。詳細との差分は assignees.user に email を含めないこと。
+// 一覧で大量のメールアドレスを返す必要がないため最小化する。
+export const taskListInclude = {
+  assignees: {
+    include: {
+      user: { select: { id: true, name: true, displayName: true } },
+    },
+  },
+  recurringMeetings: {
+    include: {
+      recurringMeeting: { select: { id: true, name: true } },
+    },
+  },
+  originMeeting: {
+    select: { id: true, title: true, heldAt: true, recurringMeetingId: true },
+  },
+  organization: { select: { id: true, name: true } },
+} as const satisfies Prisma.TaskInclude;
+
+// 一覧のデフォルト並び順。期限が近いタスク優先で、期限未設定 (NULL) は末尾、
+// 同期限内は最近更新されたものを上に出す。
+export const taskListOrderBy: Prisma.TaskOrderByWithRelationInput[] = [
+  { dueDate: { sort: "asc", nulls: "last" } },
+  { updatedAt: "desc" },
+];
+
+// Prisma が返す中間テーブル経由の構造をフロント向けに平坦化する。
+// detail / list の両方で共通利用する。
+// biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
+export function serializeTask(task: any) {
+  const { assignees, recurringMeetings, ...rest } = task;
+  return {
+    ...rest,
+    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
+    assignees: assignees.map((a: any) => a.user),
+    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
+    recurringMeetings: recurringMeetings.map((r: any) => r.recurringMeeting),
+  };
+}

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -2,14 +2,28 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
+import {
+  buildTaskListWhere,
+  taskListQuerySchema,
+} from "../lib/schemas/task.js";
+import {
+  serializeTask,
+  taskListInclude,
+  taskListOrderBy,
+} from "../lib/task-serialization.js";
 import { sendMeetingCreatedEvent } from "../lib/service-bus.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
 
 const createSchema = z.object({
   title: z.string().min(1),
   heldAt: z.string().datetime(),
 });
 
-export const meetingsRoute = new Hono()
+// 既存 GET / と POST / は auth 未適用の公開エンドポイント（pre-existing）。
+// 本ルーターには /:id/tasks のような認証必須パスを追加するため、
+// Variables 型に AuthVariables を入れておく。auth ミドルウェアは新規エンドポイント側で
+// 明示的に適用する（既存パスへは影響させない）。
+export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   .get("/", async (c) => {
     const meetings = await prisma.meeting.findMany({
       orderBy: { heldAt: "desc" },
@@ -34,4 +48,47 @@ export const meetingsRoute = new Hono()
       );
     }
     return c.json(meeting, 201);
-  });
+  })
+  .get(
+    "/:id/tasks",
+    auth,
+    zValidator("query", taskListQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const filters = c.req.valid("query");
+
+      // 会議存在 + 紐付く定例経由で組織判定。単発会議（recurringMeetingId=null）は
+      // 組織判定不能のため 404 で拒否する（MVP スコープ）。
+      const meeting = await prisma.meeting.findUnique({
+        where: { id },
+        include: { recurringMeeting: { select: { organizationId: true } } },
+      });
+      if (!meeting?.recurringMeeting) {
+        return c.json({ error: "会議が見つかりません" }, 404);
+      }
+
+      const user = c.var.user;
+      const membership = await prisma.organizationMembership.findUnique({
+        where: {
+          userId_organizationId: {
+            userId: user.id,
+            organizationId: meeting.recurringMeeting.organizationId,
+          },
+        },
+      });
+      if (!membership) {
+        return c.json({ error: "会議が見つかりません" }, 404);
+      }
+
+      // 当該会議を発生源とするタスクのみ。
+      const tasks = await prisma.task.findMany({
+        where: {
+          ...buildTaskListWhere(filters),
+          originMeetingId: id,
+        },
+        orderBy: taskListOrderBy,
+        include: taskListInclude,
+      });
+      return c.json(tasks.map(serializeTask));
+    },
+  );

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -9,6 +9,15 @@ import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { recurringMeetingCreateSchema } from "../lib/schemas/recurring-meeting.js";
+import {
+  buildTaskListWhere,
+  taskListQuerySchema,
+} from "../lib/schemas/task.js";
+import {
+  serializeTask,
+  taskListInclude,
+  taskListOrderBy,
+} from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 const createSchema = z.object({
@@ -265,6 +274,25 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     // 削除済みリソースの本体を返しても利用側で扱いに困るため 204 で返す。
     await prisma.organization.delete({ where: { id } });
     return c.body(null, 204);
+  })
+  .get("/:id/tasks", zValidator("query", taskListQuerySchema), async (c) => {
+    const id = c.req.param("id");
+    const filters = c.req.valid("query");
+
+    const guard = await requireMembership(c, id);
+    if (!guard.ok) return guard.res;
+
+    // 組織配下の全タスクをフィルタしつつ返す。フィルタは buildTaskListWhere で
+    // 共通生成し、ここでは organizationId スコープを追加するだけ。
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...buildTaskListWhere(filters),
+        organizationId: id,
+      },
+      orderBy: taskListOrderBy,
+      include: taskListInclude,
+    });
+    return c.json(tasks.map(serializeTask));
   })
   .get("/:id/meetings", async (c) => {
     const id = c.req.param("id");

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -5,6 +5,15 @@ import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { recurringMeetingUpdateSchema } from "../lib/schemas/recurring-meeting.js";
+import {
+  buildTaskListWhere,
+  taskListQuerySchema,
+} from "../lib/schemas/task.js";
+import {
+  serializeTask,
+  taskListInclude,
+  taskListOrderBy,
+} from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 // 定例配下に紐付ける Meeting 作成リクエストの schema。
@@ -97,6 +106,28 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
       },
     });
     return c.json(created, 201);
+  })
+  .get("/:id/tasks", zValidator("query", taskListQuerySchema), async (c) => {
+    const id = c.req.param("id");
+    const filters = c.req.valid("query");
+
+    // 定例存在チェック → 組織所属確認の順で 404 短絡。
+    const meeting = await prisma.recurringMeeting.findUnique({
+      where: { id },
+    });
+    const guard = await requireRecurringAccess(c, meeting);
+    if (!guard.ok) return guard.res;
+
+    // 当該定例に attach されたタスクのみ。中間テーブル経由 some 条件で絞る。
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...buildTaskListWhere(filters),
+        recurringMeetings: { some: { recurringMeetingId: id } },
+      },
+      orderBy: taskListOrderBy,
+      include: taskListInclude,
+    });
+    return c.json(tasks.map(serializeTask));
   })
   .get("/:id/meetings", async (c) => {
     const id = c.req.param("id");

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -3,41 +3,8 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
 import { taskCreateSchema, taskUpdateSchema } from "../lib/schemas/task.js";
+import { serializeTask, taskDetailInclude } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
-
-// GET / POST / PATCH のレスポンス整形で共通利用する include 設定。
-// 中間テーブル経由の関連は user / recurringMeeting / originMeeting を最小フィールドで取得する。
-const taskInclude = {
-  assignees: {
-    include: {
-      user: {
-        select: { id: true, name: true, displayName: true, email: true },
-      },
-    },
-  },
-  recurringMeetings: {
-    include: {
-      recurringMeeting: { select: { id: true, name: true } },
-    },
-  },
-  originMeeting: {
-    select: { id: true, title: true, heldAt: true, recurringMeetingId: true },
-  },
-  organization: { select: { id: true, name: true } },
-} as const;
-
-// Prisma が返す中間テーブル経由の構造をフロント向けに平坦化する。
-// biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
-function serializeTask(task: any) {
-  const { assignees, recurringMeetings, ...rest } = task;
-  return {
-    ...rest,
-    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
-    assignees: assignees.map((a: any) => a.user),
-    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
-    recurringMeetings: recurringMeetings.map((r: any) => r.recurringMeeting),
-  };
-}
 
 // 認証ユーザーが対象組織に所属しているか確認する。
 // 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
@@ -110,7 +77,7 @@ async function requireTaskAccess(
 > {
   const task = await prisma.task.findUnique({
     where: { id: taskId },
-    include: taskInclude,
+    include: taskDetailInclude,
   });
   if (!task) {
     return { ok: false, res: c.json({ error: "タスクが見つかりません" }, 404) };
@@ -195,7 +162,7 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
       }
       return tx.task.findUnique({
         where: { id: task.id },
-        include: taskInclude,
+        include: taskDetailInclude,
       });
     });
 
@@ -307,7 +274,7 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
       }
       const task = await tx.task.findUnique({
         where: { id },
-        include: taskInclude,
+        include: taskDetailInclude,
       });
       return { kind: "ok" as const, task };
     });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,8 +2,18 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
-import { taskCreateSchema, taskUpdateSchema } from "../lib/schemas/task.js";
-import { serializeTask, taskDetailInclude } from "../lib/task-serialization.js";
+import {
+  buildTaskListWhere,
+  taskCreateSchema,
+  taskListQuerySchema,
+  taskUpdateSchema,
+} from "../lib/schemas/task.js";
+import {
+  serializeTask,
+  taskDetailInclude,
+  taskListInclude,
+  taskListOrderBy,
+} from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 // 認証ユーザーが対象組織に所属しているか確認する。
@@ -89,6 +99,22 @@ async function requireTaskAccess(
 
 export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
+  .get("/me", zValidator("query", taskListQuerySchema), async (c) => {
+    const user = c.var.user;
+    const filters = c.req.valid("query");
+
+    // 自分が assignee の全組織横断タスクを返す。組織所属確認は不要
+    // （assignees 経由のスコープでユーザー自身に閉じている）。
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...buildTaskListWhere(filters),
+        assignees: { some: { userId: user.id } },
+      },
+      orderBy: taskListOrderBy,
+      include: taskListInclude,
+    });
+    return c.json(tasks.map(serializeTask));
+  })
   .post("/", zValidator("json", taskCreateSchema), async (c) => {
     const input = c.req.valid("json");
 

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -5,7 +5,14 @@ vi.mock("../src/lib/prisma.js", () => ({
   prisma: {
     meeting: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
       create: vi.fn(),
+    },
+    organizationMembership: {
+      findUnique: vi.fn(),
+    },
+    task: {
+      findMany: vi.fn(),
     },
   },
 }));
@@ -14,12 +21,42 @@ vi.mock("../src/lib/service-bus.js", () => ({
   sendMeetingCreatedEvent: vi.fn(),
 }));
 
+// auth ミドルウェアの差し替え。既存 GET / POST は auth 未適用のため
+// 影響しないが、新規 /:id/tasks では auth.ts を経由するため必要になる。
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
 import { sendMeetingCreatedEvent } from "../src/lib/service-bus.js";
 
 const mockFindMany = vi.mocked(prisma.meeting.findMany);
+const mockFindUnique = vi.mocked(prisma.meeting.findUnique);
 const mockCreate = vi.mocked(prisma.meeting.create);
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockSend = vi.mocked(sendMeetingCreatedEvent);
 
 const sampleMeeting = {
@@ -122,5 +159,96 @@ describe("POST /meetings", () => {
       }),
     });
     expect(res.status).toBe(201);
+  });
+});
+
+describe("GET /meetings/:id/tasks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const meetingWithRecurring = {
+    id: "mtg-1",
+    title: "第3回",
+    heldAt: new Date("2026-05-17T10:00:00Z"),
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  };
+
+  const sampleListTask = {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: "mtg-1",
+    decisionItemId: null,
+    title: "資料作成",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: { id: "mtg-1", title: "第3回", heldAt: new Date() },
+    assignees: [],
+    recurringMeetings: [],
+  };
+
+  it("組織メンバーは origin タスクを 200 で取得できる", async () => {
+    mockFindUnique.mockResolvedValue(meetingWithRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+
+    const res = await app.request("/meetings/mtg-1/tasks");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string }>;
+    expect(body).toHaveLength(1);
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ originMeetingId: "mtg-1" }),
+      }),
+    );
+  });
+
+  it("会議不存在は 404", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("単発会議（recurringMeetingId=null）は 404（組織判定不能）", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "mtg-x",
+      title: "単発",
+      heldAt: new Date(),
+      recurringMeetingId: null,
+      recurringMeeting: null,
+    } as never);
+    const res = await app.request("/meetings/mtg-x/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockFindUnique.mockResolvedValue(meetingWithRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -22,6 +22,9 @@ vi.mock("../src/lib/prisma.js", () => ({
       findFirst: vi.fn(),
       update: vi.fn(),
     },
+    task: {
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -79,6 +82,7 @@ const mockMembershipFindMany = vi.mocked(
 );
 const mockMembershipDelete = vi.mocked(prisma.organizationMembership.delete);
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
+const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 const sampleOrg = {
@@ -1192,5 +1196,89 @@ describe("POST /organizations/:id/join", () => {
     });
     expect(res.status).toBe(200);
     expect(observedEmail).toBe("alice@example.com");
+  });
+});
+
+describe("GET /organizations/:id/tasks", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => resetAuthUser());
+
+  function membership(role: "owner" | "admin" | "member" = "member") {
+    return {
+      userId: "user-1",
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  const sampleListTask = {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "資料作成",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    organization: { id: "org-1", name: "ACME 株式会社" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [],
+  };
+
+  it("組織メンバーは 200 でタスク一覧を取得できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+
+    const res = await app.request("/organizations/org-1/tasks");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("task-1");
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ organizationId: "org-1" }),
+      }),
+    );
+  });
+
+  it("非メンバーは 404", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/organizations/org-1/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("status フィルタと assigneeId フィルタを where に反映する", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request(
+      "/organizations/org-1/tasks?status=todo&assigneeId=user-2",
+    );
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: "org-1",
+          status: { in: ["todo"] },
+          assignees: { some: { userId: "user-2" } },
+        }),
+      }),
+    );
   });
 });

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -19,6 +19,9 @@ vi.mock("../src/lib/prisma.js", () => ({
       findMany: vi.fn(),
       create: vi.fn(),
     },
+    task: {
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -65,6 +68,7 @@ const mockRecurringDelete = vi.mocked(prisma.recurringMeeting.delete);
 const mockMeetingMemberFindUnique = vi.mocked(prisma.meetingMember.findUnique);
 const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
 const mockMeetingCreate = vi.mocked(prisma.meeting.create);
+const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member") {
@@ -868,5 +872,79 @@ describe("POST /recurring-meetings/:id/meetings", () => {
     });
     expect(res.status).toBe(404);
     expect(mockMeetingCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /recurring-meetings/:id/tasks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const sampleListTask = {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "資料作成",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [
+      { recurringMeeting: { id: "rmtg-1", name: "週次定例" } },
+    ],
+  };
+
+  it("定例配下のタスクを 200 で返す", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/tasks");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string }>;
+    expect(body).toHaveLength(1);
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recurringMeetings: { some: { recurringMeetingId: "rmtg-1" } },
+        }),
+      }),
+    );
+  });
+
+  it("定例不存在は 404", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/missing/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/rmtg-1/tasks");
+    expect(res.status).toBe(404);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -15,6 +15,7 @@ vi.mock("../src/lib/prisma.js", () => ({
     },
     task: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
       delete: vi.fn(),
       updateMany: vi.fn(),
@@ -72,6 +73,7 @@ const mockMembershipFindMany = vi.mocked(
 const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
 const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
 const mockTaskFindUnique = vi.mocked(prisma.task.findUnique);
+const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 function membership(role: "owner" | "admin" | "member" = "member") {
@@ -599,6 +601,78 @@ describe("PATCH /tasks/:id", () => {
 
     expect(res.status).toBe(200);
     expect(deletedAssignees).toBe(true);
+  });
+});
+
+describe("GET /tasks/me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("認証ユーザーが assignee のタスクを 200 で返す", async () => {
+    const listTask = {
+      ...sampleTask,
+      assignees: [
+        { user: { id: "user-1", name: "alice", displayName: "alice" } },
+      ],
+      recurringMeetings: [],
+    };
+    mockTaskFindMany.mockResolvedValue([listTask] as never);
+
+    const res = await app.request("/tasks/me");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("task-1");
+    // assignees 経由の where が user-1 で組まれていることを確認
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          assignees: { some: { userId: "user-1" } },
+        }),
+      }),
+    );
+  });
+
+  it("0 件は空配列で返す", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    const res = await app.request("/tasks/me");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body).toEqual([]);
+  });
+
+  it("status フィルタ（カンマ区切り）を where に反映する", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request("/tasks/me?status=todo,in_progress");
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["todo", "in_progress"] },
+        }),
+      }),
+    );
+  });
+
+  it("dueBefore / dueAfter で期間フィルタが組まれる", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request(
+      "/tasks/me?dueAfter=2026-05-01T00:00:00Z&dueBefore=2026-05-31T00:00:00Z",
+    );
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          dueDate: {
+            gte: new Date("2026-05-01T00:00:00Z"),
+            lte: new Date("2026-05-31T00:00:00Z"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("不正な status は 400", async () => {
+    const res = await app.request("/tasks/me?status=invalid_status");
+    expect(res.status).toBe(400);
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #165

## 概要・目的
* タスク管理 UI の各エントリーポイント（My タスク・組織横断・定例詳細・会議詳細）から呼び出される scoped 一覧 API を提供する
* 共通の filter / sort / serialization ロジックを `lib/task-serialization.ts` と `lib/schemas/task.ts` に集約し、4 エンドポイントが同じ規約で動作するよう揃える

## 背景
* CRUD API（PR #173 / 既マージ）の上に、フロントが叩く一覧経路が必要
* スコープと認可ルールがエンドポイントごとに異なるため、共通フィルタ + 個別の where 条件で構成する設計

## 変更内容
* **共通モジュール (新規)**
  * `apps/api/src/lib/task-serialization.ts`:
    * `taskDetailInclude`（CRUD 用、email 含む）/ `taskListInclude`（一覧用、email 除外）/ `taskListOrderBy`（dueDate ASC NULLS LAST → updatedAt DESC）/ `serializeTask`
  * `apps/api/src/lib/schemas/task.ts` に追加:
    * `taskListQuerySchema`: `status`（カンマ区切りで複数指定）/ `assigneeId` / `dueBefore` / `dueAfter`
    * `buildTaskListWhere`: フィルタを Prisma の where 句に変換するヘルパー

* **エンドポイント追加**
  * `tasks.ts`: `GET /tasks/me` — 認証ユーザーが assignee の全組織横断タスク
  * `organizations.ts`: `GET /:id/tasks` — `requireMembership` 再利用、`organizationId` スコープ
  * `recurring-meetings.ts`: `GET /:id/tasks` — `requireRecurringAccess` 再利用、中間テーブル経由 some 条件
  * `meetings.ts`: `GET /:id/tasks` — public な GET / POST は温存し、本エンドポイントのみハンドラ単位で auth を inline 適用。単発会議（`recurringMeetingId=null`）は組織判定不能のため 404 で拒否

* **テスト追加（15 件）**
  * `tasks.test.ts`: GET /tasks/me 5 件
  * `organizations.test.ts`: GET /:id/tasks 3 件
  * `recurring-meetings.test.ts`: GET /:id/tasks 3 件
  * `meetings.test.ts`: GET /:id/tasks 4 件
  * 既存 165 件は green を維持

## 動作確認手順
1. `git checkout issue-165-task-list-api`
2. `make install`（依存関係セットアップ）
3. `make dev` で全サービス起動、`make migrate-status` で `Database schema is up to date!` を確認
4. `make test` で 全テスト pass（API 13 ファイル / 180 件、うち本 PR で 15 件追加）を確認
5. `make lint` で警告ゼロを確認
6. API 動作確認（curl 例、`<token>` は fake-auth で発行）:
   - `curl 'http://localhost:3001/tasks/me?status=todo,in_progress' -H 'Authorization: Bearer <token>'`
   - `curl 'http://localhost:3001/organizations/<orgId>/tasks?assigneeId=<userId>' -H 'Authorization: Bearer <token>'`
   - `curl 'http://localhost:3001/recurring-meetings/<rmId>/tasks?dueBefore=2026-06-30T23:59:59Z' -H 'Authorization: Bearer <token>'`
   - `curl 'http://localhost:3001/meetings/<meetingId>/tasks' -H 'Authorization: Bearer <token>'`

## スクリーンショット
API レスポンス例（200 OK、配列、各要素は detail と同形で email を除外）:
```json
[
  {
    "id": "ckxx...",
    "organizationId": "<orgId>",
    "originMeetingId": "<meetingId>",
    "title": "資料作成",
    "status": "todo",
    "priority": "required",
    "dueDate": "2026-06-15T00:00:00.000Z",
    "version": 1,
    "assignees": [
      { "id": "<userId>", "name": "alice", "displayName": "alice" }
    ],
    "recurringMeetings": [{ "id": "<rmId>", "name": "週次定例" }],
    "originMeeting": {
      "id": "<meetingId>",
      "title": "第3回",
      "heldAt": "2026-05-17T01:00:00.000Z",
      "recurringMeetingId": "<rmId>"
    },
    "organization": { "id": "<orgId>", "name": "ACME" }
  }
]
```

不正クエリ（例: `?status=invalid`）の応答（400）:
```json
{ "success": false, "error": { ... } }
```

## 補足
* `taskListInclude` は detail と異なり `assignees.user.email` を返さない（issue 要件: id/name/displayName のみ）
* 並び順は固定（dueDate ASC NULLS LAST → updatedAt DESC）。カスタマイズは MVP スコープ外
* ページネーションなし。全件返却（規模次第で後続 Issue で対応）
* `meetings.ts` 既存の GET / POST は public のまま温存。新規 `/:id/tasks` のみ auth 適用