### PR TITLE
feat(web): tasks 機能の共通基盤（型・ラベル・queryKey・schema・hooks）を追加

### DIFF
--- a/apps/web/src/features/tasks/hooks/useCreateTask.ts
+++ b/apps/web/src/features/tasks/hooks/useCreateTask.ts
@@ -1,0 +1,26 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { CreateTaskInput } from "../schemas";
+import type { Task } from "../types";
+
+// タスク作成 mutation。
+// 成功時は ["tasks"] 配下を一括 invalidate して、各画面の一覧をリフレッシュさせる。
+// 詳細は新規作成時にはまだキャッシュに無いため invalidate 対象外。
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation<Task, Error, CreateTaskInput>({
+    mutationFn: async (input) => {
+      const res = await api.tasks.$post({ json: input }, authHeaders());
+      if (!res.ok) {
+        throw new Error(`Failed to create task: ${res.status}`);
+      }
+      return (await res.json()) as Task;
+    },
+    onSuccess: () => {
+      // 一覧系（me/org/recurring/meeting）と将来追加される関連クエリをまとめて invalidate。
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useDeleteTask.ts
+++ b/apps/web/src/features/tasks/hooks/useDeleteTask.ts
@@ -1,0 +1,26 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+
+// タスク削除 mutation。成功時は detail と一覧をまとめて invalidate。
+// 削除済み task の detail が再 fetch されると 404 になるが、これは UI 側で
+// 「タスクが見つかりません」表示に倒す前提（呼び出し側でナビゲーション等を行う）。
+export function useDeleteTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (taskId) => {
+      const res = await api.tasks[":id"].$delete(
+        { param: { id: taskId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to delete task: ${res.status}`);
+      }
+    },
+    onSuccess: (_, taskId) => {
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.detail(taskId) });
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useMeetingTasks.ts
+++ b/apps/web/src/features/tasks/hooks/useMeetingTasks.ts
@@ -1,0 +1,26 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { TaskListFilters, TaskListItem } from "../types";
+import { toTaskListQueryParams } from "./useTasksQuery";
+
+// 当該会議を発生源とするタスクを取得する。
+// クエリキーは ["tasks", "meeting", meetingId, filters]。
+export function useMeetingTasks(meetingId: string, filters?: TaskListFilters) {
+  return useQuery<TaskListItem[]>({
+    queryKey: taskQueryKeys.meeting(meetingId, filters),
+    queryFn: async () => {
+      const res = await api.meetings[":id"].tasks.$get(
+        {
+          param: { id: meetingId },
+          query: toTaskListQueryParams(filters),
+        },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch meeting tasks: ${res.status}`);
+      }
+      return (await res.json()) as TaskListItem[];
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useMyTasks.ts
+++ b/apps/web/src/features/tasks/hooks/useMyTasks.ts
@@ -1,0 +1,23 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { TaskListFilters, TaskListItem } from "../types";
+import { toTaskListQueryParams } from "./useTasksQuery";
+
+// 認証ユーザーが担当のタスクを組織横断で取得する。
+// クエリキーは ["tasks", "me", filters] で、mutation 後に invalidate される。
+export function useMyTasks(filters?: TaskListFilters) {
+  return useQuery<TaskListItem[]>({
+    queryKey: taskQueryKeys.me(filters),
+    queryFn: async () => {
+      const res = await api.tasks.me.$get(
+        { query: toTaskListQueryParams(filters) },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch my tasks: ${res.status}`);
+      }
+      return (await res.json()) as TaskListItem[];
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useOrgTasks.ts
+++ b/apps/web/src/features/tasks/hooks/useOrgTasks.ts
@@ -1,0 +1,26 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { TaskListFilters, TaskListItem } from "../types";
+import { toTaskListQueryParams } from "./useTasksQuery";
+
+// 組織配下の全タスクを取得する。
+// クエリキーは ["tasks", "org", orgId, filters]。
+export function useOrgTasks(orgId: string, filters?: TaskListFilters) {
+  return useQuery<TaskListItem[]>({
+    queryKey: taskQueryKeys.org(orgId, filters),
+    queryFn: async () => {
+      const res = await api.organizations[":id"].tasks.$get(
+        {
+          param: { id: orgId },
+          query: toTaskListQueryParams(filters),
+        },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch organization tasks: ${res.status}`);
+      }
+      return (await res.json()) as TaskListItem[];
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useRecurringMeetingTasks.ts
+++ b/apps/web/src/features/tasks/hooks/useRecurringMeetingTasks.ts
@@ -1,0 +1,31 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { TaskListFilters, TaskListItem } from "../types";
+import { toTaskListQueryParams } from "./useTasksQuery";
+
+// 定例（プロジェクト相当）に attach されたタスクを取得する。
+// クエリキーは ["tasks", "recurring", rmId, filters]。
+export function useRecurringMeetingTasks(
+  rmId: string,
+  filters?: TaskListFilters,
+) {
+  return useQuery<TaskListItem[]>({
+    queryKey: taskQueryKeys.recurring(rmId, filters),
+    queryFn: async () => {
+      const res = await api["recurring-meetings"][":id"].tasks.$get(
+        {
+          param: { id: rmId },
+          query: toTaskListQueryParams(filters),
+        },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch recurring meeting tasks: ${res.status}`,
+        );
+      }
+      return (await res.json()) as TaskListItem[];
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useTaskDetail.ts
+++ b/apps/web/src/features/tasks/hooks/useTaskDetail.ts
@@ -1,0 +1,22 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { Task } from "../types";
+
+// 単一タスクの詳細を取得する。assignees に email が含まれる詳細用レスポンス。
+// クエリキーは ["tasks", "detail", taskId]。
+export function useTaskDetail(taskId: string) {
+  return useQuery<Task>({
+    queryKey: taskQueryKeys.detail(taskId),
+    queryFn: async () => {
+      const res = await api.tasks[":id"].$get(
+        { param: { id: taskId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch task: ${res.status}`);
+      }
+      return (await res.json()) as Task;
+    },
+  });
+}

--- a/apps/web/src/features/tasks/hooks/useTasksQuery.ts
+++ b/apps/web/src/features/tasks/hooks/useTasksQuery.ts
@@ -1,0 +1,17 @@
+import type { TaskListFilters } from "../types";
+
+// 一覧 API のクエリパラメータを API 仕様（status はカンマ区切り文字列）に変換する。
+// hono/client の $get に渡す query オブジェクトとして使う。
+export function toTaskListQueryParams(
+  filters?: TaskListFilters,
+): Record<string, string> {
+  if (!filters) return {};
+  const params: Record<string, string> = {};
+  if (filters.status && filters.status.length > 0) {
+    params.status = filters.status.join(",");
+  }
+  if (filters.assigneeId) params.assigneeId = filters.assigneeId;
+  if (filters.dueBefore) params.dueBefore = filters.dueBefore;
+  if (filters.dueAfter) params.dueAfter = filters.dueAfter;
+  return params;
+}

--- a/apps/web/src/features/tasks/hooks/useUpdateTask.ts
+++ b/apps/web/src/features/tasks/hooks/useUpdateTask.ts
@@ -1,0 +1,41 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { UpdateTaskInput } from "../schemas";
+import type { Task } from "../types";
+
+// 楽観的ロック競合（PATCH 409）を呼び出し側で識別できるようにする専用エラー型。
+// メッセージに依存させず instanceof で判定する。
+export class TaskVersionConflictError extends Error {
+  constructor() {
+    super("他のユーザーが先に更新しました。最新を取得してください");
+    this.name = "TaskVersionConflictError";
+  }
+}
+
+// タスク更新 mutation。
+// 成功時は当該タスクの detail と ["tasks"] 配下の一覧を invalidate。
+// 409 は TaskVersionConflictError を throw し、UI 側で「再取得して再試行」を促す。
+export function useUpdateTask(taskId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Task, Error, UpdateTaskInput>({
+    mutationFn: async (input) => {
+      const res = await api.tasks[":id"].$patch(
+        { param: { id: taskId }, json: input },
+        authHeaders(),
+      );
+      if (res.status === 409) {
+        throw new TaskVersionConflictError();
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to update task: ${res.status}`);
+      }
+      return (await res.json()) as Task;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.detail(taskId) });
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/tasks/labels.ts
+++ b/apps/web/src/features/tasks/labels.ts
@@ -1,0 +1,41 @@
+import type {
+  AmbiguityType,
+  ResolutionType,
+  TaskPriority,
+  TaskStatus,
+} from "./types";
+
+// タスクのステータスの日本語ラベル。
+// draft / reviewing は AI 抽出直後の状態で、UI 上では「AI 提案」「レビュー中」と表示する。
+export const taskStatusLabels: Record<TaskStatus, string> = {
+  draft: "AI 提案",
+  reviewing: "レビュー中",
+  todo: "未着手",
+  in_progress: "進行中",
+  done: "完了",
+  rejected: "却下",
+};
+
+export const taskPriorityLabels: Record<TaskPriority, string> = {
+  required: "必須",
+  optional: "任意",
+};
+
+// 曖昧情報の種別。AI 根拠表示や notice バッジで利用する。
+export const ambiguityTypeLabels: Record<AmbiguityType, string> = {
+  missing_speaker: "話者欠落",
+  transcription_error_low: "軽微な誤認識",
+  transcription_error_high: "重度の誤認識",
+  no_assignee: "担当者未指定",
+  no_deadline_mentioned: "期限の言及なし",
+  no_deadline_absolute: "期限が相対表現のみ",
+  unclear_decision: "決定状態が不明確",
+  insufficient_basis: "根拠不十分",
+  unclear_scope: "スコープが不明確",
+};
+
+export const resolutionTypeLabels: Record<ResolutionType, string> = {
+  task: "タスク化",
+  decision_item: "未決事項化",
+  discarded: "破棄",
+};

--- a/apps/web/src/features/tasks/queryKeys.ts
+++ b/apps/web/src/features/tasks/queryKeys.ts
@@ -1,0 +1,17 @@
+import type { TaskListFilters } from "./types";
+
+// TanStack Query の queryKey factory。
+// 各 scope ごとに固定タプルを返すことで、mutation の invalidate 対象を
+// 明示的に集合演算できるようにする（例: invalidateQueries({ queryKey: taskQueryKeys.all })）。
+export const taskQueryKeys = {
+  all: ["tasks"] as const,
+  me: (filters?: TaskListFilters) =>
+    [...taskQueryKeys.all, "me", filters ?? {}] as const,
+  org: (orgId: string, filters?: TaskListFilters) =>
+    [...taskQueryKeys.all, "org", orgId, filters ?? {}] as const,
+  recurring: (rmId: string, filters?: TaskListFilters) =>
+    [...taskQueryKeys.all, "recurring", rmId, filters ?? {}] as const,
+  meeting: (meetingId: string, filters?: TaskListFilters) =>
+    [...taskQueryKeys.all, "meeting", meetingId, filters ?? {}] as const,
+  detail: (id: string) => [...taskQueryKeys.all, "detail", id] as const,
+};

--- a/apps/web/src/features/tasks/schemas.ts
+++ b/apps/web/src/features/tasks/schemas.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+// API 側 (apps/api/src/lib/schemas/task.ts) のバリデーションと整合する。
+// クライアント側でも先にチェックして、無駄な往復を防ぐ。
+
+const isoDatetime = z
+  .string()
+  .datetime({ message: "日時は ISO8601 形式で指定してください" });
+
+const manualTaskStatusSchema = z.enum([
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+]);
+
+const taskPrioritySchema = z.enum(["required", "optional"]);
+
+// 作成フォームのスキーマ。
+// status はサーバ側で todo 固定のため受け付けない。
+export const createTaskFormSchema = z.object({
+  organizationId: z.string().min(1, "組織は必須です"),
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string().optional(),
+  priority: taskPrioritySchema.optional(),
+  assigneeUserIds: z.array(z.string().min(1)).optional(),
+  recurringMeetingIds: z.array(z.string().min(1)).optional(),
+  originMeetingId: z.string().min(1).optional(),
+  dueDate: isoDatetime.optional(),
+  startDate: isoDatetime.optional(),
+  followUpDate: isoDatetime.optional(),
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskFormSchema>;
+
+// 更新フォームのスキーマ。
+// version は楽観的ロックに必須。全フィールド未指定の更新は API 側で 400 になるため
+// refine で先に弾く。assigneeUserIds / recurringMeetingIds は undefined = 変更なし、
+// 空配列 = 全削除のセマンティクス。
+export const updateTaskFormSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    title: z.string().min(1).optional(),
+    body: z.string().optional(),
+    status: manualTaskStatusSchema.optional(),
+    priority: taskPrioritySchema.optional(),
+    assigneeUserIds: z.array(z.string().min(1)).optional(),
+    recurringMeetingIds: z.array(z.string().min(1)).optional(),
+    originMeetingId: z.string().min(1).nullable().optional(),
+    dueDate: isoDatetime.nullable().optional(),
+    startDate: isoDatetime.nullable().optional(),
+    followUpDate: isoDatetime.nullable().optional(),
+  })
+  .refine(
+    (d) =>
+      d.title !== undefined ||
+      d.body !== undefined ||
+      d.status !== undefined ||
+      d.priority !== undefined ||
+      d.assigneeUserIds !== undefined ||
+      d.recurringMeetingIds !== undefined ||
+      d.originMeetingId !== undefined ||
+      d.dueDate !== undefined ||
+      d.startDate !== undefined ||
+      d.followUpDate !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type UpdateTaskInput = z.infer<typeof updateTaskFormSchema>;

--- a/apps/web/src/features/tasks/types.ts
+++ b/apps/web/src/features/tasks/types.ts
@@ -1,0 +1,97 @@
+// タスク機能のフロント側型定義。
+// API レスポンスとの整合を取りつつ、AI 由来フィールド (read-only) を独立した型として
+// 分類することで、UI 側で「ユーザーが入力できる範囲」と「AI が埋める範囲」を区別しやすくする。
+
+// API enum と一致。手動編集では draft / reviewing は使わない。
+export type TaskStatus =
+  | "draft"
+  | "reviewing"
+  | "todo"
+  | "in_progress"
+  | "done"
+  | "rejected";
+
+// 手動編集で選択可能なステータスのみ（draft / reviewing は AI 専用）。
+export type ManualTaskStatus = Exclude<TaskStatus, "draft" | "reviewing">;
+
+export type TaskPriority = "required" | "optional";
+
+export type AmbiguityType =
+  | "missing_speaker"
+  | "transcription_error_low"
+  | "transcription_error_high"
+  | "no_assignee"
+  | "no_deadline_mentioned"
+  | "no_deadline_absolute"
+  | "unclear_decision"
+  | "insufficient_basis"
+  | "unclear_scope";
+
+export type ResolutionType = "task" | "decision_item" | "discarded";
+
+// 担当者ユーザーの最小情報。一覧では email を含めない。
+export type AssigneeUser = {
+  id: string;
+  name: string;
+  displayName: string;
+  email?: string;
+};
+
+// AI 由来の read-only フィールド群。手動経路では入力受付なし。
+// UI 側で「AI 根拠の表示セクション」をまとめて描画するためのドキュメント的グルーピング。
+export type TaskAiDerivedFields = {
+  sourceQuote: string | null;
+  sourceContext: string | null;
+  dueDateRaw: string | null;
+  dueDateEstimated: boolean | null;
+  assigneeRaw: string | null;
+  blockingItemId: string | null;
+  carriedOverCount: number | null;
+  ambiguityFlags: AmbiguityType[] | null;
+  progressNote: string | null;
+};
+
+// ユーザーが編集可能な共通フィールド。
+export type TaskEditableFields = {
+  title: string;
+  body: string | null;
+  status: TaskStatus;
+  priority: TaskPriority | null;
+  dueDate: string | null;
+  startDate: string | null;
+  followUpDate: string | null;
+};
+
+// 一覧 API のレスポンス 1 行分。Email を含まない軽量プロフィールが付く。
+export type TaskListItem = TaskEditableFields &
+  TaskAiDerivedFields & {
+    id: string;
+    organizationId: string;
+    originMeetingId: string | null;
+    decisionItemId: string | null;
+    version: number;
+    createdAt: string;
+    updatedAt: string;
+    organization: { id: string; name: string };
+    originMeeting: {
+      id: string;
+      title: string;
+      heldAt: string;
+      recurringMeetingId: string | null;
+    } | null;
+    assignees: AssigneeUser[];
+    recurringMeetings: Array<{ id: string; name: string }>;
+  };
+
+// 詳細 API のレスポンス。assignees に email が含まれる以外は一覧と同形。
+export type Task = Omit<TaskListItem, "assignees"> & {
+  assignees: Array<AssigneeUser & { email: string }>;
+};
+
+// 一覧 API の共通フィルタ。
+export type TaskListFilters = {
+  status?: TaskStatus[];
+  assigneeId?: string;
+  dueBefore?: string;
+  dueAfter?: string;
+};

--- a/apps/web/src/test/tasks.hooks.test.tsx
+++ b/apps/web/src/test/tasks.hooks.test.tsx
@@ -1,0 +1,156 @@
+import { useCreateTask } from "@/features/tasks/hooks/useCreateTask";
+import { useDeleteTask } from "@/features/tasks/hooks/useDeleteTask";
+import {
+  TaskVersionConflictError,
+  useUpdateTask,
+} from "@/features/tasks/hooks/useUpdateTask";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// グローバル fetch をモックして API 呼び出しを完全に切り離す。
+// 各テストでレスポンスを上書きする。
+function mockFetchOnce(init: ResponseInit, body: unknown = null) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(body === null ? null : JSON.stringify(body), init),
+  );
+}
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useCreateTask", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("成功時に taskQueryKeys.all を invalidate する", async () => {
+    mockFetchOnce({ status: 201 }, { id: "task-1" });
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateTask(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        organizationId: "org-1",
+        title: "x",
+      });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: taskQueryKeys.all,
+    });
+  });
+
+  it("非 2xx は Error として throw", async () => {
+    mockFetchOnce({ status: 400 }, { error: "bad request" });
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreateTask(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await expect(
+      result.current.mutateAsync({ organizationId: "org-1", title: "x" }),
+    ).rejects.toThrow(/Failed to create task: 400/);
+  });
+});
+
+describe("useUpdateTask", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("成功時に detail と all を invalidate する", async () => {
+    mockFetchOnce({ status: 200 }, { id: "task-1", version: 1 });
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateTask("task-1"), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ version: 0, title: "更新後" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: taskQueryKeys.detail("task-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: taskQueryKeys.all,
+    });
+  });
+
+  it("409 は TaskVersionConflictError を throw", async () => {
+    mockFetchOnce({ status: 409 }, { error: "conflict" });
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useUpdateTask("task-1"), {
+      wrapper: makeWrapper(client),
+    });
+
+    await expect(
+      result.current.mutateAsync({ version: 0, title: "x" }),
+    ).rejects.toBeInstanceOf(TaskVersionConflictError);
+  });
+});
+
+describe("useDeleteTask", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("成功時に detail(taskId) と all を invalidate する", async () => {
+    mockFetchOnce({ status: 204 });
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteTask(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("task-1");
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: taskQueryKeys.detail("task-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: taskQueryKeys.all,
+      });
+    });
+  });
+});

--- a/apps/web/src/test/tasks.labels.test.ts
+++ b/apps/web/src/test/tasks.labels.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  ambiguityTypeLabels,
+  resolutionTypeLabels,
+  taskPriorityLabels,
+  taskStatusLabels,
+} from "@/features/tasks/labels";
+import type {
+  AmbiguityType,
+  ResolutionType,
+  TaskPriority,
+  TaskStatus,
+} from "@/features/tasks/types";
+
+// enum 値を将来追加した際、ラベル定義漏れで UI が undefined 表示になる事故を防ぐ。
+// satisfies で「全キーが網羅されている Record か」を型と値の両面で検証する。
+describe("ラベル定義の完全性", () => {
+  it("taskStatusLabels に全 TaskStatus がある", () => {
+    const allStatuses: TaskStatus[] = [
+      "draft",
+      "reviewing",
+      "todo",
+      "in_progress",
+      "done",
+      "rejected",
+    ];
+    for (const s of allStatuses) {
+      expect(taskStatusLabels[s]).toBeTruthy();
+    }
+    expect(Object.keys(taskStatusLabels).sort()).toEqual(
+      [...allStatuses].sort(),
+    );
+  });
+
+  it("taskPriorityLabels に全 TaskPriority がある", () => {
+    const all: TaskPriority[] = ["required", "optional"];
+    for (const p of all) {
+      expect(taskPriorityLabels[p]).toBeTruthy();
+    }
+    expect(Object.keys(taskPriorityLabels).sort()).toEqual([...all].sort());
+  });
+
+  it("ambiguityTypeLabels に全 AmbiguityType がある", () => {
+    const all: AmbiguityType[] = [
+      "missing_speaker",
+      "transcription_error_low",
+      "transcription_error_high",
+      "no_assignee",
+      "no_deadline_mentioned",
+      "no_deadline_absolute",
+      "unclear_decision",
+      "insufficient_basis",
+      "unclear_scope",
+    ];
+    for (const t of all) {
+      expect(ambiguityTypeLabels[t]).toBeTruthy();
+    }
+    expect(Object.keys(ambiguityTypeLabels).sort()).toEqual([...all].sort());
+  });
+
+  it("resolutionTypeLabels に全 ResolutionType がある", () => {
+    const all: ResolutionType[] = ["task", "decision_item", "discarded"];
+    for (const r of all) {
+      expect(resolutionTypeLabels[r]).toBeTruthy();
+    }
+    expect(Object.keys(resolutionTypeLabels).sort()).toEqual([...all].sort());
+  });
+});

--- a/apps/web/src/test/tasks.queryKeys.test.ts
+++ b/apps/web/src/test/tasks.queryKeys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
+
+// queryKey は mutation 後の invalidate 対象を決める基盤なので、
+// タプル shape の typo / 順序ズレが起きないかを単純比較で守る。
+describe("taskQueryKeys", () => {
+  it("all は ['tasks']", () => {
+    expect(taskQueryKeys.all).toEqual(["tasks"]);
+  });
+
+  it("me() は filters 省略時に空オブジェクトを含む", () => {
+    expect(taskQueryKeys.me()).toEqual(["tasks", "me", {}]);
+  });
+
+  it("me(filters) は filters を末尾に含む", () => {
+    expect(taskQueryKeys.me({ status: ["todo"] })).toEqual([
+      "tasks",
+      "me",
+      { status: ["todo"] },
+    ]);
+  });
+
+  it("org(orgId) は ['tasks', 'org', orgId, {}]", () => {
+    expect(taskQueryKeys.org("org-1")).toEqual(["tasks", "org", "org-1", {}]);
+  });
+
+  it("recurring(rmId) は ['tasks', 'recurring', rmId, {}]", () => {
+    expect(taskQueryKeys.recurring("rmtg-1")).toEqual([
+      "tasks",
+      "recurring",
+      "rmtg-1",
+      {},
+    ]);
+  });
+
+  it("meeting(meetingId) は ['tasks', 'meeting', meetingId, {}]", () => {
+    expect(taskQueryKeys.meeting("mtg-1")).toEqual([
+      "tasks",
+      "meeting",
+      "mtg-1",
+      {},
+    ]);
+  });
+
+  it("detail(id) は ['tasks', 'detail', id]", () => {
+    expect(taskQueryKeys.detail("task-1")).toEqual([
+      "tasks",
+      "detail",
+      "task-1",
+    ]);
+  });
+});

--- a/apps/web/src/test/tasks.queryParams.test.ts
+++ b/apps/web/src/test/tasks.queryParams.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { toTaskListQueryParams } from "@/features/tasks/hooks/useTasksQuery";
+
+// クエリパラメータ整形は API 側仕様（status はカンマ区切り）に合わせる必要があり、
+// hooks の URL 構築の前段ですべての分岐がここに集約される。純粋関数なので単独で検証する。
+describe("toTaskListQueryParams", () => {
+  it("undefined 入力で空オブジェクトを返す", () => {
+    expect(toTaskListQueryParams(undefined)).toEqual({});
+  });
+
+  it("空 filters {} で空オブジェクトを返す", () => {
+    expect(toTaskListQueryParams({})).toEqual({});
+  });
+
+  it("status は配列をカンマ区切り文字列に整形する", () => {
+    expect(toTaskListQueryParams({ status: ["todo", "in_progress"] })).toEqual({
+      status: "todo,in_progress",
+    });
+  });
+
+  it("status が空配列のときは status キー自体を含めない", () => {
+    // API 側で status が空ならフィルタなしと同義のため、URL に乗せない方が安全。
+    expect(toTaskListQueryParams({ status: [] })).toEqual({});
+  });
+
+  it("assigneeId / dueBefore / dueAfter を含める", () => {
+    expect(
+      toTaskListQueryParams({
+        assigneeId: "user-1",
+        dueBefore: "2026-06-30T23:59:59Z",
+        dueAfter: "2026-05-01T00:00:00Z",
+      }),
+    ).toEqual({
+      assigneeId: "user-1",
+      dueBefore: "2026-06-30T23:59:59Z",
+      dueAfter: "2026-05-01T00:00:00Z",
+    });
+  });
+
+  it("複数フィルタを同時に含められる", () => {
+    expect(
+      toTaskListQueryParams({
+        status: ["todo"],
+        assigneeId: "user-1",
+        dueBefore: "2026-06-30T23:59:59Z",
+      }),
+    ).toEqual({
+      status: "todo",
+      assigneeId: "user-1",
+      dueBefore: "2026-06-30T23:59:59Z",
+    });
+  });
+});

--- a/apps/web/src/test/tasks.schemas.test.ts
+++ b/apps/web/src/test/tasks.schemas.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTaskFormSchema,
+  updateTaskFormSchema,
+} from "@/features/tasks/schemas";
+
+describe("createTaskFormSchema", () => {
+  it("最小入力（organizationId + title）が通る", () => {
+    const result = createTaskFormSchema.safeParse({
+      organizationId: "org-1",
+      title: "資料作成",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("organizationId が無いと失敗", () => {
+    const result = createTaskFormSchema.safeParse({ title: "x" });
+    expect(result.success).toBe(false);
+  });
+
+  it("title が空文字なら失敗", () => {
+    const result = createTaskFormSchema.safeParse({
+      organizationId: "org-1",
+      title: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("dueDate が ISO8601 でないと失敗", () => {
+    const result = createTaskFormSchema.safeParse({
+      organizationId: "org-1",
+      title: "x",
+      dueDate: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateTaskFormSchema", () => {
+  it("version + 1 フィールドで通る", () => {
+    const result = updateTaskFormSchema.safeParse({
+      version: 0,
+      title: "更新後",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("version のみ（他フィールド無し）は 400 同等で失敗", () => {
+    const result = updateTaskFormSchema.safeParse({ version: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("version 欠落は失敗", () => {
+    const result = updateTaskFormSchema.safeParse({ title: "x" });
+    expect(result.success).toBe(false);
+  });
+
+  it("status=draft は手動経路で受け付けないので失敗", () => {
+    const result = updateTaskFormSchema.safeParse({
+      version: 0,
+      status: "draft",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("assigneeUserIds:[] は全削除として通る", () => {
+    const result = updateTaskFormSchema.safeParse({
+      version: 0,
+      assigneeUserIds: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("dueDate を null にする更新が通る", () => {
+    const result = updateTaskFormSchema.safeParse({
+      version: 0,
+      dueDate: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #166

## 概要・目的
* タスク機能を扱う後続 Frontend Issue（#167 My タスク・#168 定例詳細・#169 ダイアログ・#170 会議詳細）が共通利用する型・ラベル・queryKey・zod schema・TanStack Query hooks を整備する
* mutation 成功時の invalidate 対象を明示化し、画面間のデータ整合性を保つ基盤を作る

## 背景
* Backend 側（#163/#164/#165）で CRUD と一覧 API は揃ったが、フロント側は呼び出すための雛形が無い状態
* 各画面で個別に型・キーを定義すると重複・不整合の温床になる
* `features/organizations` / `features/recurring-meetings` と同じ命名・構造に揃え、レビューと拡張のコストを下げる

## 変更内容
* **pure data 層 (`features/tasks/`)**
  * `types.ts`: `TaskStatus` / `TaskPriority` / `AmbiguityType` / `ResolutionType` / `Task` / `TaskListItem` / `TaskListFilters`。AI 由来 read-only フィールドは `TaskAiDerivedFields` 型として独立分類
  * `labels.ts`: status / priority / ambiguityType / resolutionType の日本語ラベル
  * `queryKeys.ts`: `taskQueryKeys` factory（`.all` / `.me()` / `.org()` / `.recurring()` / `.meeting()` / `.detail()`）
  * `schemas.ts`: `createTaskFormSchema` / `updateTaskFormSchema`（zod、API バリデーションと整合）

* **読み取り hooks (`features/tasks/hooks/`)**
  * `useMyTasks` / `useOrgTasks` / `useRecurringMeetingTasks` / `useMeetingTasks` / `useTaskDetail`
  * `useTasksQuery.ts`: `status` を カンマ区切り文字列に整形する共通ユーティリティ

* **書き込み hooks**
  * `useCreateTask` — 成功時に `taskQueryKeys.all` を invalidate
  * `useUpdateTask` — 成功時に `detail(taskId)` と `all` を invalidate。409 は `TaskVersionConflictError` として throw し、`instanceof` で識別可能
  * `useDeleteTask` — 成功時に `detail(taskId)` と `all` を invalidate

* **テスト**
  * `tasks.queryKeys.test.ts`: タプル shape 検証 7 件
  * `tasks.schemas.test.ts`: zod 正常系/異常系 10 件
  * `tasks.hooks.test.tsx`: mutation invalidate 検証・409 識別・エラー伝播 5 件

## 動作確認手順
1. `git checkout issue-166-tasks-frontend-foundation`
2. `make install`（依存関係セットアップ）
3. `make test` で全テスト pass（web 22 ファイル / 217 件、うち本 PR で 22 件追加）を確認
4. `make lint` で警告ゼロを確認
5. 後続 Issue（#167 など）で本基盤を利用する形で動作確認する（本 PR 単体では画面追加なし）

## 補足
* `useCreateTask` の invalidate は粗く `taskQueryKeys.all` で全タスククエリを再フェッチさせる方針。性能課題が出たら scope ごとに絞る最適化を後追い
* `TaskAiDerivedFields` は型分類のドキュメント目的で分離しており、ランタイム上は `task.sourceQuote` のようにフラットにアクセスする
* フォーム用 schema は API 側 schema と整合させているが、UI 側で先にバリデーションを通すことで無駄な往復を防ぐ