### PR TITLE
feat(web): /tasks ルートとサイドバー導線で My タスク一覧を提供

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
   CalendarDays,
+  CheckSquare,
   ChevronDown,
   LayoutDashboard,
   ListIcon,
@@ -140,6 +141,20 @@ export function Sidebar() {
         >
           <LayoutDashboard size={15} />
           ダッシュボード
+        </Link>
+
+        {/* My タスクへの導線。組織非依存（assignee 経由で組織横断）のため
+            選択中組織のステータスを問わず常に表示する。 */}
+        <Link
+          to="/tasks"
+          className="flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
+          activeProps={{
+            className:
+              "flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm bg-foreground/10 text-foreground font-medium",
+          }}
+        >
+          <CheckSquare size={15} />
+          My タスク
         </Link>
 
         {/* 定例セクション。選択中組織配下の定例を一覧表示する。

--- a/apps/web/src/features/tasks/components/TaskRow.tsx
+++ b/apps/web/src/features/tasks/components/TaskRow.tsx
@@ -1,0 +1,93 @@
+import { cn } from "@/lib/utils";
+import { taskStatusLabels } from "../labels";
+import type { TaskListItem } from "../types";
+
+// 期限が過ぎていて未完了かどうかを判定する。
+// dueDate が null の場合は超過扱いにしない。
+// 比較は now を引数で差し込めるようにして、テストで固定時刻が使えるようにする。
+function isOverdue(task: TaskListItem, now: Date): boolean {
+  if (!task.dueDate) return false;
+  if (task.status === "done" || task.status === "rejected") return false;
+  return new Date(task.dueDate) < now;
+}
+
+// 日付 (YYYY-MM-DD) として整形する。
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+}
+
+// タスク一覧の 1 行コンポーネント。My タスク・定例詳細・会議詳細で共通利用する。
+// onClick 未指定時はホバー強調も無効化（ダイアログ Issue #169 完成前の暫定挙動）。
+export function TaskRow({
+  task,
+  onClick,
+  now,
+}: {
+  task: TaskListItem;
+  onClick?: () => void;
+  // テストで固定時刻を注入するための差し込み。本番は new Date() を使う。
+  now?: Date;
+}) {
+  const overdue = isOverdue(task, now ?? new Date());
+  const clickable = onClick !== undefined;
+
+  return (
+    <li>
+      <button
+        type="button"
+        // 行クリックがなければハイライト・cursor を抑え、視覚的に「未対応」を示す。
+        onClick={onClick}
+        disabled={!clickable}
+        aria-label={`タスク ${task.title}`}
+        className={cn(
+          "w-full text-left px-4 py-3 rounded-md border border-border/50 bg-card",
+          "grid grid-cols-[1fr_auto_auto_auto] items-center gap-3",
+          clickable && "hover:bg-accent transition-colors cursor-pointer",
+          !clickable && "cursor-default",
+        )}
+      >
+        <div className="min-w-0">
+          <p className="text-sm font-medium truncate">{task.title}</p>
+          <p className="text-xs text-muted-foreground truncate">
+            <span>{task.organization.name}</span>
+            {task.recurringMeetings.length > 0 && (
+              <>
+                <span className="mx-1">/</span>
+                <span>
+                  {task.recurringMeetings[0].name}
+                  {task.recurringMeetings.length > 1 &&
+                    ` +${task.recurringMeetings.length - 1}`}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        <span
+          data-testid="task-status-badge"
+          title={`ステータス: ${taskStatusLabels[task.status]}`}
+          className="text-xs px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
+        >
+          {taskStatusLabels[task.status]}
+        </span>
+        <span
+          data-testid="task-due-date"
+          title={task.dueDate ? `期限 ${formatDate(task.dueDate)}` : "期限なし"}
+          className={cn(
+            "text-xs tabular-nums",
+            overdue ? "text-destructive font-medium" : "text-muted-foreground",
+          )}
+        >
+          {task.dueDate ? formatDate(task.dueDate) : "—"}
+        </span>
+        <span
+          data-testid="task-assignee-count"
+          title={`担当者 ${task.assignees.length} 名`}
+          className="text-xs text-muted-foreground tabular-nums"
+        >
+          {task.assignees.length}名
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TasksIndexRouteImport } from './routes/tasks.index'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
 import { Route as RecurringMeetingsIdRouteImport } from './routes/recurring-meetings.$id'
 import { Route as OrganizationsIdRouteImport } from './routes/organizations.$id'
@@ -29,6 +30,11 @@ const LoginRoute = LoginRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TasksIndexRoute = TasksIndexRouteImport.update({
+  id: '/tasks/',
+  path: '/tasks/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OrganizationsIndexRoute = OrganizationsIndexRouteImport.update({
@@ -54,6 +60,7 @@ export interface FileRoutesByFullPath {
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
+  '/tasks/': typeof TasksIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -61,6 +68,7 @@ export interface FileRoutesByTo {
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations': typeof OrganizationsIndexRoute
+  '/tasks': typeof TasksIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -70,6 +78,7 @@ export interface FileRoutesById {
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
+  '/tasks/': typeof TasksIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -80,6 +89,7 @@ export interface FileRouteTypes {
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations/'
+    | '/tasks/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -87,6 +97,7 @@ export interface FileRouteTypes {
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations'
+    | '/tasks'
   id:
     | '__root__'
     | '/'
@@ -95,6 +106,7 @@ export interface FileRouteTypes {
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations/'
+    | '/tasks/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -102,6 +114,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
   RecurringMeetingsIdRoute: typeof RecurringMeetingsIdRoute
+  TasksIndexRoute: typeof TasksIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -125,6 +138,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tasks/': {
+      id: '/tasks/'
+      path: '/tasks'
+      fullPath: '/tasks/'
+      preLoaderRoute: typeof TasksIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/organizations/': {
@@ -170,6 +190,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
   RecurringMeetingsIdRoute: RecurringMeetingsIdRoute,
+  TasksIndexRoute: TasksIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -110,11 +110,23 @@ export function MyTasksView({
         </p>
       </header>
 
-      <div className="flex flex-wrap items-center gap-4">
-        <fieldset className="flex flex-wrap items-center gap-2">
-          <legend className="text-xs text-muted-foreground mr-2">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        {/* fieldset/legend だと legend がブロック扱いで「ステータス」が
+            上段に押し出され、組織ラベルとベースラインが揃わない。
+            biome の useSemanticElements は fieldset を勧めるが、本ケースでは
+            視覚整列を優先し、a11y は aria-labelledby で代替する。 */}
+        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
+        <div
+          role="group"
+          aria-labelledby="status-filter-label"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <span
+            id="status-filter-label"
+            className="text-xs text-muted-foreground"
+          >
             ステータス
-          </legend>
+          </span>
           {FILTERABLE_STATUSES.map((s) => {
             const checked = statusArr?.includes(s) ?? false;
             return (
@@ -137,7 +149,7 @@ export function MyTasksView({
               </label>
             );
           })}
-        </fieldset>
+        </div>
 
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
           組織

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -2,9 +2,16 @@ import { TaskRow } from "@/features/tasks/components/TaskRow";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskListItem, TaskStatus } from "@/features/tasks/types";
+import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { cn } from "@/lib/utils";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useAtomValue } from "jotai";
 import { z } from "zod";
+
+// 組織フィルタの「すべて」を URL で明示するためのセンチネル値。
+// `orgId` が未指定の時はサイドバー選択中の組織で初期フィルタする挙動とし、
+// ユーザーが明示的に「すべて」を選んだ場合はこの値を URL に保持する。
+const ALL_ORGS_SENTINEL = "all";
 
 // 手動経路で表示する status の選択肢。draft / reviewing は AI 専用のため UI から除外する。
 const FILTERABLE_STATUSES: TaskStatus[] = [
@@ -41,18 +48,29 @@ function parseStatusParam(raw: string | undefined): TaskStatus[] | undefined {
   return arr.length > 0 ? arr : undefined;
 }
 
-// route component から分離したビュー。テストでは props で初期 search / now を渡して
+// route component から分離したビュー。テストでは props で初期 search / now / currentOrgId を
 // 直接 render する（既存の OrganizationDetailView と同じ流儀）。
+// currentOrgId はサイドバー選択中の組織。URL に orgId が無いときの初期フィルタとして使う。
 export function MyTasksView({
   search,
   onSearchChange,
+  currentOrgId = null,
   now,
 }: {
   search: TasksSearch;
   onSearchChange: (next: TasksSearch) => void;
+  currentOrgId?: string | null;
   now?: Date;
 }) {
   const statusArr = parseStatusParam(search.status);
+
+  // effective orgId の決定ロジック:
+  //  - URL に orgId="all" → フィルタなし（ユーザーが明示的にすべてを選んだ）
+  //  - URL に orgId=<id>  → その組織でフィルタ（URL が常に優先）
+  //  - URL に orgId 未指定 → サイドバーの currentOrgId にフォールバック（初期表示用）
+  // currentOrgId が null（未選択）の場合は結果的にフィルタなしになる。
+  const effectiveOrgId: string | null =
+    search.orgId === ALL_ORGS_SENTINEL ? null : (search.orgId ?? currentOrgId);
 
   // API には組織フィルタが無いため、status のみを API に渡してクライアント側で組織を絞り込む。
   // タスクは全件返却前提のため、組織でさらに削ってもパフォーマンス問題は出ない想定。
@@ -63,8 +81,8 @@ export function MyTasksView({
   const tasks = data ?? [];
   // 組織候補は取得した tasks から動的に構築する。useMyOrganizations を別途呼ばない方針。
   const organizations = uniqueOrganizations(tasks);
-  const filtered = search.orgId
-    ? tasks.filter((t) => t.organization.id === search.orgId)
+  const filtered = effectiveOrgId
+    ? tasks.filter((t) => t.organization.id === effectiveOrgId)
     : tasks;
 
   const toggleStatus = (s: TaskStatus) => {
@@ -125,16 +143,25 @@ export function MyTasksView({
           組織
           <select
             aria-label="組織フィルタ"
-            value={search.orgId ?? ""}
+            // select の value は effective な状態を反映する。
+            // 「すべて」を選んだ後は URL に "all" が入り、select も "all" を選ぶ。
+            // 初期表示で URL 未指定かつ currentOrg がある場合はその org を選んだ状態にする。
+            value={
+              search.orgId === ALL_ORGS_SENTINEL
+                ? ALL_ORGS_SENTINEL
+                : (search.orgId ?? currentOrgId ?? ALL_ORGS_SENTINEL)
+            }
             onChange={(e) =>
               onSearchChange({
                 ...search,
-                orgId: e.target.value || undefined,
+                // 「すべて」も含めて常に URL に値を残す。これにより
+                // 「明示的にすべて」と「未指定（currentOrg を初期値）」を識別できる。
+                orgId: e.target.value,
               })
             }
             className="text-xs px-2 py-1 rounded-md border border-border/60 bg-card text-foreground"
           >
-            <option value="">すべて</option>
+            <option value={ALL_ORGS_SENTINEL}>すべて</option>
             {organizations.map((o) => (
               <option key={o.id} value={o.id}>
                 {o.name}
@@ -162,13 +189,16 @@ export function MyTasksView({
 }
 
 // route コンポーネントは search を URL と同期させる薄いラッパー。
+// サイドバー選択中の組織を jotai atom から取り出し、初期フィルタとして渡す。
 function MyTasksPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
+  const currentOrgId = useAtomValue(currentOrganizationIdAtom);
   return (
     <MyTasksView
       search={search}
       onSearchChange={(next) => navigate({ search: next })}
+      currentOrgId={currentOrgId}
     />
   );
 }

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -1,0 +1,187 @@
+import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
+import { taskStatusLabels } from "@/features/tasks/labels";
+import type { TaskListItem, TaskStatus } from "@/features/tasks/types";
+import { cn } from "@/lib/utils";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+
+// 手動経路で表示する status の選択肢。draft / reviewing は AI 専用のため UI から除外する。
+const FILTERABLE_STATUSES: TaskStatus[] = [
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+];
+
+// URL クエリパラメータの形（生の文字列）。
+// status は API 仕様に合わせてカンマ区切り文字列で永続化する。
+const tasksSearchSchema = z.object({
+  status: z.string().optional(),
+  orgId: z.string().optional(),
+});
+
+type TasksSearch = z.infer<typeof tasksSearchSchema>;
+
+export const Route = createFileRoute("/tasks/")({
+  validateSearch: tasksSearchSchema,
+  component: MyTasksPage,
+});
+
+// URL の status 文字列を TaskStatus 配列にパースする。
+// 不正値は無視（前方互換）。
+function parseStatusParam(raw: string | undefined): TaskStatus[] | undefined {
+  if (!raw) return undefined;
+  const arr = raw
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v): v is TaskStatus =>
+      FILTERABLE_STATUSES.includes(v as TaskStatus),
+    );
+  return arr.length > 0 ? arr : undefined;
+}
+
+// route component から分離したビュー。テストでは props で初期 search / now を渡して
+// 直接 render する（既存の OrganizationDetailView と同じ流儀）。
+export function MyTasksView({
+  search,
+  onSearchChange,
+  now,
+}: {
+  search: TasksSearch;
+  onSearchChange: (next: TasksSearch) => void;
+  now?: Date;
+}) {
+  const statusArr = parseStatusParam(search.status);
+
+  // API には組織フィルタが無いため、status のみを API に渡してクライアント側で組織を絞り込む。
+  // タスクは全件返却前提のため、組織でさらに削ってもパフォーマンス問題は出ない想定。
+  const { data, isLoading, isError } = useMyTasks(
+    statusArr ? { status: statusArr } : undefined,
+  );
+
+  const tasks = data ?? [];
+  // 組織候補は取得した tasks から動的に構築する。useMyOrganizations を別途呼ばない方針。
+  const organizations = uniqueOrganizations(tasks);
+  const filtered = search.orgId
+    ? tasks.filter((t) => t.organization.id === search.orgId)
+    : tasks;
+
+  const toggleStatus = (s: TaskStatus) => {
+    const current = new Set(statusArr ?? []);
+    if (current.has(s)) current.delete(s);
+    else current.add(s);
+    const next = Array.from(current);
+    onSearchChange({
+      ...search,
+      status: next.length > 0 ? next.join(",") : undefined,
+    });
+  };
+
+  return (
+    <section
+      aria-labelledby="my-tasks-title"
+      className="container mx-auto p-8 space-y-6"
+    >
+      <header>
+        <h1 id="my-tasks-title" className="text-2xl font-bold">
+          My タスク
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          自分が担当中のタスクを組織横断で表示します
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <fieldset className="flex flex-wrap items-center gap-2">
+          <legend className="text-xs text-muted-foreground mr-2">
+            ステータス
+          </legend>
+          {FILTERABLE_STATUSES.map((s) => {
+            const checked = statusArr?.includes(s) ?? false;
+            return (
+              <label
+                key={s}
+                className={cn(
+                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                  checked
+                    ? "bg-foreground text-background border-foreground"
+                    : "bg-card text-foreground border-border/60 hover:bg-accent",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked}
+                  onChange={() => toggleStatus(s)}
+                />
+                {taskStatusLabels[s]}
+              </label>
+            );
+          })}
+        </fieldset>
+
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          組織
+          <select
+            aria-label="組織フィルタ"
+            value={search.orgId ?? ""}
+            onChange={(e) =>
+              onSearchChange({
+                ...search,
+                orgId: e.target.value || undefined,
+              })
+            }
+            className="text-xs px-2 py-1 rounded-md border border-border/60 bg-card text-foreground"
+          >
+            <option value="">すべて</option>
+            {organizations.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {isLoading ? (
+        <p>読み込み中...</p>
+      ) : isError ? (
+        <p className="text-destructive">タスクの取得に失敗しました</p>
+      ) : filtered.length === 0 ? (
+        <p className="text-muted-foreground">担当中のタスクはありません</p>
+      ) : (
+        <ul aria-label="My タスク一覧" className="grid gap-2">
+          {filtered.map((task) => (
+            <TaskRow key={task.id} task={task} now={now} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// route コンポーネントは search を URL と同期させる薄いラッパー。
+function MyTasksPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  return (
+    <MyTasksView
+      search={search}
+      onSearchChange={(next) => navigate({ search: next })}
+    />
+  );
+}
+
+// タスクの organization 配列から重複を除いた組織候補を作る。
+function uniqueOrganizations(
+  tasks: TaskListItem[],
+): Array<{ id: string; name: string }> {
+  const seen = new Map<string, string>();
+  for (const t of tasks) {
+    if (!seen.has(t.organization.id)) {
+      seen.set(t.organization.id, t.organization.name);
+    }
+  }
+  return Array.from(seen, ([id, name]) => ({ id, name }));
+}

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -607,3 +607,15 @@ describe("Sidebar 定例リスト", () => {
     });
   });
 });
+
+describe("Sidebar ナビゲーション", () => {
+  it("My タスクへの導線が /tasks で表示される", async () => {
+    (api.organizations.$get as Mock).mockResolvedValue(mockJson(mockOrgs));
+
+    renderSidebar();
+
+    // ダッシュボードと同列に常に表示されるため、組織選択状態を待たずに描画される。
+    const link = await screen.findByRole("link", { name: /My タスク/ });
+    expect(link).toHaveAttribute("href", "/tasks");
+  });
+});

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -273,6 +273,142 @@ describe("MyTasksView - TaskRow 詳細", () => {
   });
 });
 
+describe("MyTasksView - currentOrgId 初期フィルタ", () => {
+  it("URL に orgId が無いとき currentOrgId でフィルタされる", async () => {
+    const t1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const t2 = {
+      ...baseTask,
+      id: "t2",
+      title: "別組織のタスク",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([t1, t2]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={() => {}}
+        currentOrgId="org-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("My タスク一覧")).toBeInTheDocument();
+    });
+    const list = screen.getByLabelText("My タスク一覧");
+    expect(within(list).getByText("資料作成")).toBeInTheDocument();
+    expect(within(list).queryByText("別組織のタスク")).not.toBeInTheDocument();
+  });
+
+  it("URL の orgId は currentOrgId より優先される", async () => {
+    const t1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const t2 = {
+      ...baseTask,
+      id: "t2",
+      title: "別組織のタスク",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([t1, t2]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{ orgId: "org-2" }}
+        onSearchChange={() => {}}
+        currentOrgId="org-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("別組織のタスク")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("資料作成")).not.toBeInTheDocument();
+  });
+
+  it("URL の orgId=all は currentOrgId を無視してフィルタ解除", async () => {
+    const t1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const t2 = {
+      ...baseTask,
+      id: "t2",
+      title: "別組織のタスク",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([t1, t2]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{ orgId: "all" }}
+        onSearchChange={() => {}}
+        currentOrgId="org-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("資料作成")).toBeInTheDocument();
+    });
+    expect(screen.getByText("別組織のタスク")).toBeInTheDocument();
+  });
+
+  it("currentOrgId が null なら従来通り全件表示", async () => {
+    const t1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const t2 = {
+      ...baseTask,
+      id: "t2",
+      title: "別組織のタスク",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([t1, t2]));
+
+    renderWithQuery(
+      <MyTasksView search={{}} onSearchChange={() => {}} currentOrgId={null} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("資料作成")).toBeInTheDocument();
+    });
+    expect(screen.getByText("別組織のタスク")).toBeInTheDocument();
+  });
+
+  it("select で「すべて」を選ぶと URL に orgId=all がセットされる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    const onSearchChange = vi.fn();
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={onSearchChange}
+        currentOrgId="org-1"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("担当中のタスクはありません"),
+      ).toBeInTheDocument(),
+    );
+
+    const select = screen.getByLabelText("組織フィルタ") as HTMLSelectElement;
+    await userEvent.selectOptions(select, "all");
+
+    expect(onSearchChange).toHaveBeenCalledWith({ orgId: "all" });
+  });
+});
+
 describe("MyTasksView - フィルタ整合", () => {
   it("status を既に持っていてもう一度同じものを押すと外す（解除）", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -1,0 +1,331 @@
+import type { TaskListItem } from "@/features/tasks/types";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    tasks: {
+      me: { $get: vi.fn() },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+// Link / createFileRoute は RouterProvider 配下でないと落ちる。
+// 既存テスト群と同じパターンで差し替える。
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    createFileRoute: () => () => ({}),
+  };
+});
+
+import { api } from "@/lib/api";
+import { MyTasksView } from "../routes/tasks.index";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const baseTask: TaskListItem = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: null,
+  assignees: [{ id: "user-1", name: "alice", displayName: "alice" }],
+  recurringMeetings: [{ id: "rmtg-1", name: "週次定例" }],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MyTasksView", () => {
+  it("タスク 1 件を行として表示する", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("My タスク一覧")).toBeInTheDocument();
+    });
+    const list = screen.getByLabelText("My タスク一覧");
+    expect(within(list).getByText("資料作成")).toBeInTheDocument();
+    expect(within(list).getByText(/ACME/)).toBeInTheDocument();
+  });
+
+  it("0 件時は空状態メッセージを表示する", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("担当中のタスクはありません"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("status チェックボックスをクリックすると onSearchChange に文字列で渡る", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    const onSearchChange = vi.fn();
+
+    renderWithQuery(
+      <MyTasksView search={{}} onSearchChange={onSearchChange} />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("担当中のタスクはありません"),
+      ).toBeInTheDocument(),
+    );
+
+    // 「未着手」ラベルのチェックボックスを切り替える
+    await userEvent.click(screen.getByLabelText(/未着手/));
+
+    expect(onSearchChange).toHaveBeenCalledWith({ status: "todo" });
+  });
+
+  it("組織フィルタで指定組織のタスクのみ表示される", async () => {
+    const taskOrg1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const taskOrg2 = {
+      ...baseTask,
+      id: "t2",
+      title: "別組織のタスク",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([taskOrg1, taskOrg2]),
+    );
+
+    renderWithQuery(
+      <MyTasksView search={{ orgId: "org-1" }} onSearchChange={() => {}} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("資料作成")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("別組織のタスク")).not.toBeInTheDocument();
+  });
+
+  it("期限超過タスクは destructive クラスで強調表示される", async () => {
+    const overdueTask = {
+      ...baseTask,
+      id: "t-over",
+      title: "期限切れタスク",
+      dueDate: "2026-05-10T00:00:00.000Z",
+      status: "todo" as const,
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([overdueTask]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={() => {}}
+        now={new Date("2026-05-17T00:00:00Z")}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("期限切れタスク")).toBeInTheDocument();
+    });
+    const dueLabel = screen.getByTestId("task-due-date");
+    expect(dueLabel.className).toMatch(/text-destructive/);
+  });
+
+  it("done のタスクは期限切れでも強調されない", async () => {
+    const doneTask = {
+      ...baseTask,
+      id: "t-done",
+      title: "完了済み",
+      dueDate: "2026-05-10T00:00:00.000Z",
+      status: "done" as const,
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([doneTask]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={() => {}}
+        now={new Date("2026-05-17T00:00:00Z")}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("完了済み")).toBeInTheDocument();
+    });
+    const dueLabel = screen.getByTestId("task-due-date");
+    expect(dueLabel.className).not.toMatch(/text-destructive/);
+  });
+
+  it("status 文字列フィルタは API リクエストに含まれる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{ status: "todo,in_progress" }}
+        onSearchChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(api.tasks.me.$get).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks.me.$get).mock.calls[0];
+    expect((call[0] as { query: { status?: string } }).query.status).toBe(
+      "todo,in_progress",
+    );
+  });
+
+  it("読み込み中はインジケータを表示する", () => {
+    // 解決しない Promise を返してローディング状態を維持
+    vi.mocked(api.tasks.me.$get).mockReturnValue(
+      new Promise(() => {}) as never,
+    );
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+});
+
+describe("MyTasksView - TaskRow 詳細", () => {
+  it("attached 定例が複数あれば +N で表示する", async () => {
+    const multiRm = {
+      ...baseTask,
+      recurringMeetings: [
+        { id: "rmtg-1", name: "週次定例" },
+        { id: "rmtg-2", name: "月次定例" },
+        { id: "rmtg-3", name: "臨時会" },
+      ],
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([multiRm]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/週次定例 \+2/)).toBeInTheDocument();
+    });
+  });
+
+  it("担当者数を 'N名' で表示する", async () => {
+    const twoAssignees = {
+      ...baseTask,
+      assignees: [
+        { id: "user-1", name: "alice", displayName: "alice" },
+        { id: "user-2", name: "bob", displayName: "bob" },
+      ],
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([twoAssignees]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-assignee-count")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("task-assignee-count")).toHaveTextContent("2名");
+  });
+
+  it("行は onClick 未指定なら disabled になる（ダイアログ未実装の暫定動作）", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("資料作成")).toBeInTheDocument();
+    });
+    const row = screen.getByRole("button", { name: /タスク 資料作成/ });
+    expect(row).toBeDisabled();
+  });
+});
+
+describe("MyTasksView - フィルタ整合", () => {
+  it("status を既に持っていてもう一度同じものを押すと外す（解除）", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    const onSearchChange = vi.fn();
+
+    renderWithQuery(
+      <MyTasksView
+        search={{ status: "todo" }}
+        onSearchChange={onSearchChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("担当中のタスクはありません"),
+      ).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByLabelText(/未着手/));
+    // status をクリアして undefined にする
+    expect(onSearchChange).toHaveBeenCalledWith({ status: undefined });
+  });
+
+  it("組織フィルタは取得結果のユニーク組織から構築される", async () => {
+    const t1 = {
+      ...baseTask,
+      id: "t1",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    const t2 = {
+      ...baseTask,
+      id: "t2",
+      organization: { id: "org-2", name: "Beta" },
+    };
+    const t3 = {
+      ...baseTask,
+      id: "t3",
+      organization: { id: "org-1", name: "ACME" },
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([t1, t2, t3]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    // データロードを待ってから options を取り出す（初回 render では空配列で
+    // select に「すべて」しか入っていないため）
+    await waitFor(() => {
+      expect(screen.getByLabelText("My タスク一覧")).toBeInTheDocument();
+    });
+    const select = screen.getByLabelText("組織フィルタ");
+    const options = within(select).getAllByRole("option");
+    // "すべて" + ACME + Beta = 3
+    expect(options).toHaveLength(3);
+    expect(options[1]).toHaveTextContent("ACME");
+    expect(options[2]).toHaveTextContent("Beta");
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #167

## 概要・目的
* ログインユーザーが自身に割り当てられた全組織横断のタスクを一覧・確認できる /tasks ページを新設する
* サイドバーから直接アクセスできる導線を整備し、Asana の "My Tasks" 相当の体験を提供する
* 後続 Issue（#168 定例詳細・#170 会議詳細）で再利用する `TaskRow` 共通コンポーネントも同 PR で整備

## 背景
* Backend 側（#163/#164/#165）と Frontend 基盤（#166）が揃ったので、最初の利用画面を作る
* `validateSearch` を本リポで初導入し、URL クエリ永続化のパターンを確立する
* API には組織フィルタが無いため、組織絞り込みはクライアント側で実施

## 変更内容
* **新規ルート `routes/tasks.index.tsx`**
  * `createFileRoute("/tasks/")` + `validateSearch` で `status` / `orgId` を URL クエリで永続化
  * `status` は API 仕様に合わせカンマ区切り文字列で保持（`?status=todo,in_progress`）
  * 組織フィルタは取得結果の organization 配列から動的に選択肢を構築
  * `MyTasksView` を切り出してテスト容易性を確保（既存 OrganizationDetailView と同じ流儀）
  * 0 件時の空状態表示・ローディング・エラー処理

* **共通行コンポーネント `features/tasks/components/TaskRow.tsx`**
  * title / 組織 / 定例（複数あれば「+N」）/ status バッジ / 期限 / 担当者数を 1 行で表示
  * 期限超過判定（`dueDate < now && status not in [done, rejected]`）で `text-destructive` 強調
  * `now` プロップで固定時刻をテスト注入可能
  * `onClick` 未指定時は `disabled` 化（ダイアログ #169 完成前の暫定動作）
  * 後続 Issue（定例詳細・会議詳細）でも再利用

* **サイドバー導線 `components/layout/Sidebar.tsx`**
  * 「ダッシュボード」と「定例」セクションの間に CheckSquare アイコン付き Link を追加
  * 組織非依存（assignee 経由で組織横断）のため常に表示

* **テスト（14 件追加）**
  * `tasks.index.test.tsx`: 13 件
    * 正常系（1 行表示）/ 空状態 / status チェックボックス操作 / 組織フィルタ反映 / 期限超過強調 / done 例外 / status 文字列の API リクエスト反映 / ローディング / 複数定例 +N 表示 / 担当者数表示 / disabled 行 / status トグル解除 / 組織候補ユニーク化
  * `sidebar.test.tsx`: 1 件（"My タスク" Link 検証）

## 動作確認手順
1. `git checkout issue-167-my-tasks-page`
2. `make install`
3. `make dev` で全サービス起動
4. ブラウザで `http://localhost:5173/tasks` にアクセス（fake-auth でログイン済み前提）
5. サイドバーから "My タスク" をクリックして /tasks に遷移できることを確認
6. status チェックボックスをトグルして URL クエリ (`?status=todo`) が更新されることを確認
7. 組織セレクトで絞り込みが効くことを確認
8. 期限超過のタスクが赤字で表示されることを確認（テストデータ次第）
9. `make test` で 全テスト pass を確認（web 25 ファイル / 241 件、本 PR で 14 件追加）
10. `make lint` で警告ゼロを確認

## スクリーンショット

<img width="779" height="448" alt="image" src="https://github.com/user-attachments/assets/c09ec11a-afac-4f94-b806-e866c3d1a72b" />


## 補足
* タスク詳細ダイアログ（#169）完成までは行クリック非対応（`disabled` 化）。ダイアログ Issue 完了後に行クリック対応の追従 PR を出す予定
* 組織フィルタはクライアント側で `.filter()`。API に orgId クエリが無いことに合わせる
* status の選択肢は `todo / in_progress / done / rejected` の 4 値のみ表示。AI 専用の `draft / reviewing` は将来のレビュー画面で別 UI を用意する想定
* 並び順は API 側固定（dueDate ASC NULLS LAST → updatedAt DESC）に従い、フロントでの再ソートは行わない