### PR TITLE
feat(web): 定例詳細ページにタスクセクションを追加

### DIFF
--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -7,15 +7,58 @@ import {
   describeCron,
   parseCron,
 } from "@/features/recurring-meetings/scheduleCron";
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMeetingTasks";
+import { taskStatusLabels } from "@/features/tasks/labels";
+import type { TaskStatus } from "@/features/tasks/types";
+import { cn } from "@/lib/utils";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+
+// タスクセクションのフィルタ用 status 選択肢。
+// AI 専用の draft / reviewing は UI から除外する（My タスクと同じ方針）。
+const FILTERABLE_STATUSES: TaskStatus[] = [
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+];
+
+// URL クエリパラメータの形。タスクセクションの status フィルタを永続化する。
+const recurringMeetingSearchSchema = z.object({
+  status: z.string().optional(),
+});
+
+type RecurringMeetingSearch = z.infer<typeof recurringMeetingSearchSchema>;
 
 export const Route = createFileRoute("/recurring-meetings/$id")({
+  validateSearch: recurringMeetingSearchSchema,
   component: RecurringMeetingDetailPage,
 });
 
+// URL の status 文字列を TaskStatus 配列にパースする（My タスクと同じロジック）。
+function parseStatusParam(raw: string | undefined): TaskStatus[] | undefined {
+  if (!raw) return undefined;
+  const arr = raw
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v): v is TaskStatus =>
+      FILTERABLE_STATUSES.includes(v as TaskStatus),
+    );
+  return arr.length > 0 ? arr : undefined;
+}
+
 function RecurringMeetingDetailPage() {
   const { id } = Route.useParams();
-  return <RecurringMeetingDetailView id={id} />;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  return (
+    <RecurringMeetingDetailView
+      id={id}
+      search={search}
+      onSearchChange={(next) => navigate({ search: next })}
+    />
+  );
 }
 
 // route コンポーネントから分離したビュー。テストでは props で id を渡して直接 render する
@@ -25,13 +68,23 @@ function RecurringMeetingDetailPage() {
 // 衝突するのを避ける。
 export function RecurringMeetingDetailView({
   id,
+  search = {},
+  onSearchChange = () => {},
   now,
 }: {
   id: string;
+  search?: RecurringMeetingSearch;
+  onSearchChange?: (next: RecurringMeetingSearch) => void;
   now?: Date;
 }) {
   const detailQuery = useRecurringMeetingDetail(id);
   const meetingsQuery = useRecurringMeetingMeetings(id);
+
+  const statusArr = parseStatusParam(search.status);
+  const tasksQuery = useRecurringMeetingTasks(
+    id,
+    statusArr ? { status: statusArr } : undefined,
+  );
 
   if (detailQuery.isLoading) {
     return (
@@ -56,6 +109,17 @@ export function RecurringMeetingDetailView({
 
   const meetings = meetingsQuery.data ?? [];
   const { upcoming, past } = partitionMeetings(meetings, now);
+
+  const toggleStatus = (s: TaskStatus) => {
+    const current = new Set(statusArr ?? []);
+    if (current.has(s)) current.delete(s);
+    else current.add(s);
+    const next = Array.from(current);
+    onSearchChange({
+      ...search,
+      status: next.length > 0 ? next.join(",") : undefined,
+    });
+  };
 
   return (
     <section
@@ -122,6 +186,77 @@ export function RecurringMeetingDetailView({
           </section>
         </>
       )}
+
+      <section aria-label="タスク" className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">タスク</h2>
+          {/* 作成ダイアログは #169 で実装予定。完成までは disabled プレースホルダ。
+              title 属性で意図をホバー時に説明する。 */}
+          <button
+            type="button"
+            disabled
+            title="タスク作成ダイアログは準備中です"
+            className="text-sm px-3 py-1.5 rounded-md border border-border/60 bg-muted/50 text-muted-foreground cursor-not-allowed"
+          >
+            タスクを追加
+          </button>
+        </div>
+
+        {/* status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
+            biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+            避けるため div + role=group で代替する（My タスクと同じ判断）。 */}
+        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
+        <div
+          role="group"
+          aria-labelledby="rm-task-status-filter-label"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <span
+            id="rm-task-status-filter-label"
+            className="text-xs text-muted-foreground"
+          >
+            ステータス
+          </span>
+          {FILTERABLE_STATUSES.map((s) => {
+            const checked = statusArr?.includes(s) ?? false;
+            return (
+              <label
+                key={s}
+                className={cn(
+                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                  checked
+                    ? "bg-foreground text-background border-foreground"
+                    : "bg-card text-foreground border-border/60 hover:bg-accent",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked}
+                  onChange={() => toggleStatus(s)}
+                />
+                {taskStatusLabels[s]}
+              </label>
+            );
+          })}
+        </div>
+
+        {tasksQuery.isLoading ? (
+          <p className="text-muted-foreground">タスクを読み込み中...</p>
+        ) : tasksQuery.isError ? (
+          <p className="text-destructive text-sm">タスクの取得に失敗しました</p>
+        ) : (tasksQuery.data ?? []).length === 0 ? (
+          <p className="text-muted-foreground">
+            このプロジェクトのタスクはまだありません
+          </p>
+        ) : (
+          <ul aria-label="プロジェクトのタスク一覧" className="grid gap-2">
+            {(tasksQuery.data ?? []).map((task) => (
+              <TaskRow key={task.id} task={task} now={now} />
+            ))}
+          </ul>
+        )}
+      </section>
     </section>
   );
 }

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -13,6 +13,9 @@ vi.mock("@/lib/api", () => ({
           $get: vi.fn(),
           $post: vi.fn(),
         },
+        tasks: {
+          $get: vi.fn(),
+        },
       },
     },
   },
@@ -117,6 +120,9 @@ describe("定例詳細ページ - ヘッダ表示", () => {
     vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
       mockJson([]),
     );
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
   });
 
   it("定例名・説明・cron 人間表記・デフォルト所要時間を表示する", async () => {
@@ -150,6 +156,9 @@ describe("定例詳細ページ - 会議のセクション分け", () => {
   beforeEach(() => {
     vi.mocked(api["recurring-meetings"][":id"].$get).mockResolvedValue(
       mockJson(detail),
+    );
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
     );
   });
 
@@ -296,5 +305,121 @@ describe("定例詳細ページ - 会議のセクション分け", () => {
     expect(
       screen.queryByRole("list", { name: "今後の会議一覧" }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("定例詳細ページ - タスクセクション", () => {
+  const sampleTask = {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "資料作成",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo" as const,
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: "2026-05-17T00:00:00.000Z",
+    updatedAt: "2026-05-17T00:00:00.000Z",
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [{ id: "rmtg-1", name: "週次定例" }],
+  };
+
+  beforeEach(() => {
+    vi.mocked(api["recurring-meetings"][":id"].$get).mockResolvedValue(
+      mockJson(detail),
+    );
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+  });
+
+  function renderWithSearch(opts?: {
+    search?: { status?: string };
+    onSearchChange?: (next: { status?: string }) => void;
+  }) {
+    return renderWithQuery(
+      <RecurringMeetingDetailView
+        id="rmtg-1"
+        now={NOW}
+        search={opts?.search ?? {}}
+        onSearchChange={opts?.onSearchChange ?? (() => {})}
+      />,
+    );
+  }
+
+  it("タスクを 1 件取得して表示する", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([sampleTask]),
+    );
+    renderWithSearch();
+    expect(await screen.findByText("タスク")).toBeInTheDocument();
+    const list = await screen.findByLabelText("プロジェクトのタスク一覧");
+    expect(within(list).getByText("資料作成")).toBeInTheDocument();
+  });
+
+  it("0 件時は空状態メッセージと disabled の「タスクを追加」ボタンを表示する", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithSearch();
+    expect(
+      await screen.findByText("このプロジェクトのタスクはまだありません"),
+    ).toBeInTheDocument();
+    const addBtn = screen.getByRole("button", { name: "タスクを追加" });
+    expect(addBtn).toBeDisabled();
+  });
+
+  it("status チェックボックスを切り替えると onSearchChange が呼ばれる", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    const onSearchChange = vi.fn();
+    renderWithSearch({ onSearchChange });
+
+    await screen.findByText("タスク");
+    const checkbox = screen.getByLabelText(/未着手/);
+    await userEvent.click(checkbox);
+    expect(onSearchChange).toHaveBeenCalledWith({ status: "todo" });
+  });
+
+  it("初期 status フィルタが反映される", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithSearch({ search: { status: "in_progress" } });
+    await screen.findByText("タスク");
+
+    // API 呼び出しの query.status に in_progress が乗ること
+    const call = vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mock
+      .calls[0];
+    expect((call[0] as { query: { status?: string } }).query.status).toBe(
+      "in_progress",
+    );
+  });
+
+  it("タスク取得失敗時はエラーメッセージを表示する（定例ヘッダは維持）", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockRejectedValue(
+      new Error("network"),
+    );
+    renderWithSearch();
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(
+      await screen.findByText("タスクの取得に失敗しました"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #168

## 概要・目的
* `/recurring-meetings/$id` に、当該定例に attach されたタスクの一覧セクションを追加する（Asana の Project 画面相当）
* 共通 `TaskRow` を再利用して My タスクページと見た目を統一する
* status フィルタを URL クエリで永続化する（My タスクと同じ流儀）

## 背景
* 既存の定例詳細ページは「今後の会議 / 過去の会議」のみで、タスクの確認動線が無かった
* 共通基盤 (#166) と一覧 API (#165) が揃ったので、利用画面を作る段階

## 変更内容
* **`routes/recurring-meetings.$id.tsx`**:
  * `validateSearch` を追加し `status` クエリを永続化（`?status=todo,in_progress` 形式）
  * `useRecurringMeetingTasks(id, {status})` でタスク取得
  * 「タスク」セクションを「過去の会議」の下に配置（タブ分割は MVP 後検討）
  * `TaskRow` で各行表示（`now` プロップで時刻注入可能）
  * 「タスクを追加」ボタン：#169 ダイアログ完成まで disabled プレースホルダ（`title` 属性で意図をアナウンス）
  * status フィルタは My タスクと同じ inline label + aria-labelledby パターン

* **テスト追補（5 件）**:
  * タスク 1 件の表示
  * 0 件時の空状態メッセージ + disabled ボタン
  * status チェックボックスの onSearchChange 発火
  * 初期 status フィルタの API リクエスト反映
  * タスク取得失敗時のエラーメッセージ表示（定例ヘッダは維持）
  * 既存 11 件のテストも green を維持（mock 拡張のみ）

## 動作確認手順
1. `git checkout issue-168-recurring-meeting-tasks-section`
2. `make install`
3. `make dev` で全サービス起動
4. fake-auth でログインし、組織 → 定例詳細ページに遷移
5. 「タスク」セクションが「過去の会議」の下に表示されることを確認
6. status チェックボックスをトグルして URL クエリ (`?status=todo`) が更新されることを確認
7. 「タスクを追加」ボタンが disabled になっていてホバー時に「タスク作成ダイアログは準備中です」と表示されることを確認（#169 マージ後に有効化）
8. `make test` で 全テスト pass（web 25 ファイル / 251 件、本 PR で 5 件追加）を確認
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1131" height="604" alt="image" src="https://github.com/user-attachments/assets/452cac8e-5a3e-42da-ace2-96b282a54703" />

## 補足
* 「タスクを追加」ボタンは #169（タスク作成 / 編集ダイアログ）完成後に有効化する追従 PR を予定
* 行クリックも同様にダイアログ未実装のため disabled 状態（共通 TaskRow の挙動）
* 並び順は API 側固定（dueDate ASC NULLS LAST → updatedAt DESC）に従い、フロントでの再ソートは行わない