### PR TITLE
feat(web): タスク作成 / 編集 / 削除ダイアログを実装

### DIFF
--- a/apps/web/src/features/organizations/hooks/useOrganizationMembers.ts
+++ b/apps/web/src/features/organizations/hooks/useOrganizationMembers.ts
@@ -1,0 +1,26 @@
+import type { Member } from "@/features/organizations/types";
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// 組織のメンバー一覧を取得する hook。
+// 既存 organizations.$id.tsx に inline で書かれていたパターンを共有化し、
+// タスク作成ダイアログの担当者候補としても再利用する。
+// クエリキーは "organizations" → ":id" → "members" の階層で、組織 detail と
+// invalidate が連動するように合わせている。
+export function useOrganizationMembers(orgId: string | null) {
+  return useQuery<Member[]>({
+    queryKey: ["organizations", orgId, "members"],
+    enabled: orgId !== null,
+    queryFn: async () => {
+      if (!orgId) throw new Error("orgId is required");
+      const res = await api.organizations[":id"].members.$get(
+        { param: { id: orgId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch organization members: ${res.status}`);
+      }
+      return (await res.json()) as Member[];
+    },
+  });
+}

--- a/apps/web/src/features/tasks/components/AssigneePicker.tsx
+++ b/apps/web/src/features/tasks/components/AssigneePicker.tsx
@@ -1,0 +1,70 @@
+import { useOrganizationMembers } from "@/features/organizations/hooks/useOrganizationMembers";
+import { cn } from "@/lib/utils";
+
+// 担当者の複数選択ピッカー。組織メンバーをチェックボックスのトグルチップで表示し、
+// チェック状態の userId 配列を value/onChange で受け渡す。
+// API には pending 招待は含まれない（OrganizationMembership ベース）ので、
+// 候補は確定メンバーのみ。
+export function AssigneePicker({
+  organizationId,
+  value,
+  onChange,
+}: {
+  organizationId: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const { data, isLoading, isError } = useOrganizationMembers(organizationId);
+
+  const toggle = (userId: string) => {
+    const set = new Set(value);
+    if (set.has(userId)) set.delete(userId);
+    else set.add(userId);
+    onChange(Array.from(set));
+  };
+
+  if (isLoading) {
+    return (
+      <p className="text-xs text-muted-foreground">メンバーを読み込み中...</p>
+    );
+  }
+  if (isError) {
+    return (
+      <p className="text-xs text-destructive">メンバーの取得に失敗しました</p>
+    );
+  }
+  const members = data ?? [];
+  if (members.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">組織にメンバーがいません</p>
+    );
+  }
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: fieldset の legend がレイアウト崩れを起こすため div + role=group で代替（My タスクと同じ判断）
+    <div className="flex flex-wrap gap-2" role="group" aria-label="担当者">
+      {members.map((m) => {
+        const checked = value.includes(m.userId);
+        return (
+          <label
+            key={m.userId}
+            className={cn(
+              "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+              checked
+                ? "bg-foreground text-background border-foreground"
+                : "bg-card text-foreground border-border/60 hover:bg-accent",
+            )}
+          >
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={checked}
+              onChange={() => toggle(m.userId)}
+            />
+            {m.displayName}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/web/src/features/tasks/components/CreateTaskDialog.tsx
@@ -1,0 +1,245 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCreateTask } from "@/features/tasks/hooks/useCreateTask";
+import { taskPriorityLabels } from "@/features/tasks/labels";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type ReactNode, useId, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+import { AssigneePicker } from "./AssigneePicker";
+import { RecurringMeetingPicker } from "./RecurringMeetingPicker";
+
+// フォーム入力用 schema。日付は <input type="date"> の "YYYY-MM-DD" を受け取り、
+// 送信時に new Date(date).toISOString() で UTC ISO8601 (00:00:00 UTC) に変換する。
+// 空文字は「未指定」として扱い、API には送らない。
+const createTaskFormSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string(),
+  priority: z.enum(["", "required", "optional"]),
+  dueDate: z.string(),
+  startDate: z.string(),
+  followUpDate: z.string(),
+  recurringMeetingIds: z.array(z.string()),
+  assigneeUserIds: z.array(z.string()),
+});
+
+type CreateTaskFormValues = z.infer<typeof createTaskFormSchema>;
+
+// "YYYY-MM-DD" 文字列を UTC 00:00 として ISO8601 datetime に変換する。
+// 空文字 / undefined はそのまま undefined を返し、API には送らない。
+function dateToIsoOrUndefined(date: string): string | undefined {
+  if (!date) return undefined;
+  return new Date(`${date}T00:00:00.000Z`).toISOString();
+}
+
+export function CreateTaskDialog({
+  organizationId,
+  recurringMeetingId,
+  originMeetingId,
+  trigger,
+  open: openProp,
+  onOpenChange,
+}: {
+  organizationId: string;
+  // 呼び出し元の文脈で初期紐付けする定例。例: 定例詳細ページからの作成で「現定例」が初期 attach。
+  recurringMeetingId?: string;
+  // 呼び出し元の文脈で発生源会議が決まっている場合（会議詳細ページからの作成）。
+  originMeetingId?: string;
+  trigger?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (onOpenChange) onOpenChange(next);
+    else setInternalOpen(next);
+  };
+
+  const titleId = useId();
+  const bodyId = useId();
+  const priorityId = useId();
+  const dueDateId = useId();
+  const startDateId = useId();
+  const followUpDateId = useId();
+
+  const defaultValues: CreateTaskFormValues = {
+    title: "",
+    body: "",
+    priority: "",
+    dueDate: "",
+    startDate: "",
+    followUpDate: "",
+    recurringMeetingIds: recurringMeetingId ? [recurringMeetingId] : [],
+    assigneeUserIds: [],
+  };
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<CreateTaskFormValues>({
+    resolver: zodResolver(createTaskFormSchema),
+    defaultValues,
+  });
+
+  const mutation = useCreateTask();
+
+  const onSubmit = (data: CreateTaskFormValues) => {
+    mutation.mutate(
+      {
+        organizationId,
+        title: data.title,
+        body: data.body || undefined,
+        priority: data.priority || undefined,
+        dueDate: dateToIsoOrUndefined(data.dueDate),
+        startDate: dateToIsoOrUndefined(data.startDate),
+        followUpDate: dateToIsoOrUndefined(data.followUpDate),
+        recurringMeetingIds:
+          data.recurringMeetingIds.length > 0
+            ? data.recurringMeetingIds
+            : undefined,
+        assigneeUserIds:
+          data.assigneeUserIds.length > 0 ? data.assigneeUserIds : undefined,
+        originMeetingId,
+      },
+      {
+        onSuccess: () => {
+          reset(defaultValues);
+          setOpen(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          reset(defaultValues);
+          mutation.reset();
+        }
+      }}
+    >
+      {trigger !== undefined ? (
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+      ) : openProp === undefined ? (
+        <DialogTrigger asChild>
+          <Button size="sm">タスクを追加</Button>
+        </DialogTrigger>
+      ) : null}
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>タスクを作成</DialogTitle>
+          <DialogDescription>
+            新しいタスクを作成します。組織のメンバーを担当者に指定できます。
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={titleId}>タイトル</Label>
+            <Input id={titleId} {...register("title")} />
+            {errors.title && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.title.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={bodyId}>本文</Label>
+            <Input id={bodyId} {...register("body")} />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={priorityId}>必須度</Label>
+            <select
+              id={priorityId}
+              {...register("priority")}
+              className="text-sm px-2 py-1.5 rounded-md border border-border/60 bg-card"
+            >
+              <option value="">未指定</option>
+              <option value="required">{taskPriorityLabels.required}</option>
+              <option value="optional">{taskPriorityLabels.optional}</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={dueDateId}>期限</Label>
+              <Input id={dueDateId} type="date" {...register("dueDate")} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={startDateId}>開始日</Label>
+              <Input id={startDateId} type="date" {...register("startDate")} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={followUpDateId}>再検討日</Label>
+              <Input
+                id={followUpDateId}
+                type="date"
+                {...register("followUpDate")}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>紐付ける定例</Label>
+            <Controller
+              name="recurringMeetingIds"
+              control={control}
+              render={({ field }) => (
+                <RecurringMeetingPicker
+                  organizationId={organizationId}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>担当者</Label>
+            <Controller
+              name="assigneeUserIds"
+              control={control}
+              render={({ field }) => (
+                <AssigneePicker
+                  organizationId={organizationId}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+
+          {mutation.isError && (
+            <p className="text-destructive text-sm">
+              タスクの作成に失敗しました
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              作成
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/tasks/components/DeleteTaskDialog.tsx
+++ b/apps/web/src/features/tasks/components/DeleteTaskDialog.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDeleteTask } from "@/features/tasks/hooks/useDeleteTask";
+import type { Task } from "@/features/tasks/types";
+
+// タスク削除の確認ダイアログ。親（EditTaskDialog や行のメニュー）から open を制御する。
+// onDeleted で親に削除完了を通知し、編集ダイアログを閉じる等のフローを任せる。
+export function DeleteTaskDialog({
+  task,
+  open,
+  onOpenChange,
+  onDeleted,
+}: {
+  task: Task;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted?: () => void;
+}) {
+  const mutation = useDeleteTask();
+
+  const onConfirm = () => {
+    mutation.mutate(task.id, {
+      onSuccess: () => {
+        onOpenChange(false);
+        if (onDeleted) onDeleted();
+      },
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next);
+        if (!next) mutation.reset();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>タスクを削除</DialogTitle>
+          <DialogDescription>
+            {`「${task.title}」を削除しますか？この操作は取り消せません。`}
+          </DialogDescription>
+        </DialogHeader>
+        {mutation.isError && (
+          <p className="text-destructive text-sm">タスクの削除に失敗しました</p>
+        )}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={mutation.isPending}
+          >
+            削除を実行
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/tasks/components/EditTaskDialog.tsx
+++ b/apps/web/src/features/tasks/components/EditTaskDialog.tsx
@@ -1,0 +1,345 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
+import {
+  TaskVersionConflictError,
+  useUpdateTask,
+} from "@/features/tasks/hooks/useUpdateTask";
+import { taskPriorityLabels, taskStatusLabels } from "@/features/tasks/labels";
+import type { ManualTaskStatus, Task } from "@/features/tasks/types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useEffect, useId, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+import { AssigneePicker } from "./AssigneePicker";
+import { RecurringMeetingPicker } from "./RecurringMeetingPicker";
+import { TaskAiReadOnlySection } from "./TaskAiReadOnlySection";
+
+// 編集フォームのスキーマ。日付・選択肢が未指定の場合は空文字を許容し、
+// 送信時に元の値と diff を取って変更フィールドのみ API に送る。
+const editTaskFormSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string(),
+  status: z.enum(["todo", "in_progress", "done", "rejected"]),
+  priority: z.enum(["", "required", "optional"]),
+  dueDate: z.string(),
+  startDate: z.string(),
+  followUpDate: z.string(),
+  recurringMeetingIds: z.array(z.string()),
+  assigneeUserIds: z.array(z.string()),
+});
+
+type EditTaskFormValues = z.infer<typeof editTaskFormSchema>;
+
+// 編集画面の手動 status は 4 値のみ表示する。draft / reviewing は AI 専用なので除外。
+const MANUAL_STATUSES: ManualTaskStatus[] = [
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+];
+
+// ISO datetime "YYYY-MM-DDTHH:mm:ss.sssZ" を <input type="date"> の "YYYY-MM-DD" に変換する。
+// null は空文字に倒し、フォームで「未指定」を表現する。
+function isoToDateInput(iso: string | null): string {
+  if (!iso) return "";
+  return iso.slice(0, 10);
+}
+
+// <input type="date"> の "YYYY-MM-DD" を UTC 00:00 の ISO datetime に変換する。
+// 空文字は null（クリア意図）として送る。
+function dateInputToIsoOrNull(date: string): string | null {
+  if (!date) return null;
+  return new Date(`${date}T00:00:00.000Z`).toISOString();
+}
+
+// 配列の内容が同一かを順不同で比較する。
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((x) => set.has(x));
+}
+
+// task から RHF の defaultValues を組み立てる。useEffect の依存に乗らないよう、
+// コンポーネント外の純粋関数として定義する。
+function buildDefaults(t: Task): EditTaskFormValues {
+  return {
+    title: t.title,
+    body: t.body ?? "",
+    // 手動 4 値以外（AI 用の draft/reviewing）は UI 上 todo にフォールバック。
+    // 編集時にユーザーがそのまま保存しても draft/reviewing を維持しないのは仕様。
+    status: MANUAL_STATUSES.includes(t.status as ManualTaskStatus)
+      ? (t.status as ManualTaskStatus)
+      : "todo",
+    priority: t.priority ?? "",
+    dueDate: isoToDateInput(t.dueDate),
+    startDate: isoToDateInput(t.startDate),
+    followUpDate: isoToDateInput(t.followUpDate),
+    recurringMeetingIds: t.recurringMeetings.map((r) => r.id),
+    assigneeUserIds: t.assignees.map((a) => a.id),
+  };
+}
+
+export function EditTaskDialog({
+  task,
+  trigger,
+  open: openProp,
+  onOpenChange,
+  onRequestDelete,
+}: {
+  task: Task;
+  trigger?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // 削除ボタンを押したときの動線。親が DeleteTaskDialog を制御する想定。
+  onRequestDelete?: () => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (onOpenChange) onOpenChange(next);
+    else setInternalOpen(next);
+  };
+
+  const titleId = useId();
+  const bodyId = useId();
+  const statusId = useId();
+  const priorityId = useId();
+  const dueDateId = useId();
+  const startDateId = useId();
+  const followUpDateId = useId();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<EditTaskFormValues>({
+    resolver: zodResolver(editTaskFormSchema),
+    defaultValues: buildDefaults(task),
+  });
+
+  // 親から新しい task が渡ってきたとき、閉じている間にフォームを再同期する。
+  useEffect(() => {
+    if (!open) reset(buildDefaults(task));
+  }, [task, open, reset]);
+
+  const mutation = useUpdateTask(task.id);
+  const queryClient = useQueryClient();
+  const isVersionConflict = mutation.error instanceof TaskVersionConflictError;
+
+  const onSubmit = (data: EditTaskFormValues) => {
+    // 変更があったフィールドのみを送る。空文字 / null の判定は API 仕様
+    // （nullable な日付は null で送るとクリア）に合わせる。
+    const json: Parameters<typeof mutation.mutate>[0] = {
+      version: task.version,
+    };
+    if (data.title !== task.title) json.title = data.title;
+    if (data.body !== (task.body ?? "")) json.body = data.body;
+    if (data.status !== task.status) json.status = data.status;
+    const prevPriority = task.priority ?? "";
+    if (data.priority !== prevPriority) {
+      json.priority = data.priority || undefined;
+    }
+    const nextDue = dateInputToIsoOrNull(data.dueDate);
+    if (nextDue !== task.dueDate) json.dueDate = nextDue;
+    const nextStart = dateInputToIsoOrNull(data.startDate);
+    if (nextStart !== task.startDate) json.startDate = nextStart;
+    const nextFollowUp = dateInputToIsoOrNull(data.followUpDate);
+    if (nextFollowUp !== task.followUpDate) json.followUpDate = nextFollowUp;
+
+    const prevRmIds = task.recurringMeetings.map((r) => r.id);
+    if (!sameSet(data.recurringMeetingIds, prevRmIds)) {
+      json.recurringMeetingIds = data.recurringMeetingIds;
+    }
+    const prevAssignees = task.assignees.map((a) => a.id);
+    if (!sameSet(data.assigneeUserIds, prevAssignees)) {
+      json.assigneeUserIds = data.assigneeUserIds;
+    }
+
+    mutation.mutate(json, {
+      onSuccess: () => {
+        setOpen(false);
+      },
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) mutation.reset();
+      }}
+    >
+      {trigger !== undefined ? (
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+      ) : null}
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>タスクを編集</DialogTitle>
+          <DialogDescription>
+            タスクの情報を更新します。最新で保存されていないと 409 になります。
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={titleId}>タイトル</Label>
+            <Input id={titleId} {...register("title")} />
+            {errors.title && (
+              <p role="alert" className="text-destructive text-sm">
+                {errors.title.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={bodyId}>本文</Label>
+            <Input id={bodyId} {...register("body")} />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={statusId}>ステータス</Label>
+              <select
+                id={statusId}
+                {...register("status")}
+                className="text-sm px-2 py-1.5 rounded-md border border-border/60 bg-card"
+              >
+                {MANUAL_STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {taskStatusLabels[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={priorityId}>必須度</Label>
+              <select
+                id={priorityId}
+                {...register("priority")}
+                className="text-sm px-2 py-1.5 rounded-md border border-border/60 bg-card"
+              >
+                <option value="">未指定</option>
+                <option value="required">{taskPriorityLabels.required}</option>
+                <option value="optional">{taskPriorityLabels.optional}</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={dueDateId}>期限</Label>
+              <Input id={dueDateId} type="date" {...register("dueDate")} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={startDateId}>開始日</Label>
+              <Input id={startDateId} type="date" {...register("startDate")} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={followUpDateId}>再検討日</Label>
+              <Input
+                id={followUpDateId}
+                type="date"
+                {...register("followUpDate")}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>紐付ける定例</Label>
+            <Controller
+              name="recurringMeetingIds"
+              control={control}
+              render={({ field }) => (
+                <RecurringMeetingPicker
+                  organizationId={task.organizationId}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>担当者</Label>
+            <Controller
+              name="assigneeUserIds"
+              control={control}
+              render={({ field }) => (
+                <AssigneePicker
+                  organizationId={task.organizationId}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+
+          <TaskAiReadOnlySection task={task} />
+
+          {isVersionConflict ? (
+            // 楽観的ロック競合。最新を取得してフォームを巻き戻す導線を出す。
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+              <p className="text-destructive">
+                他のユーザーが先に更新しました。最新を取得して再試行してください。
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => {
+                  // detail と一覧の両方を invalidate して親で refetch させる。
+                  queryClient.invalidateQueries({
+                    queryKey: taskQueryKeys.detail(task.id),
+                  });
+                  queryClient.invalidateQueries({
+                    queryKey: taskQueryKeys.all,
+                  });
+                  mutation.reset();
+                }}
+              >
+                最新を取得
+              </Button>
+            </div>
+          ) : mutation.isError ? (
+            <p className="text-destructive text-sm">
+              タスクの更新に失敗しました
+            </p>
+          ) : null}
+
+          <DialogFooter className="sm:justify-between">
+            {onRequestDelete ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={onRequestDelete}
+              >
+                削除
+              </Button>
+            ) : (
+              <span />
+            )}
+            <Button type="submit" disabled={mutation.isPending}>
+              保存
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/tasks/components/RecurringMeetingPicker.tsx
+++ b/apps/web/src/features/tasks/components/RecurringMeetingPicker.tsx
@@ -1,0 +1,68 @@
+import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
+import { cn } from "@/lib/utils";
+
+// 定例（プロジェクト相当）の複数選択ピッカー。
+// 同一組織配下の定例だけを候補にする（API 側のクロス組織アタッチ禁止と整合）。
+export function RecurringMeetingPicker({
+  organizationId,
+  value,
+  onChange,
+}: {
+  organizationId: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const { data, isLoading, isError } = useOrganizationMeetings(organizationId);
+
+  const toggle = (rmId: string) => {
+    const set = new Set(value);
+    if (set.has(rmId)) set.delete(rmId);
+    else set.add(rmId);
+    onChange(Array.from(set));
+  };
+
+  if (isLoading) {
+    return <p className="text-xs text-muted-foreground">定例を読み込み中...</p>;
+  }
+  if (isError) {
+    return <p className="text-xs text-destructive">定例の取得に失敗しました</p>;
+  }
+  const meetings = data ?? [];
+  if (meetings.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">組織に定例がありません</p>
+    );
+  }
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: fieldset の legend がレイアウト崩れを起こすため div + role=group で代替（My タスクと同じ判断）
+    <div
+      className="flex flex-wrap gap-2"
+      role="group"
+      aria-label="紐付ける定例"
+    >
+      {meetings.map((m) => {
+        const checked = value.includes(m.id);
+        return (
+          <label
+            key={m.id}
+            className={cn(
+              "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+              checked
+                ? "bg-foreground text-background border-foreground"
+                : "bg-card text-foreground border-border/60 hover:bg-accent",
+            )}
+          >
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={checked}
+              onChange={() => toggle(m.id)}
+            />
+            {m.name}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/tasks/components/TaskAiReadOnlySection.tsx
+++ b/apps/web/src/features/tasks/components/TaskAiReadOnlySection.tsx
@@ -1,0 +1,86 @@
+import { ambiguityTypeLabels } from "@/features/tasks/labels";
+import type { Task } from "@/features/tasks/types";
+
+// AI 由来の read-only フィールドが「1 つでも値を持っているか」を判定する。
+// すべて null / 空配列 / 0 の場合はセクション自体を非表示にする方針。
+function hasAnyAiField(task: Task): boolean {
+  if (task.sourceQuote) return true;
+  if (task.sourceContext) return true;
+  if (task.dueDateRaw) return true;
+  if (task.dueDateEstimated) return true;
+  if (task.assigneeRaw) return true;
+  if (task.ambiguityFlags && task.ambiguityFlags.length > 0) return true;
+  if (task.carriedOverCount && task.carriedOverCount > 0) return true;
+  if (task.progressNote) return true;
+  return false;
+}
+
+// AI が抽出時に付けた根拠情報を read-only で表示するセクション。
+// 値がない項目は行ごと非表示にして、ノイズを減らす。
+export function TaskAiReadOnlySection({ task }: { task: Task }) {
+  if (!hasAnyAiField(task)) return null;
+
+  return (
+    <details className="rounded-md border border-border/40 bg-muted/30">
+      <summary className="px-3 py-2 cursor-pointer text-sm text-muted-foreground">
+        AI 抽出情報（読み取り専用）
+      </summary>
+      <dl className="px-3 pb-3 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+        {task.sourceQuote && (
+          <>
+            <dt className="text-muted-foreground">根拠発話</dt>
+            <dd>{task.sourceQuote}</dd>
+          </>
+        )}
+        {task.sourceContext && (
+          <>
+            <dt className="text-muted-foreground">前後の文脈</dt>
+            <dd className="whitespace-pre-wrap">{task.sourceContext}</dd>
+          </>
+        )}
+        {task.dueDateRaw && (
+          <>
+            <dt className="text-muted-foreground">期限（原文）</dt>
+            <dd>
+              {task.dueDateRaw}
+              {task.dueDateEstimated ? "（推定）" : null}
+            </dd>
+          </>
+        )}
+        {task.assigneeRaw && (
+          <>
+            <dt className="text-muted-foreground">担当者（原文）</dt>
+            <dd>{task.assigneeRaw}</dd>
+          </>
+        )}
+        {task.ambiguityFlags && task.ambiguityFlags.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">曖昧フラグ</dt>
+            <dd className="flex flex-wrap gap-1">
+              {task.ambiguityFlags.map((f) => (
+                <span
+                  key={f}
+                  className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                >
+                  {ambiguityTypeLabels[f] ?? f}
+                </span>
+              ))}
+            </dd>
+          </>
+        )}
+        {task.carriedOverCount && task.carriedOverCount > 0 && (
+          <>
+            <dt className="text-muted-foreground">持ち越し回数</dt>
+            <dd>{task.carriedOverCount}</dd>
+          </>
+        )}
+        {task.progressNote && (
+          <>
+            <dt className="text-muted-foreground">進捗メモ</dt>
+            <dd className="whitespace-pre-wrap">{task.progressNote}</dd>
+          </>
+        )}
+      </dl>
+    </details>
+  );
+}

--- a/apps/web/src/test/tasks.createDialog.test.tsx
+++ b/apps/web/src/test/tasks.createDialog.test.tsx
@@ -1,0 +1,176 @@
+import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+    tasks: {
+      $post: vi.fn(),
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+    mockJson([
+      {
+        userId: "user-1",
+        name: "alice",
+        displayName: "Alice",
+        email: "a@example.com",
+        role: "member",
+        joinedAt: "2026-05-01T00:00:00.000Z",
+      },
+    ]),
+  );
+  vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+    mockJson([
+      {
+        id: "rmtg-1",
+        organizationId: "org-1",
+        name: "週次定例",
+        description: null,
+        scheduleCron: "0 10 * * 1",
+        defaultDurationMinutes: 60,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+        _count: { members: 1 },
+      },
+    ]),
+  );
+  vi.mocked(api.tasks.$post).mockResolvedValue(
+    mockJson({ id: "task-new" }, 201),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CreateTaskDialog", () => {
+  it("最小入力（title のみ）で作成 API を呼ぶ", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<CreateTaskDialog organizationId="org-1" />);
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(await screen.findByLabelText("タイトル"), "資料作成");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    await waitFor(() => {
+      expect(api.tasks.$post).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks.$post).mock.calls[0];
+    expect((call[0] as { json: { title: string } }).json).toMatchObject({
+      organizationId: "org-1",
+      title: "資料作成",
+    });
+    // ダイアログが閉じる
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
+    });
+  });
+
+  it("title 空欄で submit するとバリデーションエラーで API は呼ばれない", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<CreateTaskDialog organizationId="org-1" />);
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
+    expect(api.tasks.$post).not.toHaveBeenCalled();
+  });
+
+  it("recurringMeetingId プロップで定例が初期 attach される", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <CreateTaskDialog organizationId="org-1" recurringMeetingId="rmtg-1" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    await screen.findByRole("dialog");
+    await user.type(await screen.findByLabelText("タイトル"), "x");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    await waitFor(() => expect(api.tasks.$post).toHaveBeenCalled());
+    const call = vi.mocked(api.tasks.$post).mock.calls[0];
+    expect(
+      (call[0] as { json: { recurringMeetingIds?: string[] } }).json
+        .recurringMeetingIds,
+    ).toEqual(["rmtg-1"]);
+  });
+
+  it("dueDate は ISO8601 (UTC 00:00) に変換されて送られる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<CreateTaskDialog organizationId="org-1" />);
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    await screen.findByRole("dialog");
+    await user.type(await screen.findByLabelText("タイトル"), "x");
+    await user.type(screen.getByLabelText("期限"), "2026-05-20");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    await waitFor(() => expect(api.tasks.$post).toHaveBeenCalled());
+    const call = vi.mocked(api.tasks.$post).mock.calls[0];
+    expect((call[0] as { json: { dueDate?: string } }).json.dueDate).toBe(
+      "2026-05-20T00:00:00.000Z",
+    );
+  });
+
+  it("originMeetingId プロップは API リクエストに含まれる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <CreateTaskDialog organizationId="org-1" originMeetingId="mtg-1" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    await screen.findByRole("dialog");
+    await user.type(await screen.findByLabelText("タイトル"), "x");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    await waitFor(() => expect(api.tasks.$post).toHaveBeenCalled());
+    const call = vi.mocked(api.tasks.$post).mock.calls[0];
+    expect(
+      (call[0] as { json: { originMeetingId?: string } }).json.originMeetingId,
+    ).toBe("mtg-1");
+  });
+
+  it("API 失敗時はエラーメッセージを表示しダイアログは閉じない", async () => {
+    vi.mocked(api.tasks.$post).mockResolvedValue(
+      mockJson({ error: "bad" }, 400),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(<CreateTaskDialog organizationId="org-1" />);
+
+    await user.click(screen.getByRole("button", { name: "タスクを追加" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(await screen.findByLabelText("タイトル"), "x");
+    await user.click(screen.getByRole("button", { name: "作成" }));
+
+    expect(
+      await screen.findByText("タスクの作成に失敗しました"),
+    ).toBeInTheDocument();
+    expect(dialog).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/tasks.deleteDialog.test.tsx
+++ b/apps/web/src/test/tasks.deleteDialog.test.tsx
@@ -1,0 +1,135 @@
+import { DeleteTaskDialog } from "@/features/tasks/components/DeleteTaskDialog";
+import type { Task } from "@/features/tasks/types";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    tasks: {
+      ":id": {
+        $delete: vi.fn(),
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const task: Task = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: null,
+  assignees: [],
+  recurringMeetings: [],
+};
+
+beforeEach(() => {
+  vi.mocked(api.tasks[":id"].$delete).mockResolvedValue(mockJson(null, 204));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DeleteTaskDialog", () => {
+  it("タイトルが確認文に表示される", async () => {
+    renderWithQuery(
+      <DeleteTaskDialog task={task} open onOpenChange={() => {}} />,
+    );
+    expect(
+      await screen.findByText(/「資料作成」を削除しますか？/),
+    ).toBeInTheDocument();
+  });
+
+  it("「削除を実行」で DELETE が呼ばれ onDeleted が発火する", async () => {
+    const onOpenChange = vi.fn();
+    const onDeleted = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(
+      <DeleteTaskDialog
+        task={task}
+        open
+        onOpenChange={onOpenChange}
+        onDeleted={onDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除を実行" }));
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$delete).toHaveBeenCalledWith(
+        { param: { id: "task-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("「キャンセル」では DELETE は呼ばれず onOpenChange(false) のみ", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(
+      <DeleteTaskDialog task={task} open onOpenChange={onOpenChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(api.tasks[":id"].$delete).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("API 失敗時はエラーメッセージを表示し onDeleted は呼ばれない", async () => {
+    vi.mocked(api.tasks[":id"].$delete).mockResolvedValue(
+      mockJson({ error: "bad" }, 500),
+    );
+    const onDeleted = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(
+      <DeleteTaskDialog
+        task={task}
+        open
+        onOpenChange={() => {}}
+        onDeleted={onDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除を実行" }));
+    expect(
+      await screen.findByText("タスクの削除に失敗しました"),
+    ).toBeInTheDocument();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/test/tasks.editDialog.test.tsx
+++ b/apps/web/src/test/tasks.editDialog.test.tsx
@@ -1,0 +1,245 @@
+import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
+import type { Task } from "@/features/tasks/types";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+    tasks: {
+      ":id": {
+        $patch: vi.fn(),
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const baseTask: Task = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: "本文",
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 3,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: null,
+  assignees: [
+    {
+      id: "user-1",
+      name: "alice",
+      displayName: "Alice",
+      email: "a@example.com",
+    },
+  ],
+  recurringMeetings: [{ id: "rmtg-1", name: "週次定例" }],
+};
+
+beforeEach(() => {
+  vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+    mockJson([
+      {
+        userId: "user-1",
+        name: "alice",
+        displayName: "Alice",
+        email: "a@example.com",
+        role: "member",
+        joinedAt: "2026-05-01T00:00:00.000Z",
+      },
+      {
+        userId: "user-2",
+        name: "bob",
+        displayName: "Bob",
+        email: "b@example.com",
+        role: "member",
+        joinedAt: "2026-05-01T00:00:00.000Z",
+      },
+    ]),
+  );
+  vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+    mockJson([
+      {
+        id: "rmtg-1",
+        organizationId: "org-1",
+        name: "週次定例",
+        description: null,
+        scheduleCron: "0 10 * * 1",
+        defaultDurationMinutes: 60,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+        _count: { members: 1 },
+      },
+    ]),
+  );
+  vi.mocked(api.tasks[":id"].$patch).mockResolvedValue(
+    mockJson({ ...baseTask, version: 4 }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EditTaskDialog", () => {
+  it("初期値が task からプリフィルされる", async () => {
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+    expect(await screen.findByLabelText("タイトル")).toHaveValue("資料作成");
+    expect(screen.getByLabelText("本文")).toHaveValue("本文");
+    expect(screen.getByLabelText("ステータス")).toHaveValue("todo");
+  });
+
+  it("title を変更して保存すると PATCH が呼ばれ version が送られる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+
+    const titleInput = await screen.findByLabelText("タイトル");
+    await user.clear(titleInput);
+    await user.type(titleInput, "更新後");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$patch).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks[":id"].$patch).mock.calls[0];
+    const sent = (call[0] as { json: { title?: string; version: number } })
+      .json;
+    expect(sent.version).toBe(3);
+    expect(sent.title).toBe("更新後");
+  });
+
+  it("変更なしの保存でも version のみは送る（API 側で 400 になるがフロントは試みる）", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+
+    await screen.findByLabelText("タイトル");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$patch).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks[":id"].$patch).mock.calls[0];
+    const sent = (call[0] as { json: Record<string, unknown> }).json;
+    // version 以外のキーは無い
+    expect(Object.keys(sent)).toEqual(["version"]);
+  });
+
+  it("409 (version 不一致) は専用メッセージと再取得ボタンを表示する", async () => {
+    vi.mocked(api.tasks[":id"].$patch).mockResolvedValue(
+      mockJson({ error: "conflict" }, 409),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+
+    const titleInput = await screen.findByLabelText("タイトル");
+    await user.clear(titleInput);
+    await user.type(titleInput, "更新後");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(
+      await screen.findByText(/他のユーザーが先に更新しました/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "最新を取得" }),
+    ).toBeInTheDocument();
+  });
+
+  it("AI 由来フィールドがあれば read-only セクションが表示される", async () => {
+    const aiTask: Task = {
+      ...baseTask,
+      sourceQuote: "「GW明けまでに」",
+      ambiguityFlags: ["no_deadline_absolute"],
+    };
+    renderWithQuery(
+      <EditTaskDialog task={aiTask} open onOpenChange={() => {}} />,
+    );
+    expect(
+      await screen.findByText("AI 抽出情報（読み取り専用）"),
+    ).toBeInTheDocument();
+  });
+
+  it("AI 由来フィールドが全て空ならセクションは非表示", async () => {
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+    await screen.findByLabelText("タイトル");
+    expect(
+      screen.queryByText("AI 抽出情報（読み取り専用）"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dueDate を変更すると null から ISO に変換されて送られる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <EditTaskDialog task={baseTask} open onOpenChange={() => {}} />,
+    );
+
+    const dueInput = await screen.findByLabelText("期限");
+    await user.type(dueInput, "2026-05-25");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(api.tasks[":id"].$patch).toHaveBeenCalled());
+    const call = vi.mocked(api.tasks[":id"].$patch).mock.calls[0];
+    expect((call[0] as { json: { dueDate?: string } }).json.dueDate).toBe(
+      "2026-05-25T00:00:00.000Z",
+    );
+  });
+
+  it("onRequestDelete を渡すと削除ボタンが表示される", async () => {
+    const onRequestDelete = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(
+      <EditTaskDialog
+        task={baseTask}
+        open
+        onOpenChange={() => {}}
+        onRequestDelete={onRequestDelete}
+      />,
+    );
+
+    const deleteBtn = await screen.findByRole("button", { name: "削除" });
+    await user.click(deleteBtn);
+    expect(onRequestDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/test/tasks.pickers.test.tsx
+++ b/apps/web/src/test/tasks.pickers.test.tsx
@@ -1,0 +1,134 @@
+import { AssigneePicker } from "@/features/tasks/components/AssigneePicker";
+import { RecurringMeetingPicker } from "@/features/tasks/components/RecurringMeetingPicker";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AssigneePicker", () => {
+  it("メンバーをチップで表示しトグルできる", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson([
+        {
+          userId: "user-1",
+          name: "alice",
+          displayName: "Alice",
+          email: "a@example.com",
+          role: "member",
+          joinedAt: "2026-05-01T00:00:00.000Z",
+        },
+        {
+          userId: "user-2",
+          name: "bob",
+          displayName: "Bob",
+          email: "b@example.com",
+          role: "member",
+          joinedAt: "2026-05-01T00:00:00.000Z",
+        },
+      ]),
+    );
+
+    const onChange = vi.fn();
+    renderWithQuery(
+      <AssigneePicker
+        organizationId="org-1"
+        value={["user-1"]}
+        onChange={onChange}
+      />,
+    );
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+
+    // 既選択を外す
+    await userEvent.click(screen.getByText("Alice"));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("メンバー 0 件は空メッセージ", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithQuery(
+      <AssigneePicker organizationId="org-1" value={[]} onChange={() => {}} />,
+    );
+    expect(
+      await screen.findByText("組織にメンバーがいません"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("RecurringMeetingPicker", () => {
+  it("定例をチップで表示しトグルできる", async () => {
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([
+        {
+          id: "rmtg-1",
+          organizationId: "org-1",
+          name: "週次定例",
+          description: null,
+          scheduleCron: "0 10 * * 1",
+          defaultDurationMinutes: 60,
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+          _count: { members: 1 },
+        },
+      ]),
+    );
+
+    const onChange = vi.fn();
+    renderWithQuery(
+      <RecurringMeetingPicker
+        organizationId="org-1"
+        value={[]}
+        onChange={onChange}
+      />,
+    );
+
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("週次定例"));
+    expect(onChange).toHaveBeenCalledWith(["rmtg-1"]);
+  });
+
+  it("定例 0 件は空メッセージ", async () => {
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithQuery(
+      <RecurringMeetingPicker
+        organizationId="org-1"
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      await screen.findByText("組織に定例がありません"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #169

## 概要・目的
* My タスク・定例詳細・会議詳細など複数画面から共通利用する、タスクの作成・編集・削除ダイアログを実装する
* AI 由来 read-only フィールドを編集時に折りたたみ表示できる枠を用意し、AI 連携経路と整合させる
* 楽観的ロック競合（409）専用 UI を備え、ユーザーが安全に最新化できる動線を提供する

## 背景
* Backend CRUD (#164) と Frontend 基盤 (#166) は揃っており、UI 上の最終ピースとしてダイアログ群が必要だった
* My タスクページ (#167)・定例詳細 (#168) の「タスクを追加」ボタンや行クリックは現在 disabled だが、本 PR の完了後に各画面の後続 PR で有効化する

## 変更内容
* **共通基盤**
  * `features/organizations/hooks/useOrganizationMembers.ts`: 既存 inline パターンを hook 化
  * `features/tasks/components/AssigneePicker.tsx`: 組織メンバーをチップで multi-select
  * `features/tasks/components/RecurringMeetingPicker.tsx`: 定例をチップで multi-select

* **作成ダイアログ** `features/tasks/components/CreateTaskDialog.tsx`
  * `organizationId` 必須、`recurringMeetingId?` で初期 attach、`originMeetingId?` で発生源伝播
  * `<input type="date">` の "YYYY-MM-DD" を `new Date(...).toISOString()` で UTC 00:00 の ISO datetime に変換
  * 空フィールドは API に送らず（undefined）、status は手動経路では UI に出さず todo 固定

* **編集ダイアログ** `features/tasks/components/EditTaskDialog.tsx`
  * 元 task と diff を取って変更フィールドのみ PATCH に乗せる
  * 手動 status は `todo / in_progress / done / rejected` の 4 値のみドロップダウン表示（draft/reviewing は AI 専用なので除外）
  * `TaskAiReadOnlySection` で AI 由来フィールドを折りたたみ表示（全 null なら非表示）
  * 409 (`TaskVersionConflictError`) 専用 UI ＋「最新を取得」ボタン（detail + all を invalidate）
  * `onRequestDelete` プロップで削除ボタンを表示

* **削除確認ダイアログ** `features/tasks/components/DeleteTaskDialog.tsx`
  * 制御モードのみ（親が open / onDeleted を制御）
  * `useDeleteTask` 経由で DELETE、削除成功時に `onDeleted` で親に通知

* **テスト（22 件追加）**
  * Picker x 4 / CreateTaskDialog x 6 / EditTaskDialog x 8 / DeleteTaskDialog x 4
  * web 全体 273 件 pass

## 動作確認手順
1. `git checkout issue-169-task-form-dialog`
2. `make install`
3. `make test` で 全テスト pass（web 29 ファイル / 273 件、本 PR で 22 件追加）を確認
4. `make lint` で警告ゼロを確認
5. 本 PR は単体ダイアログコンポーネントのみで画面統合はないため、画面動作確認は後続 PR で行う
6. 既存テスト（My タスクページ・定例詳細）には影響しないため `make dev` での既存画面動作は維持

## スクリーンショット
画面イメージ（テキストモック）:

```
CreateTaskDialog
┌──────────────────────────────────────────┐
│ タスクを作成                             │
│ 新しいタスクを作成します                 │
│                                          │
│ タイトル   [____________________________]│
│ 本文       [____________________________]│
│ 必須度     [未指定 ▼]                    │
│ 期限 [____] 開始日 [____] 再検討日 [____] │
│ 紐付ける定例: [週次定例] [月次会]        │
│ 担当者:       [Alice]   [Bob]            │
│                                  [作成]  │
└──────────────────────────────────────────┘

EditTaskDialog
┌──────────────────────────────────────────┐
│ タスクを編集                             │
│ ... 入力欄 ...                           │
│ ステータス [未着手 ▼]  必須度 [必須 ▼]   │
│ ▼ AI 抽出情報（読み取り専用）            │
│   根拠発話   「GW明けまでに」            │
│   曖昧フラグ [期限が相対表現のみ]        │
│   持ち越し回数 2                         │
│ [削除]                          [保存]   │
└──────────────────────────────────────────┘
```

409 競合時:
```
┌──────────────────────────────────────────┐
│ ! 他のユーザーが先に更新しました。       │
│   最新を取得して再試行してください。     │
│   [最新を取得]                           │
└──────────────────────────────────────────┘
```

## 補足
* 本 PR は **単体ダイアログのみ**で、各画面への統合（disabled CTA の有効化、行クリック動線）は後続 PR で行う
* Date 入力は UTC 00:00 として扱う（best practice：localized timezone のリスクを避け、API 側 nullable DateTime と整合）
* `useSemanticElements` ルールについては Picker / フィルタ UI で `fieldset/legend` の代わりに `div + role=group` を使用（legend のレイアウト崩れ回避、My タスク・定例詳細と同方針）