### PR TITLE
feat: 会議詳細ページ /meetings/$id と GET API、関連 CTA 有効化

### DIFF
--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -49,6 +49,49 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
     }
     return c.json(meeting, 201);
   })
+  .get("/:id", auth, async (c) => {
+    const id = c.req.param("id");
+    // 会議 + 紐付く定例 + 組織を一度に取得する。単発会議（recurringMeetingId=null）は
+    // 組織判定不能のため 404 で拒否する（/:id/tasks と同方針）。
+    const meeting = await prisma.meeting.findUnique({
+      where: { id },
+      include: {
+        recurringMeeting: {
+          include: {
+            organization: { select: { id: true, name: true } },
+          },
+        },
+      },
+    });
+    if (!meeting?.recurringMeeting) {
+      return c.json({ error: "会議が見つかりません" }, 404);
+    }
+
+    const user = c.var.user;
+    const membership = await prisma.organizationMembership.findUnique({
+      where: {
+        userId_organizationId: {
+          userId: user.id,
+          organizationId: meeting.recurringMeeting.organizationId,
+        },
+      },
+    });
+    if (!membership) {
+      return c.json({ error: "会議が見つかりません" }, 404);
+    }
+
+    // 詳細レスポンス: meeting メタ + 紐付く recurringMeeting (id/name) + organization (id/name) の最小情報。
+    // 議事録メタや解析結果は別 Issue で追加する想定なので、ここでは構造を保ったまま薄く返す。
+    const { recurringMeeting, ...rest } = meeting;
+    return c.json({
+      ...rest,
+      recurringMeeting: {
+        id: recurringMeeting.id,
+        name: recurringMeeting.name,
+      },
+      organization: recurringMeeting.organization,
+    });
+  })
   .get(
     "/:id/tasks",
     auth,

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -252,3 +252,76 @@ describe("GET /meetings/:id/tasks", () => {
     expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 });
+
+describe("GET /meetings/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const detailMeeting = {
+    id: "mtg-1",
+    title: "第3回",
+    heldAt: new Date("2026-05-17T10:00:00Z"),
+    estimatedDurationMinutes: 60,
+    estimationNote: null,
+    sequenceNumber: 3,
+    previousMeetingId: null,
+    transcriptionQuality: null,
+    supplementaryMemo: null,
+    meetingType: "recurring_meeting",
+    recurringMeetingId: "rmtg-1",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    recurringMeeting: {
+      id: "rmtg-1",
+      name: "週次定例",
+      organizationId: "org-1",
+      organization: { id: "org-1", name: "ACME" },
+    },
+  };
+
+  it("組織メンバーは 200 で詳細を取得できる", async () => {
+    mockFindUnique.mockResolvedValue(detailMeeting as never);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+
+    const res = await app.request("/meetings/mtg-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      title: string;
+      recurringMeeting: { id: string; name: string };
+      organization: { id: string; name: string };
+    };
+    expect(body.id).toBe("mtg-1");
+    expect(body.title).toBe("第3回");
+    expect(body.recurringMeeting).toEqual({ id: "rmtg-1", name: "週次定例" });
+    expect(body.organization).toEqual({ id: "org-1", name: "ACME" });
+  });
+
+  it("会議不存在は 404", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing");
+    expect(res.status).toBe(404);
+  });
+
+  it("単発会議（recurringMeetingId=null）は 404", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "mtg-x",
+      title: "単発",
+      heldAt: new Date(),
+      recurringMeetingId: null,
+      recurringMeeting: null,
+    } as never);
+    const res = await app.request("/meetings/mtg-x");
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属は 404", async () => {
+    mockFindUnique.mockResolvedValue(detailMeeting as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1");
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -1,0 +1,38 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// 会議詳細レスポンス。API 側 (apps/api/src/routes/meetings.ts) の整形に揃える。
+// 議事録メタ・解析結果などは別 Issue で拡張予定なので、ここでは最小限に絞っている。
+export type MeetingDetail = {
+  id: string;
+  title: string;
+  heldAt: string;
+  estimatedDurationMinutes: number | null;
+  estimationNote: string | null;
+  sequenceNumber: number | null;
+  previousMeetingId: string | null;
+  transcriptionQuality: string | null;
+  supplementaryMemo: string | null;
+  meetingType: string;
+  recurringMeetingId: string | null;
+  createdAt: string;
+  recurringMeeting: { id: string; name: string };
+  organization: { id: string; name: string };
+};
+
+// 会議詳細を取得する hook。クエリキーは ["meetings", id, "detail"]。
+export function useMeetingDetail(id: string) {
+  return useQuery<MeetingDetail>({
+    queryKey: ["meetings", id, "detail"],
+    queryFn: async () => {
+      const res = await api.meetings[":id"].$get(
+        { param: { id } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch meeting: ${res.status}`);
+      }
+      return (await res.json()) as MeetingDetail;
+    },
+  });
+}

--- a/apps/web/src/features/recurring-meetings/components/MeetingCard.tsx
+++ b/apps/web/src/features/recurring-meetings/components/MeetingCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import type { MeetingListItem } from "../hooks/useRecurringMeetingMeetings";
 
 function formatDateTime(iso: string): string {
@@ -13,17 +14,24 @@ function formatDateTime(iso: string): string {
 }
 
 // 個別 Meeting を表示するカード。タイトル / 開催日時 / 所要時間の最小情報を出す。
+// クリックで会議詳細ページ（/meetings/$id）へ遷移する。
 // 議事録メタや話者などの詳細は将来の Meeting 詳細ページで提供する想定。
 export function MeetingCard({ meeting }: { meeting: MeetingListItem }) {
   return (
-    <li className="flex flex-col gap-1 rounded-md border bg-card p-4 shadow-sm">
-      <span className="font-medium truncate">{meeting.title}</span>
-      <div className="flex items-center gap-3 text-xs text-muted-foreground">
-        <span>{formatDateTime(meeting.heldAt)}</span>
-        {meeting.estimatedDurationMinutes !== null && (
-          <span>{meeting.estimatedDurationMinutes} 分</span>
-        )}
-      </div>
+    <li>
+      <Link
+        to="/meetings/$id"
+        params={{ id: meeting.id }}
+        className="flex flex-col gap-1 rounded-md border bg-card p-4 shadow-sm hover:bg-accent transition-colors"
+      >
+        <span className="font-medium truncate">{meeting.title}</span>
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span>{formatDateTime(meeting.heldAt)}</span>
+          {meeting.estimatedDurationMinutes !== null && (
+            <span>{meeting.estimatedDurationMinutes} 分</span>
+          )}
+        </div>
+      </Link>
     </li>
   );
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as TasksIndexRouteImport } from './routes/tasks.index'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
 import { Route as RecurringMeetingsIdRouteImport } from './routes/recurring-meetings.$id'
 import { Route as OrganizationsIdRouteImport } from './routes/organizations.$id'
+import { Route as MeetingsIdRouteImport } from './routes/meetings.$id'
 
 const OrganizationsRoute = OrganizationsRouteImport.update({
   id: '/organizations',
@@ -52,11 +53,17 @@ const OrganizationsIdRoute = OrganizationsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => OrganizationsRoute,
 } as any)
+const MeetingsIdRoute = MeetingsIdRouteImport.update({
+  id: '/meetings/$id',
+  path: '/meetings/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
+  '/meetings/$id': typeof MeetingsIdRoute
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
@@ -65,6 +72,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/meetings/$id': typeof MeetingsIdRoute
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations': typeof OrganizationsIndexRoute
@@ -75,6 +83,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
+  '/meetings/$id': typeof MeetingsIdRoute
   '/organizations/$id': typeof OrganizationsIdRoute
   '/recurring-meetings/$id': typeof RecurringMeetingsIdRoute
   '/organizations/': typeof OrganizationsIndexRoute
@@ -86,6 +95,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/organizations'
+    | '/meetings/$id'
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations/'
@@ -94,6 +104,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/login'
+    | '/meetings/$id'
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations'
@@ -103,6 +114,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/organizations'
+    | '/meetings/$id'
     | '/organizations/$id'
     | '/recurring-meetings/$id'
     | '/organizations/'
@@ -113,6 +125,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
+  MeetingsIdRoute: typeof MeetingsIdRoute
   RecurringMeetingsIdRoute: typeof RecurringMeetingsIdRoute
   TasksIndexRoute: typeof TasksIndexRoute
 }
@@ -168,6 +181,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrganizationsIdRouteImport
       parentRoute: typeof OrganizationsRoute
     }
+    '/meetings/$id': {
+      id: '/meetings/$id'
+      path: '/meetings/$id'
+      fullPath: '/meetings/$id'
+      preLoaderRoute: typeof MeetingsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -189,6 +209,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
+  MeetingsIdRoute: MeetingsIdRoute,
   RecurringMeetingsIdRoute: RecurringMeetingsIdRoute,
   TasksIndexRoute: TasksIndexRoute,
 }

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,0 +1,205 @@
+import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
+import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
+import { taskStatusLabels } from "@/features/tasks/labels";
+import type { TaskStatus } from "@/features/tasks/types";
+import { cn } from "@/lib/utils";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+
+// 手動経路で表示する status の選択肢。AI 専用の draft/reviewing は UI から除外。
+const FILTERABLE_STATUSES: TaskStatus[] = [
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+];
+
+const meetingSearchSchema = z.object({
+  status: z.string().optional(),
+});
+
+type MeetingSearch = z.infer<typeof meetingSearchSchema>;
+
+export const Route = createFileRoute("/meetings/$id")({
+  validateSearch: meetingSearchSchema,
+  component: MeetingDetailPage,
+});
+
+function parseStatusParam(raw: string | undefined): TaskStatus[] | undefined {
+  if (!raw) return undefined;
+  const arr = raw
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v): v is TaskStatus =>
+      FILTERABLE_STATUSES.includes(v as TaskStatus),
+    );
+  return arr.length > 0 ? arr : undefined;
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function MeetingDetailPage() {
+  const { id } = Route.useParams();
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  return (
+    <MeetingDetailView
+      id={id}
+      search={search}
+      onSearchChange={(next) => navigate({ search: next })}
+    />
+  );
+}
+
+// route コンポーネントから分離したビュー。テストでは props で id を渡して直接 render する
+// （既存 RecurringMeetingDetailView と同じ流儀）。
+export function MeetingDetailView({
+  id,
+  search = {},
+  onSearchChange = () => {},
+  now,
+}: {
+  id: string;
+  search?: MeetingSearch;
+  onSearchChange?: (next: MeetingSearch) => void;
+  now?: Date;
+}) {
+  const detailQuery = useMeetingDetail(id);
+  const statusArr = parseStatusParam(search.status);
+  const tasksQuery = useMeetingTasks(
+    id,
+    statusArr ? { status: statusArr } : undefined,
+  );
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="container mx-auto p-8">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+  if (detailQuery.isError || !detailQuery.data) {
+    return (
+      <div className="container mx-auto p-8">
+        <p>会議の取得に失敗しました</p>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+
+  const toggleStatus = (s: TaskStatus) => {
+    const current = new Set(statusArr ?? []);
+    if (current.has(s)) current.delete(s);
+    else current.add(s);
+    const next = Array.from(current);
+    onSearchChange({
+      ...search,
+      status: next.length > 0 ? next.join(",") : undefined,
+    });
+  };
+
+  return (
+    <section
+      aria-labelledby="meeting-title"
+      className="container mx-auto p-8 space-y-6"
+    >
+      <header className="space-y-2">
+        <Link
+          to="/recurring-meetings/$id"
+          params={{ id: detail.recurringMeeting.id }}
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← {detail.recurringMeeting.name} に戻る
+        </Link>
+        <h1 id="meeting-title" className="text-2xl font-bold">
+          {detail.title}
+        </h1>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <span>{formatDateTime(detail.heldAt)}</span>
+          {detail.estimatedDurationMinutes !== null && (
+            <span>{detail.estimatedDurationMinutes} 分</span>
+          )}
+        </div>
+      </header>
+
+      <section aria-label="タスク" className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">タスク</h2>
+          {/* この会議由来として origin を伝播し、紐付け先の定例も初期 attach する。 */}
+          <CreateTaskDialog
+            organizationId={detail.organization.id}
+            recurringMeetingId={detail.recurringMeeting.id}
+            originMeetingId={detail.id}
+          />
+        </div>
+
+        {/* status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
+            biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+            避けるため div + role=group で代替する。 */}
+        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
+        <div
+          role="group"
+          aria-labelledby="meeting-task-status-filter-label"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <span
+            id="meeting-task-status-filter-label"
+            className="text-xs text-muted-foreground"
+          >
+            ステータス
+          </span>
+          {FILTERABLE_STATUSES.map((s) => {
+            const checked = statusArr?.includes(s) ?? false;
+            return (
+              <label
+                key={s}
+                className={cn(
+                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                  checked
+                    ? "bg-foreground text-background border-foreground"
+                    : "bg-card text-foreground border-border/60 hover:bg-accent",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked}
+                  onChange={() => toggleStatus(s)}
+                />
+                {taskStatusLabels[s]}
+              </label>
+            );
+          })}
+        </div>
+
+        {tasksQuery.isLoading ? (
+          <p className="text-muted-foreground">タスクを読み込み中...</p>
+        ) : tasksQuery.isError ? (
+          <p className="text-destructive text-sm">タスクの取得に失敗しました</p>
+        ) : (tasksQuery.data ?? []).length === 0 ? (
+          <p className="text-muted-foreground">
+            この会議から発生したタスクはまだありません
+          </p>
+        ) : (
+          <ul aria-label="会議由来のタスク一覧" className="grid gap-2">
+            {(tasksQuery.data ?? []).map((task) => (
+              <TaskRow key={task.id} task={task} now={now} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -7,6 +7,7 @@ import {
   describeCron,
   parseCron,
 } from "@/features/recurring-meetings/scheduleCron";
+import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { TaskRow } from "@/features/tasks/components/TaskRow";
 import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMeetingTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
@@ -190,16 +191,12 @@ export function RecurringMeetingDetailView({
       <section aria-label="タスク" className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-semibold">タスク</h2>
-          {/* 作成ダイアログは #169 で実装予定。完成までは disabled プレースホルダ。
-              title 属性で意図をホバー時に説明する。 */}
-          <button
-            type="button"
-            disabled
-            title="タスク作成ダイアログは準備中です"
-            className="text-sm px-3 py-1.5 rounded-md border border-border/60 bg-muted/50 text-muted-foreground cursor-not-allowed"
-          >
-            タスクを追加
-          </button>
+          {/* タスク作成ダイアログ (#169) で実装したものを起動する。
+              現定例を初期 attach する。originMeetingId は会議詳細ページ側で扱う。 */}
+          <CreateTaskDialog
+            organizationId={detail.organizationId}
+            recurringMeetingId={detail.id}
+          />
         </div>
 
         {/* status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -1,0 +1,219 @@
+import type { MeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    meetings: {
+      ":id": {
+        $get: vi.fn(),
+        tasks: { $get: vi.fn() },
+      },
+    },
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+    tasks: {
+      $post: vi.fn(),
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+// Link / createFileRoute は RouterProvider 配下でないと落ちる。
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  type MockLinkProps = {
+    to: string;
+    params?: Record<string, string>;
+    children?: React.ReactNode;
+    className?: string;
+  };
+  return {
+    ...actual,
+    Link: ({ to, params, children, className }: MockLinkProps) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+    createFileRoute: () => () => ({}),
+  };
+});
+
+import { api } from "@/lib/api";
+import { MeetingDetailView } from "../routes/meetings.$id";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const detail: MeetingDetail = {
+  id: "mtg-1",
+  title: "第3回",
+  heldAt: "2026-05-17T01:00:00.000Z",
+  estimatedDurationMinutes: 60,
+  estimationNote: null,
+  sequenceNumber: 3,
+  previousMeetingId: null,
+  transcriptionQuality: null,
+  supplementaryMemo: null,
+  meetingType: "recurring_meeting",
+  recurringMeetingId: "rmtg-1",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  recurringMeeting: { id: "rmtg-1", name: "週次定例" },
+  organization: { id: "org-1", name: "ACME" },
+};
+
+const sampleTask = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: "mtg-1",
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo" as const,
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: {
+    id: "mtg-1",
+    title: "第3回",
+    heldAt: "2026-05-17T01:00:00.000Z",
+    recurringMeetingId: "rmtg-1",
+  },
+  assignees: [],
+  recurringMeetings: [{ id: "rmtg-1", name: "週次定例" }],
+};
+
+beforeEach(() => {
+  vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detail));
+  vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(mockJson([]));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const NOW = new Date("2026-05-17T00:00:00Z");
+
+describe("MeetingDetailView", () => {
+  it("会議タイトル・日時・所要時間を表示する", async () => {
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(await screen.findByText("第3回")).toBeInTheDocument();
+    expect(screen.getByText("60 分")).toBeInTheDocument();
+  });
+
+  it("親定例へのパンくずリンクが /recurring-meetings/$id を指す", async () => {
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const link = await screen.findByRole("link", {
+      name: /週次定例 に戻る/,
+    });
+    expect(link).toHaveAttribute("href", "/recurring-meetings/rmtg-1");
+  });
+
+  it("タスク 1 件を行として表示する", async () => {
+    vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(
+      mockJson([sampleTask]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const list = await screen.findByLabelText("会議由来のタスク一覧");
+    expect(within(list).getByText("資料作成")).toBeInTheDocument();
+  });
+
+  it("0 件時は専用メッセージを表示する", async () => {
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByText("この会議から発生したタスクはまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("status フィルタ切替で onSearchChange が呼ばれる", async () => {
+    const onSearchChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(
+      <MeetingDetailView
+        id="mtg-1"
+        search={{}}
+        onSearchChange={onSearchChange}
+        now={NOW}
+      />,
+    );
+
+    await screen.findByText("タスク");
+    await user.click(screen.getByLabelText(/未着手/));
+    expect(onSearchChange).toHaveBeenCalledWith({ status: "todo" });
+  });
+
+  it("初期 status フィルタが API リクエストに含まれる", async () => {
+    renderWithQuery(
+      <MeetingDetailView
+        id="mtg-1"
+        search={{ status: "in_progress" }}
+        now={NOW}
+      />,
+    );
+    await screen.findByText("タスク");
+    const call = vi.mocked(api.meetings[":id"].tasks.$get).mock.calls[0];
+    expect((call[0] as { query: { status?: string } }).query.status).toBe(
+      "in_progress",
+    );
+  });
+
+  it("会議取得失敗時はエラーメッセージを表示する", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockRejectedValue(new Error("network"));
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByText("会議の取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("「タスクを追加」ボタンが押せる（CreateTaskDialog 起動）", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+
+    const user = userEvent.setup();
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const addBtn = await screen.findByRole("button", { name: "タスクを追加" });
+    expect(addBtn).not.toBeDisabled();
+    await user.click(addBtn);
+    // ダイアログが開いて Create のヘッダが見える
+    expect(
+      await screen.findByRole("heading", { name: "タスクを作成" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -372,7 +372,7 @@ describe("定例詳細ページ - タスクセクション", () => {
     expect(within(list).getByText("資料作成")).toBeInTheDocument();
   });
 
-  it("0 件時は空状態メッセージと disabled の「タスクを追加」ボタンを表示する", async () => {
+  it("0 件時は空状態メッセージと「タスクを追加」ボタンを表示する", async () => {
     vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
       mockJson([]),
     );
@@ -380,8 +380,9 @@ describe("定例詳細ページ - タスクセクション", () => {
     expect(
       await screen.findByText("このプロジェクトのタスクはまだありません"),
     ).toBeInTheDocument();
+    // #169 のダイアログ完成により、ボタンは有効化された。
     const addBtn = screen.getByRole("button", { name: "タスクを追加" });
-    expect(addBtn).toBeDisabled();
+    expect(addBtn).not.toBeDisabled();
   });
 
   it("status チェックボックスを切り替えると onSearchChange が呼ばれる", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #170

## 概要・目的
* 個別会議の詳細ページ `/meetings/\$id` を新設し、会議メタ情報と originMeetingId 由来のタスク一覧を提供する
* 単体取得用の `GET /meetings/:id` API を Backend に追加する
* `MeetingCard` のクリックで詳細ページへ遷移できるよう Link 化する
* #169 のダイアログ完成を受け、定例詳細ページの disabled CTA を `CreateTaskDialog` に置換

## 背景
* 会議カードのクリック導線が無く、議事録や AI 解析の入り口になる「会議詳細」が存在しなかった
* #167/#168 で disabled だった「タスクを追加」CTA も #169 で実装されたダイアログを使って有効化できるタイミング

## 変更内容
* **Backend**
  * `apps/api/src/routes/meetings.ts`: `GET /:id` を追加（auth inline）
    * 紐付く `recurringMeeting` 経由で組織判定。単発会議は 404
    * レスポンスは meeting メタ + recurringMeeting (id/name) + organization (id/name) の最小情報
  * `apps/api/test/meetings.test.ts`: 4 件追加（正常系・不存在・単発会議 404・組織非所属 404）

* **Frontend 新規**
  * `features/meetings/hooks/useMeetingDetail.ts`: `["meetings", id, "detail"]` クエリで詳細取得
  * `routes/meetings.\$id.tsx`:
    * `validateSearch` で `status` フィルタを URL に永続化
    * 親定例へのパンくず `← {recurringMeeting.name} に戻る`
    * 会議タイトル / 日時 / 所要時間のヘッダ
    * `useMeetingTasks` + `TaskRow` でタスク一覧、空状態メッセージ
    * `CreateTaskDialog` を `organizationId` + `recurringMeetingId` + `originMeetingId` 付きで有効化
  * `test/meetings.\$id.test.tsx`: 8 件追加

* **Frontend 変更**
  * `features/recurring-meetings/components/MeetingCard.tsx`: カード全体を `Link` でラップし `/meetings/\$id` へ遷移
  * `routes/recurring-meetings.\$id.tsx`: disabled プレースホルダだった「タスクを追加」を `CreateTaskDialog` に置換（テストも追従）

## 動作確認手順
1. `git checkout issue-170-meeting-detail-page`
2. `make install`
3. `make dev` で全サービス起動
4. fake-auth でログイン後、組織 → 定例詳細に遷移し、会議カードをクリックして `/meetings/\$id` に遷移できることを確認
5. 会議詳細ページで会議タイトル / 日時 / パンくず / タスク一覧 / 「タスクを追加」ボタンが表示されることを確認
6. 「タスクを追加」をクリック → ダイアログが開き、紐付ける定例に当該定例が初期 attach されることを確認（API レスポンスで originMeetingId / recurringMeetingIds が乗る）
7. 定例詳細ページ `/recurring-meetings/\$id` でも「タスクを追加」が有効化されていることを確認
8. `make test` で全テスト pass（api 184 件・web 281 件、本 PR で 12 件追加）を確認
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1130" height="801" alt="image" src="https://github.com/user-attachments/assets/24e6f8c9-04ef-4a3b-b184-cb896f284608" />
<img width="585" height="558" alt="image" src="https://github.com/user-attachments/assets/7c9ad304-818b-4bf6-bade-2fc7388255af" />
<img width="1126" height="435" alt="image" src="https://github.com/user-attachments/assets/e9040940-ff5f-4c57-8481-9a595ce00f2a" />

## 補足
* 議事録・文字起こし・AI 解析結果の表示は本 Issue では対象外（後続の AI 機能実装で追加）
* 会議の編集 / 削除も対象外（別 Issue）
* 単発会議は MVP では 404（既存 `/:id/tasks` と同方針）
* `/tasks`（My タスクページ）の行クリック → EditTaskDialog 起動は別 Issue / 追従 PR で扱う