### PR TITLE
feat(web): タスク行クリックで EditTaskDialog を起動可能にする（共通ラッパー）

### DIFF
--- a/apps/web/src/features/tasks/components/TaskListWithDialogs.tsx
+++ b/apps/web/src/features/tasks/components/TaskListWithDialogs.tsx
@@ -1,0 +1,109 @@
+import { DeleteTaskDialog } from "@/features/tasks/components/DeleteTaskDialog";
+import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
+import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import type { TaskListItem } from "@/features/tasks/types";
+import { useState } from "react";
+
+// タスク一覧の行クリック → 編集ダイアログ → 削除ダイアログまで一気通貫で扱う共通ラッパー。
+// 各ページ（My タスク・定例詳細・会議詳細）で重複する「行クリック state + useTaskDetail
+// + EditTaskDialog + DeleteTaskDialog の連動」をここに閉じ込める。
+//
+// 動作:
+//   1. 行クリック → selectedTaskId をセット
+//   2. useTaskDetail で詳細取得（取得中はダイアログ未表示）
+//   3. 取得成功で EditTaskDialog を開く
+//   4. 削除ボタン押下で DeleteTaskDialog を開く
+//   5. ダイアログ閉鎖時に selectedTaskId をクリア
+export function TaskListWithDialogs({
+  tasks,
+  ariaLabel,
+  now,
+}: {
+  tasks: TaskListItem[];
+  ariaLabel: string;
+  now?: Date;
+}) {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // taskId が null の時は useTaskDetail 側で enabled:false になり fetch されない。
+  const detailQuery = useTaskDetail(selectedTaskId);
+  const task = detailQuery.data ?? null;
+  const isLoading = selectedTaskId !== null && detailQuery.isLoading;
+  const isError = selectedTaskId !== null && detailQuery.isError;
+
+  const closeAll = () => {
+    setDeleteOpen(false);
+    setSelectedTaskId(null);
+  };
+
+  return (
+    <>
+      <ul aria-label={ariaLabel} className="grid gap-2">
+        {tasks.map((t) => (
+          <TaskRow
+            key={t.id}
+            task={t}
+            now={now}
+            onClick={() => setSelectedTaskId(t.id)}
+          />
+        ))}
+      </ul>
+
+      {/* 詳細取得失敗のインラインアラート。toast UI 未導入のため簡素表示 + 再試行。 */}
+      {isError && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm flex items-center justify-between gap-2"
+        >
+          <span className="text-destructive">
+            タスク詳細の取得に失敗しました
+          </span>
+          <button
+            type="button"
+            onClick={() => detailQuery.refetch()}
+            className="text-xs px-2 py-1 rounded-md border border-destructive/40 hover:bg-destructive/10"
+          >
+            再試行
+          </button>
+        </div>
+      )}
+
+      {/* 取得中はダイアログを開かず、UI を阻害しないよう軽い表示のみ。
+          長時間かかる場合はトーストやスケルトンへ拡張する余地を残す。 */}
+      {isLoading && (
+        <p className="text-xs text-muted-foreground" role="status">
+          タスク詳細を読み込み中...
+        </p>
+      )}
+
+      {/* 詳細取得成功時のみ EditTaskDialog を mount する。
+          mount/unmount で RHF の defaultValues が常に最新 task で初期化される。 */}
+      {task !== null && (
+        <EditTaskDialog
+          task={task}
+          open={!deleteOpen}
+          onOpenChange={(next) => {
+            // Edit が閉じられたら全状態をリセット（次の行クリックを受けられる状態に戻す）。
+            if (!next && !deleteOpen) closeAll();
+          }}
+          onRequestDelete={() => setDeleteOpen(true)}
+        />
+      )}
+
+      {task !== null && (
+        <DeleteTaskDialog
+          task={task}
+          open={deleteOpen}
+          onOpenChange={(next) => {
+            setDeleteOpen(next);
+            // 削除ダイアログを「キャンセル」で閉じた場合は Edit に戻る。
+            // onDeleted で閉じる場合は closeAll が走り Edit ごと閉じる。
+          }}
+          onDeleted={closeAll}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/tasks/hooks/useTaskDetail.ts
+++ b/apps/web/src/features/tasks/hooks/useTaskDetail.ts
@@ -5,10 +5,13 @@ import type { Task } from "../types";
 
 // 単一タスクの詳細を取得する。assignees に email が含まれる詳細用レスポンス。
 // クエリキーは ["tasks", "detail", taskId]。
-export function useTaskDetail(taskId: string) {
+// taskId に null / 空文字を渡すと query は無効化される（行クリック前の初期状態に使う）。
+export function useTaskDetail(taskId: string | null) {
   return useQuery<Task>({
-    queryKey: taskQueryKeys.detail(taskId),
+    queryKey: taskQueryKeys.detail(taskId ?? ""),
+    enabled: !!taskId,
     queryFn: async () => {
+      if (!taskId) throw new Error("taskId is required");
       const res = await api.tasks[":id"].$get(
         { param: { id: taskId } },
         authHeaders(),

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,6 +1,6 @@
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
-import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskStatus } from "@/features/tasks/types";
@@ -193,11 +193,11 @@ export function MeetingDetailView({
             この会議から発生したタスクはまだありません
           </p>
         ) : (
-          <ul aria-label="会議由来のタスク一覧" className="grid gap-2">
-            {(tasksQuery.data ?? []).map((task) => (
-              <TaskRow key={task.id} task={task} now={now} />
-            ))}
-          </ul>
+          <TaskListWithDialogs
+            tasks={tasksQuery.data ?? []}
+            ariaLabel="会議由来のタスク一覧"
+            now={now}
+          />
         )}
       </section>
     </section>

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -8,7 +8,7 @@ import {
   parseCron,
 } from "@/features/recurring-meetings/scheduleCron";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
-import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMeetingTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskStatus } from "@/features/tasks/types";
@@ -247,11 +247,11 @@ export function RecurringMeetingDetailView({
             このプロジェクトのタスクはまだありません
           </p>
         ) : (
-          <ul aria-label="プロジェクトのタスク一覧" className="grid gap-2">
-            {(tasksQuery.data ?? []).map((task) => (
-              <TaskRow key={task.id} task={task} now={now} />
-            ))}
-          </ul>
+          <TaskListWithDialogs
+            tasks={tasksQuery.data ?? []}
+            ariaLabel="プロジェクトのタスク一覧"
+            now={now}
+          />
         )}
       </section>
     </section>

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -1,4 +1,4 @@
-import { TaskRow } from "@/features/tasks/components/TaskRow";
+import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskListItem, TaskStatus } from "@/features/tasks/types";
@@ -190,11 +190,11 @@ export function MyTasksView({
       ) : filtered.length === 0 ? (
         <p className="text-muted-foreground">担当中のタスクはありません</p>
       ) : (
-        <ul aria-label="My タスク一覧" className="grid gap-2">
-          {filtered.map((task) => (
-            <TaskRow key={task.id} task={task} now={now} />
-          ))}
-        </ul>
+        <TaskListWithDialogs
+          tasks={filtered}
+          ariaLabel="My タスク一覧"
+          now={now}
+        />
       )}
     </section>
   );

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -260,7 +260,7 @@ describe("MyTasksView - TaskRow 詳細", () => {
     expect(screen.getByTestId("task-assignee-count")).toHaveTextContent("2名");
   });
 
-  it("行は onClick 未指定なら disabled になる（ダイアログ未実装の暫定動作）", async () => {
+  it("行はクリック可能（編集ダイアログ起動の準備済み、共通ラッパー経由）", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
 
     renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
@@ -268,8 +268,10 @@ describe("MyTasksView - TaskRow 詳細", () => {
     await waitFor(() => {
       expect(screen.getByText("資料作成")).toBeInTheDocument();
     });
+    // TaskListWithDialogs の onClick が紐付くため disabled ではない。
+    // ダイアログ起動自体は TaskListWithDialogs の専用テストでカバー。
     const row = screen.getByRole("button", { name: /タスク 資料作成/ });
-    expect(row).toBeDisabled();
+    expect(row).not.toBeDisabled();
   });
 });
 

--- a/apps/web/src/test/tasks.listWithDialogs.test.tsx
+++ b/apps/web/src/test/tasks.listWithDialogs.test.tsx
@@ -1,0 +1,184 @@
+import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
+import type { Task, TaskListItem } from "@/features/tasks/types";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    tasks: {
+      ":id": {
+        $get: vi.fn(),
+        $patch: vi.fn(),
+        $delete: vi.fn(),
+      },
+    },
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const listItem: TaskListItem = {
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: null,
+  assignees: [],
+  recurringMeetings: [],
+};
+
+const detail: Task = {
+  ...listItem,
+  assignees: [],
+};
+
+beforeEach(() => {
+  vi.mocked(api.tasks[":id"].$get).mockResolvedValue(mockJson(detail));
+  vi.mocked(api.tasks[":id"].$patch).mockResolvedValue(mockJson(detail));
+  vi.mocked(api.tasks[":id"].$delete).mockResolvedValue(mockJson(null, 204));
+  vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+    mockJson([]),
+  );
+  vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+    mockJson([]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("TaskListWithDialogs", () => {
+  it("初期状態では詳細取得 API は呼ばれず、行は表示される", async () => {
+    renderWithQuery(
+      <TaskListWithDialogs tasks={[listItem]} ariaLabel="一覧" />,
+    );
+    expect(await screen.findByLabelText("一覧")).toBeInTheDocument();
+    expect(screen.getByText("資料作成")).toBeInTheDocument();
+    expect(api.tasks[":id"].$get).not.toHaveBeenCalled();
+  });
+
+  it("行クリックで GET /tasks/:id が呼ばれ、EditTaskDialog が開く", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <TaskListWithDialogs tasks={[listItem]} ariaLabel="一覧" />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /タスク 資料作成/ }),
+    );
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$get).toHaveBeenCalledWith(
+        { param: { id: "task-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    expect(
+      await screen.findByRole("heading", { name: "タスクを編集" }),
+    ).toBeInTheDocument();
+  });
+
+  it("Edit 内の削除ボタン → DeleteTaskDialog が開く（Edit は非表示に）", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <TaskListWithDialogs tasks={[listItem]} ariaLabel="一覧" />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /タスク 資料作成/ }),
+    );
+    await screen.findByRole("heading", { name: "タスクを編集" });
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    // DeleteTaskDialog のヘッダが見える
+    expect(
+      await screen.findByRole("heading", { name: "タスクを削除" }),
+    ).toBeInTheDocument();
+  });
+
+  it("削除実行で DELETE が呼ばれ、両ダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <TaskListWithDialogs tasks={[listItem]} ariaLabel="一覧" />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /タスク 資料作成/ }),
+    );
+    await screen.findByRole("heading", { name: "タスクを編集" });
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    await screen.findByRole("heading", { name: "タスクを削除" });
+    await user.click(screen.getByRole("button", { name: "削除を実行" }));
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$delete).toHaveBeenCalled();
+    });
+    // 両ダイアログが閉じる
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "タスクを編集" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "タスクを削除" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("詳細取得失敗時はエラーバナーと再試行ボタンが出る", async () => {
+    vi.mocked(api.tasks[":id"].$get).mockResolvedValue(
+      mockJson({ error: "err" }, 500),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(
+      <TaskListWithDialogs tasks={[listItem]} ariaLabel="一覧" />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /タスク 資料作成/ }),
+    );
+
+    expect(
+      await screen.findByText("タスク詳細の取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "再試行" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #181

## 概要・目的
* タスク一覧の行クリック → 編集ダイアログ → 削除ダイアログの動線を共通ラッパー `TaskListWithDialogs` に集約し、3 ページで一気に有効化する
* これにより UI から実際にタスクを編集・削除できるようになり、タスク管理 MVP が機能的に閉じる

## 背景
* #169 でダイアログは完成していたが、各ページの `TaskRow` は `onClick` が未指定で disabled のままだった
* 結果として「UI から編集も削除もできない」状態が残っていた

## 変更内容
* **共通基盤 (新規)**
  * `features/tasks/components/TaskListWithDialogs.tsx`:
    * 行クリックで `selectedTaskId` をセット → `useTaskDetail` で詳細取得 → `EditTaskDialog` を mount
    * Edit 内の削除ボタンで `DeleteTaskDialog` を表示（Edit を `open=false` にして裏に隠す）
    * 削除確定または Edit 閉鎖で全 state をリセット
    * 詳細取得失敗時は inline エラーバナー + 再試行ボタン
  * `features/tasks/hooks/useTaskDetail.ts`: `taskId: string | null` を受け、null の時は `enabled: false` で fetch を抑止

* **3 ルートを置き換え**
  * `routes/tasks.index.tsx`: `<ul>...<TaskRow/></ul>` を `<TaskListWithDialogs/>` に置換
  * `routes/recurring-meetings.\$id.tsx`: 同上
  * `routes/meetings.\$id.tsx`: 同上

* **テスト**
  * 新規 `tasks.listWithDialogs.test.tsx`: 5 件
    * 初期は GET /tasks/:id を呼ばない
    * 行クリックで GET → EditTaskDialog 起動
    * Edit → 削除ボタン → DeleteTaskDialog
    * 削除実行 → DELETE → 両ダイアログ閉鎖
    * 詳細取得失敗時のエラーバナー
  * 既存 `tasks.index.test.tsx` の「行が disabled」テストを「行はクリック可能」に書き換え

## 動作確認手順
1. `git checkout issue-181-task-row-click-edit`
2. `make install`
3. `make dev` で全サービス起動
4. ログイン後、`/tasks` / `/recurring-meetings/<id>` / `/meetings/<id>` のいずれかでタスク行をクリック
5. 編集ダイアログが開き、フィールドが initial 値で表示されることを確認
6. 編集して「保存」 → 一覧が再フェッチされ反映されることを確認
7. 編集ダイアログ内の「削除」 → 確認ダイアログ → 「削除を実行」 → 一覧から消えることを確認
8. `make test` で全テスト pass（web 31 ファイル / 286 件、本 PR で 5 件追加）を確認
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1024" height="812" alt="image" src="https://github.com/user-attachments/assets/e3d39e43-eb36-4816-baa6-09f149bb4e97" />
<img width="691" height="382" alt="image" src="https://github.com/user-attachments/assets/f717e5ac-cb05-4e70-bae0-ecff60e664d9" />


## 補足
* 詳細取得中はダイアログを開かず、軽量な「読み込み中...」テキストを表示
* 詳細取得失敗時は inline バナー + 再試行ボタン（toast 未導入のため）
* 編集ダイアログの 409 (`TaskVersionConflictError`) 対応は #169 で実装済み
* `TaskRow` の disabled フォールバック動作は維持（onClick 未指定なら従来通り）
* 残タスク: #182（My タスクページに「タスクを追加」CTA）で MVP UX が完結