### PR TITLE
feat(web): My タスクページに「タスクを追加」CTA を追加

### DIFF
--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@/components/ui/button";
+import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
@@ -101,13 +103,28 @@ export function MyTasksView({
       aria-labelledby="my-tasks-title"
       className="container mx-auto p-8 space-y-6"
     >
-      <header>
-        <h1 id="my-tasks-title" className="text-2xl font-bold">
-          My タスク
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          自分が担当中のタスクを組織横断で表示します
-        </p>
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 id="my-tasks-title" className="text-2xl font-bold">
+            My タスク
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            自分が担当中のタスクを組織横断で表示します
+          </p>
+        </div>
+        {/* currentOrgId が無い場合は組織を特定できないため作成不可。
+            disabled 化して title でガイダンスを出す（toast 未導入のため）。 */}
+        {currentOrgId ? (
+          <CreateTaskDialog organizationId={currentOrgId} />
+        ) : (
+          <Button
+            size="sm"
+            disabled
+            title="タスクを作成するには組織を選択してください"
+          >
+            タスクを追加
+          </Button>
+        )}
       </header>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
@@ -188,7 +205,23 @@ export function MyTasksView({
       ) : isError ? (
         <p className="text-destructive">タスクの取得に失敗しました</p>
       ) : filtered.length === 0 ? (
-        <p className="text-muted-foreground">担当中のタスクはありません</p>
+        <div className="flex flex-col items-start gap-3">
+          <p className="text-muted-foreground">担当中のタスクはありません</p>
+          {/* fast path CTA。ヘッダの CTA と独立した CreateTaskDialog インスタンスだが、
+              成功時に useMyTasks のキャッシュ invalidate で一覧が更新されるため、
+              インスタンスを共有しなくても挙動上の問題はない。 */}
+          {currentOrgId ? (
+            <CreateTaskDialog organizationId={currentOrgId} />
+          ) : (
+            <Button
+              size="sm"
+              disabled
+              title="タスクを作成するには組織を選択してください"
+            >
+              タスクを追加
+            </Button>
+          )}
+        </div>
       ) : (
         <TaskListWithDialogs
           tasks={filtered}

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -8,6 +8,17 @@ vi.mock("@/lib/api", () => ({
   api: {
     tasks: {
       me: { $get: vi.fn() },
+      // CreateTaskDialog から呼ばれる可能性があるエンドポイントを抑止する。
+      // 本テストはダイアログを開かないが、Picker の useQuery が
+      // ダイアログ mount 時に走る可能性があるため最低限のスタブを用意する。
+      $post: vi.fn(),
+      ":id": { $get: vi.fn(), $patch: vi.fn(), $delete: vi.fn() },
+    },
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
     },
   },
   authHeaders: () => ({ headers: {} }),
@@ -465,5 +476,57 @@ describe("MyTasksView - フィルタ整合", () => {
     expect(options).toHaveLength(3);
     expect(options[1]).toHaveTextContent("ACME");
     expect(options[2]).toHaveTextContent("Beta");
+  });
+});
+
+describe("MyTasksView - タスク作成 CTA", () => {
+  it("currentOrgId ありなら「タスクを追加」ボタンが有効になる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={() => {}}
+        currentOrgId="org-1"
+      />,
+    );
+
+    // ヘッダ右の CTA。リスト表示後でも常に出ているので findAll で取って先頭を見る。
+    const buttons = await screen.findAllByRole("button", {
+      name: "タスクを追加",
+    });
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const b of buttons) expect(b).not.toBeDisabled();
+  });
+
+  it("currentOrgId が null なら「タスクを追加」ボタンは disabled", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+
+    renderWithQuery(
+      <MyTasksView search={{}} onSearchChange={() => {}} currentOrgId={null} />,
+    );
+
+    const buttons = await screen.findAllByRole("button", {
+      name: "タスクを追加",
+    });
+    for (const b of buttons) expect(b).toBeDisabled();
+  });
+
+  it("0 件時は空状態メッセージの下に「タスクを追加」CTA が出る", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+
+    renderWithQuery(
+      <MyTasksView
+        search={{}}
+        onSearchChange={() => {}}
+        currentOrgId="org-1"
+      />,
+    );
+
+    await screen.findByText("担当中のタスクはありません");
+    // 空状態時は「ヘッダ CTA」+「空状態 CTA」の 2 つが表示される。
+    const buttons = screen.getAllByRole("button", { name: "タスクを追加" });
+    expect(buttons).toHaveLength(2);
+    for (const b of buttons) expect(b).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #182

## 概要・目的
* My タスクページ (`/tasks`) から直接タスクを作成できる導線を追加し、タスク管理 MVP UX を完結させる
* サイドバー選択中組織を `organizationId` のコンテキストとして利用、未選択時は disabled + tooltip でガイダンス

## 背景
* これまで `/tasks` には作成 CTA がなく、「組織 → 定例 → タスク追加」と辿る必要があった
* `/recurring-meetings/$id` / `/meetings/$id` には CreateTaskDialog が有効化されているのに、My タスクページに無いのは UX 不整合だった

## 変更内容
* **`routes/tasks.index.tsx`**:
  * ヘッダを flex で再構成し、右側に「タスクを追加」CTA を配置
  * 空状態（0 件時）に fast path として同等の CTA を配置
  * `currentOrgId` 非 null なら `CreateTaskDialog organizationId={currentOrgId}` を起動
  * null なら `<Button disabled title="タスクを作成するには組織を選択してください">` で代替
* **テスト追加（3 件）**:
  * `currentOrgId` ありで両 CTA が有効
  * `currentOrgId` null で両 CTA が disabled
  * 0 件時に空状態 CTA も表示される（ヘッダ + 空状態の 2 つ）

## 動作確認手順
1. `git checkout issue-182-my-tasks-create-cta`
2. `make install`
3. `make dev` で全サービス起動
4. fake-auth でログイン後、サイドバーから組織を選択して `/tasks` にアクセス
5. ヘッダ右に「タスクを追加」ボタンが表示され、クリックで CreateTaskDialog が開くことを確認
6. ダイアログでタイトルを入力して「作成」 → 一覧に即時反映されることを確認
7. ローカルストレージから `current_organization_id` を消すと、ボタンが disabled になることを確認（hover で組織選択を促すツールチップ）
8. `make test` で全テスト pass（web 31 ファイル / 289 件、本 PR で 3 件追加）を確認
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1124" height="783" alt="image" src="https://github.com/user-attachments/assets/cf9fa806-b8c7-4bcc-adc9-342cfd0a1613" />

## 補足
* これにより My タスクページの「作成 → 確認 → 編集 → 削除」が完結し、**タスク管理 MVP UX が機能的に閉じる**
* 多組織持ちで「現在組織以外」への作成は別組織の組織詳細経由で誘導する（MVP では現組織のみ）
* ヘッダと空状態の CTA は独立した `CreateTaskDialog` インスタンスだが、`useMyTasks` の invalidate で両方とも反映される