### PR TITLE
feat(web): 定例ピッカーを可視チェックボックス UI に変更

### DIFF
--- a/apps/web/src/features/tasks/components/RecurringMeetingPicker.tsx
+++ b/apps/web/src/features/tasks/components/RecurringMeetingPicker.tsx
@@ -1,7 +1,9 @@
 import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
-import { cn } from "@/lib/utils";
 
 // 定例（プロジェクト相当）の複数選択ピッカー。
+// 「どのプロジェクトに紐付けるか」の選択操作を分かりやすくするため、
+// 可視のチェックボックス UI を採用する（担当者ピッカーの chip スタイルとは
+// 意図的に区別する: 人タグ vs プロジェクト紐付け）。
 // 同一組織配下の定例だけを候補にする（API 側のクロス組織アタッチ禁止と整合）。
 export function RecurringMeetingPicker({
   organizationId,
@@ -35,31 +37,30 @@ export function RecurringMeetingPicker({
   }
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: fieldset の legend がレイアウト崩れを起こすため div + role=group で代替（My タスクと同じ判断）
+    // 定例の数が増えてもダイアログ高さが破綻しないよう、
+    // 6 件超で内部スクロールにする。グリッドは sm 以上で 2 列にして密度を保つ。
+    // biome-ignore lint/a11y/useSemanticElements: fieldset の legend がレイアウト崩れを起こすため div + role=group で代替
     <div
-      className="flex flex-wrap gap-2"
       role="group"
       aria-label="紐付ける定例"
+      className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 max-h-40 overflow-y-auto rounded-md border border-border/40 p-2"
     >
       {meetings.map((m) => {
         const checked = value.includes(m.id);
         return (
           <label
             key={m.id}
-            className={cn(
-              "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-              checked
-                ? "bg-foreground text-background border-foreground"
-                : "bg-card text-foreground border-border/60 hover:bg-accent",
-            )}
+            className="flex items-center gap-2 text-sm cursor-pointer select-none px-1.5 py-1 rounded hover:bg-accent"
           >
+            {/* 可視のチェックボックス。ブラウザ既定 UI を尊重しつつ、
+                accent-color でアプリのテーマカラーに揃える。 */}
             <input
               type="checkbox"
-              className="sr-only"
               checked={checked}
               onChange={() => toggle(m.id)}
+              className="h-4 w-4 cursor-pointer accent-foreground"
             />
-            {m.name}
+            <span className="truncate">{m.name}</span>
           </label>
         );
       })}


### PR DESCRIPTION
## 関連Issue
Closes #185

## 概要・目的
* タスク作成/編集ダイアログの「紐付ける定例」選択を、タグ風 chip から可視のチェックボックス UI に変更する
* 「どのプロジェクトに紐付けるか」の選択意図を視覚的に明確化する
* 担当者ピッカーは人タグの見た目を維持するため chip のまま（意図的に区別）

## 背景
* 既存はチェックボックスを `sr-only` で隠し、ラベル自体を色つき chip でトグル表示する UI
* 「紐付け先プロジェクトを選ぶ」操作は、視覚的にチェック状態が明確な方が認知負荷が低い
* 担当者（人タグ）と区別することで、ダイアログ内の「人 vs プロジェクト」の役割分担を視覚的に伝える

## 変更内容
* **`features/tasks/components/RecurringMeetingPicker.tsx`**:
  * `<input type="checkbox" className="sr-only">` による chip 化を廃止
  * 可視チェックボックス + `accent-foreground` でテーマカラーに揃える
  * 2 列グリッド（sm 以上）+ `max-h-40 overflow-y-auto` でダイアログ高さの肥大を抑制
  * hover/cursor/aria 構造（`role="group" aria-label="紐付ける定例"`）は維持
* **AssigneePicker は変更なし**（chip 維持）
* **テスト**: 既存 `tasks.pickers.test.tsx`（4 件）は green を維持（クリックトグル・空状態の検証は UI 変更後も正しく動作）

## 動作確認手順
1. `git checkout issue-185-recurring-picker-checkbox`
2. `make install`
3. `make dev` で全サービス起動
4. fake-auth でログインし、`/recurring-meetings/<id>` または `/tasks` から「タスクを追加」ダイアログを開く
5. 「紐付ける定例」セクションにチェックボックスが表示され、定例名が縦リスト or 2 列で並ぶことを確認
6. チェックを入れる/外す動作が以前と同じく機能することを確認
7. 「担当者」セクションは chip スタイルのままであることを確認（意図的な差別化）
8. `make test` で全テスト pass を確認
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="967" height="790" alt="image" src="https://github.com/user-attachments/assets/f07aec21-bf2f-43fe-8942-4f202c961e90" />