### PR TITLE
feat(web): TaskRow に担当者アバター・startDate・定例全列挙を追加

### DIFF
--- a/apps/web/src/features/tasks/components/AvatarStack.tsx
+++ b/apps/web/src/features/tasks/components/AvatarStack.tsx
@@ -1,0 +1,91 @@
+import { cn } from "@/lib/utils";
+
+// 担当者アバターのスタック表示。タスク一覧の「誰が担当か」を視覚化する。
+// 最大件数を超えると "+N" バッジで省略表現する。
+
+// 表示用ユーザーの最小型。TaskListItem / Task の assignee と互換。
+export type AvatarUser = {
+  id: string;
+  displayName: string;
+};
+
+// イニシャル 1 文字を取り出す。サロゲートペア（絵文字等）を 1 文字として扱うため
+// Array.from で分割してから先頭を取る。
+function initial(name: string | null | undefined): string {
+  if (!name) return "?";
+  const chars = Array.from(name.trim());
+  return chars[0] ?? "?";
+}
+
+// userId をハッシュして安定的に色パレットから 1 色を選ぶ。
+// 同じユーザーは常に同じ色のアバターになり、視覚的な識別性が増す。
+const PALETTE = [
+  "bg-blue-500",
+  "bg-emerald-500",
+  "bg-amber-500",
+  "bg-rose-500",
+  "bg-violet-500",
+  "bg-cyan-500",
+  "bg-orange-500",
+  "bg-fuchsia-500",
+] as const;
+
+function hashColor(id: string): string {
+  // 単純な文字コード合計の mod。MVP では衝突しても見た目以外の影響なし。
+  let sum = 0;
+  for (let i = 0; i < id.length; i++) sum = (sum + id.charCodeAt(i)) | 0;
+  return PALETTE[Math.abs(sum) % PALETTE.length];
+}
+
+export function AvatarStack({
+  users,
+  max = 4,
+  size = "sm",
+}: {
+  users: AvatarUser[];
+  max?: number;
+  size?: "sm" | "md";
+}) {
+  if (users.length === 0) {
+    return <span className="text-xs text-muted-foreground">担当者未指定</span>;
+  }
+
+  const shown = users.slice(0, max);
+  const remaining = users.length - shown.length;
+  const sizeClass = size === "sm" ? "h-6 w-6 text-[10px]" : "h-7 w-7 text-xs";
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: fieldset の legend がレイアウト崩れを起こすため div + role=group で代替（プロジェクト方針）
+    <div
+      role="group"
+      aria-label={`担当者: ${users.map((u) => u.displayName).join(", ")}`}
+      className="flex -space-x-1.5"
+      data-testid="task-assignee-avatars"
+    >
+      {shown.map((u) => (
+        <span
+          key={u.id}
+          title={u.displayName}
+          className={cn(
+            "inline-flex items-center justify-center rounded-full font-semibold text-white ring-2 ring-card",
+            sizeClass,
+            hashColor(u.id),
+          )}
+        >
+          {initial(u.displayName)}
+        </span>
+      ))}
+      {remaining > 0 && (
+        <span
+          title={`他 ${remaining} 名`}
+          className={cn(
+            "inline-flex items-center justify-center rounded-full font-semibold text-muted-foreground bg-muted ring-2 ring-card",
+            sizeClass,
+          )}
+        >
+          +{remaining}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/tasks/components/TaskRow.tsx
+++ b/apps/web/src/features/tasks/components/TaskRow.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { taskStatusLabels } from "../labels";
 import type { TaskListItem } from "../types";
+import { AvatarStack } from "./AvatarStack";
 
 // 期限が過ぎていて未完了かどうかを判定する。
 // dueDate が null の場合は超過扱いにしない。
@@ -11,14 +12,17 @@ function isOverdue(task: TaskListItem, now: Date): boolean {
   return new Date(task.dueDate) < now;
 }
 
-// 日付 (YYYY-MM-DD) として整形する。
-function formatDate(iso: string): string {
+// 行内の日付は短縮表記 "M/D" にして横幅を抑える。
+// 年跨ぎは MVP では年なしのまま（少数派のため）。本格運用で必要なら拡張する。
+function formatShortDate(iso: string): string {
   const d = new Date(iso);
-  return `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+  return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
 // タスク一覧の 1 行コンポーネント。My タスク・定例詳細・会議詳細で共通利用する。
-// onClick 未指定時はホバー強調も無効化（ダイアログ Issue #169 完成前の暫定挙動）。
+// 2 行構造で「タイトル + status」「組織 + 定例タグ」「日付 + 担当者アバター」の
+// 3 ブロックで情報を密に提示する。
+// onClick 未指定時はホバー強調も無効化（ダイアログ未接続時の暫定挙動）。
 export function TaskRow({
   task,
   onClick,
@@ -32,61 +36,72 @@ export function TaskRow({
   const overdue = isOverdue(task, now ?? new Date());
   const clickable = onClick !== undefined;
 
+  // 日付ラベル: 着手 と 期日 を中点で連結。両方なしのときは "—"。
+  const dateParts: string[] = [];
+  if (task.startDate) dateParts.push(`着手 ${formatShortDate(task.startDate)}`);
+  if (task.dueDate) dateParts.push(`期日 ${formatShortDate(task.dueDate)}`);
+
   return (
     <li>
       <button
         type="button"
-        // 行クリックがなければハイライト・cursor を抑え、視覚的に「未対応」を示す。
         onClick={onClick}
         disabled={!clickable}
         aria-label={`タスク ${task.title}`}
         className={cn(
-          "w-full text-left px-4 py-3 rounded-md border border-border/50 bg-card",
-          "grid grid-cols-[1fr_auto_auto_auto] items-center gap-3",
+          "w-full text-left p-4 rounded-md border border-border/50 bg-card flex flex-col gap-2",
           clickable && "hover:bg-accent transition-colors cursor-pointer",
           !clickable && "cursor-default",
         )}
       >
-        <div className="min-w-0">
-          <p className="text-sm font-medium truncate">{task.title}</p>
-          <p className="text-xs text-muted-foreground truncate">
-            <span>{task.organization.name}</span>
-            {task.recurringMeetings.length > 0 && (
-              <>
-                <span className="mx-1">/</span>
-                <span>
-                  {task.recurringMeetings[0].name}
-                  {task.recurringMeetings.length > 1 &&
-                    ` +${task.recurringMeetings.length - 1}`}
-                </span>
-              </>
-            )}
+        {/* Row 1: タイトル + ステータスバッジ */}
+        <div className="flex items-start justify-between gap-3">
+          <p className="text-sm font-medium truncate min-w-0 flex-1">
+            {task.title}
           </p>
+          <span
+            data-testid="task-status-badge"
+            title={`ステータス: ${taskStatusLabels[task.status]}`}
+            className="text-xs px-2 py-0.5 rounded-md bg-muted text-muted-foreground shrink-0"
+          >
+            {taskStatusLabels[task.status]}
+          </span>
         </div>
-        <span
-          data-testid="task-status-badge"
-          title={`ステータス: ${taskStatusLabels[task.status]}`}
-          className="text-xs px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
-        >
-          {taskStatusLabels[task.status]}
-        </span>
-        <span
-          data-testid="task-due-date"
-          title={task.dueDate ? `期限 ${formatDate(task.dueDate)}` : "期限なし"}
-          className={cn(
-            "text-xs tabular-nums",
-            overdue ? "text-destructive font-medium" : "text-muted-foreground",
+
+        {/* Row 2: 組織 + 定例タグ群（全列挙、折り返し可） */}
+        <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="font-medium">{task.organization.name}</span>
+          {task.recurringMeetings.length > 0 && (
+            <>
+              <span className="opacity-40">·</span>
+              {task.recurringMeetings.map((rm) => (
+                <span
+                  key={rm.id}
+                  className="inline-flex items-center px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground"
+                  data-testid="task-recurring-tag"
+                >
+                  {rm.name}
+                </span>
+              ))}
+            </>
           )}
-        >
-          {task.dueDate ? formatDate(task.dueDate) : "—"}
-        </span>
-        <span
-          data-testid="task-assignee-count"
-          title={`担当者 ${task.assignees.length} 名`}
-          className="text-xs text-muted-foreground tabular-nums"
-        >
-          {task.assignees.length}名
-        </span>
+        </div>
+
+        {/* Row 3: 日付 + 担当者アバター */}
+        <div className="flex items-center justify-between gap-3">
+          <span
+            data-testid="task-dates"
+            className={cn(
+              "text-xs tabular-nums",
+              overdue
+                ? "text-destructive font-medium"
+                : "text-muted-foreground",
+            )}
+          >
+            {dateParts.length > 0 ? dateParts.join(" · ") : "—"}
+          </span>
+          <AvatarStack users={task.assignees} max={4} />
+        </div>
       </button>
     </li>
   );

--- a/apps/web/src/test/tasks.avatarStack.test.tsx
+++ b/apps/web/src/test/tasks.avatarStack.test.tsx
@@ -1,0 +1,75 @@
+import { AvatarStack } from "@/features/tasks/components/AvatarStack";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("AvatarStack", () => {
+  it("0 件は「担当者未指定」と表示", () => {
+    render(<AvatarStack users={[]} />);
+    expect(screen.getByText("担当者未指定")).toBeInTheDocument();
+  });
+
+  it("displayName の先頭イニシャルを表示する", () => {
+    render(
+      <AvatarStack
+        users={[
+          { id: "u1", displayName: "Alice" },
+          { id: "u2", displayName: "Bob" },
+        ]}
+      />,
+    );
+    const stack = screen.getByTestId("task-assignee-avatars");
+    expect(stack).toHaveTextContent("A");
+    expect(stack).toHaveTextContent("B");
+  });
+
+  it("max を超えると +N で省略する", () => {
+    render(
+      <AvatarStack
+        max={2}
+        users={[
+          { id: "u1", displayName: "Alice" },
+          { id: "u2", displayName: "Bob" },
+          { id: "u3", displayName: "Charlie" },
+          { id: "u4", displayName: "Dave" },
+        ]}
+      />,
+    );
+    const stack = screen.getByTestId("task-assignee-avatars");
+    expect(stack).toHaveTextContent("A");
+    expect(stack).toHaveTextContent("B");
+    expect(stack).not.toHaveTextContent("C");
+    expect(stack).toHaveTextContent("+2");
+  });
+
+  it("aria-label に担当者全員の displayName が含まれる", () => {
+    render(
+      <AvatarStack
+        users={[
+          { id: "u1", displayName: "Alice" },
+          { id: "u2", displayName: "Bob" },
+        ]}
+      />,
+    );
+    const stack = screen.getByLabelText(/担当者: Alice, Bob/);
+    expect(stack).toBeInTheDocument();
+  });
+
+  it("同じ userId は再 render で同じ色になる（背景クラスが一致）", () => {
+    const { rerender } = render(
+      <AvatarStack users={[{ id: "u1", displayName: "Alice" }]} />,
+    );
+    const stack1 = screen.getByTestId("task-assignee-avatars");
+    const firstClass = (stack1.firstChild as HTMLElement | null)?.className;
+
+    rerender(<AvatarStack users={[{ id: "u1", displayName: "Alice" }]} />);
+    const stack2 = screen.getByTestId("task-assignee-avatars");
+    const secondClass = (stack2.firstChild as HTMLElement | null)?.className;
+
+    expect(firstClass).toBe(secondClass);
+  });
+
+  it("displayName が空文字でも '?' で fallback する", () => {
+    render(<AvatarStack users={[{ id: "u1", displayName: "" }]} />);
+    expect(screen.getByTestId("task-assignee-avatars")).toHaveTextContent("?");
+  });
+});

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -174,8 +174,8 @@ describe("MyTasksView", () => {
     await waitFor(() => {
       expect(screen.getByText("期限切れタスク")).toBeInTheDocument();
     });
-    const dueLabel = screen.getByTestId("task-due-date");
-    expect(dueLabel.className).toMatch(/text-destructive/);
+    const dateLabel = screen.getByTestId("task-dates");
+    expect(dateLabel.className).toMatch(/text-destructive/);
   });
 
   it("done のタスクは期限切れでも強調されない", async () => {
@@ -199,8 +199,8 @@ describe("MyTasksView", () => {
     await waitFor(() => {
       expect(screen.getByText("完了済み")).toBeInTheDocument();
     });
-    const dueLabel = screen.getByTestId("task-due-date");
-    expect(dueLabel.className).not.toMatch(/text-destructive/);
+    const dateLabel = screen.getByTestId("task-dates");
+    expect(dateLabel.className).not.toMatch(/text-destructive/);
   });
 
   it("status 文字列フィルタは API リクエストに含まれる", async () => {
@@ -235,7 +235,7 @@ describe("MyTasksView", () => {
 });
 
 describe("MyTasksView - TaskRow 詳細", () => {
-  it("attached 定例が複数あれば +N で表示する", async () => {
+  it("attached 定例は全件タグとして列挙される（+N 省略をやめた）", async () => {
     const multiRm = {
       ...baseTask,
       recurringMeetings: [
@@ -249,26 +249,66 @@ describe("MyTasksView - TaskRow 詳細", () => {
     renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/週次定例 \+2/)).toBeInTheDocument();
+      expect(screen.getByText("週次定例")).toBeInTheDocument();
     });
+    expect(screen.getByText("月次定例")).toBeInTheDocument();
+    expect(screen.getByText("臨時会")).toBeInTheDocument();
+    expect(screen.getAllByTestId("task-recurring-tag")).toHaveLength(3);
   });
 
-  it("担当者数を 'N名' で表示する", async () => {
-    const twoAssignees = {
+  it("担当者はアバタースタックで表示される（イニシャル + +N）", async () => {
+    const manyAssignees = {
       ...baseTask,
       assignees: [
-        { id: "user-1", name: "alice", displayName: "alice" },
-        { id: "user-2", name: "bob", displayName: "bob" },
+        { id: "user-1", name: "alice", displayName: "Alice" },
+        { id: "user-2", name: "bob", displayName: "Bob" },
+        { id: "user-3", name: "charlie", displayName: "Charlie" },
+        { id: "user-4", name: "dave", displayName: "Dave" },
+        { id: "user-5", name: "eve", displayName: "Eve" },
       ],
     };
-    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([twoAssignees]));
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([manyAssignees]));
 
     renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("task-assignee-count")).toBeInTheDocument();
+      expect(screen.getByTestId("task-assignee-avatars")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("task-assignee-count")).toHaveTextContent("2名");
+    const stack = screen.getByTestId("task-assignee-avatars");
+    // 最大 4 件まで表示、5 件目以降は +1
+    expect(stack).toHaveTextContent("A");
+    expect(stack).toHaveTextContent("B");
+    expect(stack).toHaveTextContent("C");
+    expect(stack).toHaveTextContent("D");
+    expect(stack).toHaveTextContent("+1");
+  });
+
+  it("startDate と dueDate が両方ある時は両方表示される", async () => {
+    const withDates = {
+      ...baseTask,
+      startDate: "2026-05-15T00:00:00.000Z",
+      dueDate: "2026-05-20T00:00:00.000Z",
+    };
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([withDates]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dates")).toBeInTheDocument();
+    });
+    const dates = screen.getByTestId("task-dates");
+    expect(dates).toHaveTextContent("着手 5/15");
+    expect(dates).toHaveTextContent("期日 5/20");
+  });
+
+  it("startDate も dueDate も無い時は '—' を表示する", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dates")).toHaveTextContent("—");
+    });
   });
 
   it("行はクリック可能（編集ダイアログ起動の準備済み、共通ラッパー経由）", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #186

## 概要・目的
* タスク一覧から確認できる情報量を増やし、一覧から内容を把握しやすくする
* 担当者を**イニシャルアバター**で視覚化、`startDate`（着手予定日）を新規表示、紐付く定例を**全列挙**（+N 省略をやめる）

## 背景
* 既存 TaskRow は 1 行 grid で `タイトル / 組織·定例 1+N / status / dueDate / 担当者数` のみ
* 「誰が担当か」が「2 名」の数字で、誰なのかが見えなかった
* startDate はフォームで入力できるが一覧に反映されていなかった
* 定例が複数 attach されると「+N」省略されて全体が見えなかった

## 変更内容
* **新規 `features/tasks/components/AvatarStack.tsx`**:
  * 担当者アバターを最大 4 件まで重ねて表示、超過は `+N`
  * イニシャルは `displayName` の先頭 1 文字（サロゲートペア対応）
  * 8 色のテーマパレットから userId ハッシュで安定的に選択
  * `aria-label` に全担当者名を含めて a11y を確保
* **`features/tasks/components/TaskRow.tsx` 再構成**:
  * Row 1: タイトル + ステータスバッジ
  * Row 2: 組織名 · 全定例タグ（折り返し可、`+N` 省略をやめる）
  * Row 3: 着手日 · 期日（短縮表記 `M/D`）+ 担当者アバター（AvatarStack）
  * 期限超過判定は維持
  * data-testid を新仕様に整理（`task-status-badge` / `task-recurring-tag` / `task-dates` / `task-assignee-avatars`）
* **テスト**:
  * 新規 `tasks.avatarStack.test.tsx`: 6 件（空・イニシャル・+N 省略・aria-label・色安定性・空文字 fallback）
  * 既存 `tasks.index.test.tsx`: 既存 4 件を新仕様に書き換え、startDate 表示と「日付なし → "—"」の 2 件追加

## 動作確認手順
1. `git checkout issue-186-task-row-expansion`
2. `make install`
3. `make dev` で全サービス起動
4. `/tasks` / `/recurring-meetings/<id>` / `/meetings/<id>` でタスク一覧を確認
5. 各タスク行が 3 ブロック構造で表示されること、担当者アバターが重ねて出ること、startDate が「着手 M/D」で表示されることを確認
6. 期限超過タスクは「期日 M/D」が赤字強調されることを確認（done/rejected は強調されない）
7. 紐付く定例が 3 件以上ある場合、全件タグ表示されること（+N 省略がない）を確認
8. `make test` で全テスト pass を確認（web 297 件）
9. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1126" height="490" alt="image" src="https://github.com/user-attachments/assets/d0826a71-4e98-4d61-915c-4f73a2cc141d" />