### PR TITLE
feat(web): Kanban ビューと List/Kanban 切替（DnD + 楽観的更新）

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/web/src/features/tasks/components/KanbanBoard.tsx
+++ b/apps/web/src/features/tasks/components/KanbanBoard.tsx
@@ -2,10 +2,13 @@ import { DeleteTaskDialog } from "@/features/tasks/components/DeleteTaskDialog";
 import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
 import { KanbanCard } from "@/features/tasks/components/KanbanCard";
 import { KanbanColumn } from "@/features/tasks/components/KanbanColumn";
+import { useKanbanStatusUpdate } from "@/features/tasks/hooks/useKanbanStatusUpdate";
 import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import { TaskVersionConflictError } from "@/features/tasks/hooks/useUpdateTask";
 import type { ManualTaskStatus, TaskListItem } from "@/features/tasks/types";
 import {
   DndContext,
+  type DragEndEvent,
   PointerSensor,
   useSensor,
   useSensors,
@@ -35,7 +38,7 @@ function isManualStatus(status: string): status is ManualTaskStatus {
 // queryKey は楽観的更新の対象キャッシュを特定するために使う（呼び出し元と一致させる）。
 export function KanbanBoard({
   tasks,
-  queryKey: _queryKey, // 楽観的更新で使う。本 commit では未使用
+  queryKey,
   ariaLabel,
   now,
 }: {
@@ -44,6 +47,8 @@ export function KanbanBoard({
   ariaLabel: string;
   now?: Date;
 }) {
+  const statusUpdate = useKanbanStatusUpdate(queryKey);
+  const [dndError, setDndError] = useState<string | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -70,13 +75,38 @@ export function KanbanBoard({
     if (isManualStatus(t.status)) byStatus.get(t.status)?.push(t);
   }
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return; // 列外にドロップした場合は何もしない
+    const taskId = String(active.id);
+    const dropStatus = String(over.id);
+    if (!isManualStatus(dropStatus)) return;
+
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task) return;
+    if (task.status === dropStatus) return; // 同じ列に戻したケースは no-op
+
+    setDndError(null);
+    statusUpdate.mutate(
+      { taskId, version: task.version, status: dropStatus },
+      {
+        onError: (err) => {
+          // 409 とそれ以外でメッセージを区別する。useKanbanStatusUpdate 側で rollback 済み。
+          if (err instanceof TaskVersionConflictError) {
+            setDndError(
+              "他のユーザーが先に更新しました。最新を取得して再試行してください。",
+            );
+          } else {
+            setDndError("ステータスの更新に失敗しました");
+          }
+        },
+      },
+    );
+  };
+
   return (
     <>
-      <DndContext
-        sensors={sensors}
-        // 本 commit ではドロップで何もしない（次 commit で楽観的更新を入れる）。
-        onDragEnd={() => {}}
-      >
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
         {/* biome-ignore lint/a11y/useSemanticElements: 4 列のレイアウトコンテナで role=group をつけて aria-label を有効化 */}
         <div
           role="group"
@@ -107,6 +137,24 @@ export function KanbanBoard({
           })}
         </div>
       </DndContext>
+
+      {/* DnD によるステータス更新エラーの inline 表示。
+          rollback は楽観的更新側で処理済みなので、表示するメッセージだけここで管理。 */}
+      {dndError !== null && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm flex items-center justify-between gap-2 mt-3"
+        >
+          <span className="text-destructive">{dndError}</span>
+          <button
+            type="button"
+            onClick={() => setDndError(null)}
+            className="text-xs px-2 py-1 rounded-md border border-destructive/40 hover:bg-destructive/10"
+          >
+            閉じる
+          </button>
+        </div>
+      )}
 
       {/* TaskListWithDialogs と同じ詳細取得 → 編集ダイアログ → 削除ダイアログの動線。
           重複は将来 useTaskDialogState 等で共通化する余地あり。 */}

--- a/apps/web/src/features/tasks/components/KanbanBoard.tsx
+++ b/apps/web/src/features/tasks/components/KanbanBoard.tsx
@@ -1,0 +1,154 @@
+import { DeleteTaskDialog } from "@/features/tasks/components/DeleteTaskDialog";
+import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
+import { KanbanCard } from "@/features/tasks/components/KanbanCard";
+import { KanbanColumn } from "@/features/tasks/components/KanbanColumn";
+import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import type { ManualTaskStatus, TaskListItem } from "@/features/tasks/types";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { QueryKey } from "@tanstack/react-query";
+import { useState } from "react";
+
+// 手動経路で扱う 4 列（draft / reviewing は AI 専用なのでカンバンには出さない）。
+const KANBAN_COLUMNS: ManualTaskStatus[] = [
+  "todo",
+  "in_progress",
+  "done",
+  "rejected",
+];
+
+// 手動経路の status かを絞り込む。draft / reviewing は表示対象から除外する。
+function isManualStatus(status: string): status is ManualTaskStatus {
+  return (
+    status === "todo" ||
+    status === "in_progress" ||
+    status === "done" ||
+    status === "rejected"
+  );
+}
+
+// Kanban ビュー。タスクを status 列で並べ、DnD でステータスを変更する。
+// queryKey は楽観的更新の対象キャッシュを特定するために使う（呼び出し元と一致させる）。
+export function KanbanBoard({
+  tasks,
+  queryKey: _queryKey, // 楽観的更新で使う。本 commit では未使用
+  ariaLabel,
+  now,
+}: {
+  tasks: TaskListItem[];
+  queryKey: QueryKey;
+  ariaLabel: string;
+  now?: Date;
+}) {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const detailQuery = useTaskDetail(selectedTaskId);
+  const task = detailQuery.data ?? null;
+  const isError = selectedTaskId !== null && detailQuery.isError;
+
+  // PointerSensor の activationConstraint で短いクリックは drag を発火させない。
+  // distance: 5 で十分（タスクカードのクリック=編集と区別）。
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const closeAll = () => {
+    setDeleteOpen(false);
+    setSelectedTaskId(null);
+  };
+
+  // 列ごとにタスクを振り分け。手動 4 status 以外は無視（AI 専用は将来別 UI）。
+  const byStatus = new Map<ManualTaskStatus, TaskListItem[]>(
+    KANBAN_COLUMNS.map((s) => [s, []]),
+  );
+  for (const t of tasks) {
+    if (isManualStatus(t.status)) byStatus.get(t.status)?.push(t);
+  }
+
+  return (
+    <>
+      <DndContext
+        sensors={sensors}
+        // 本 commit ではドロップで何もしない（次 commit で楽観的更新を入れる）。
+        onDragEnd={() => {}}
+      >
+        {/* biome-ignore lint/a11y/useSemanticElements: 4 列のレイアウトコンテナで role=group をつけて aria-label を有効化 */}
+        <div
+          role="group"
+          aria-label={ariaLabel}
+          data-testid="kanban-board"
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3"
+        >
+          {KANBAN_COLUMNS.map((status) => {
+            const items = byStatus.get(status) ?? [];
+            return (
+              <KanbanColumn key={status} status={status} count={items.length}>
+                {items.length === 0 ? (
+                  <p className="text-xs text-muted-foreground px-1">
+                    タスクなし
+                  </p>
+                ) : (
+                  items.map((t) => (
+                    <KanbanCard
+                      key={t.id}
+                      task={t}
+                      now={now}
+                      onClick={() => setSelectedTaskId(t.id)}
+                    />
+                  ))
+                )}
+              </KanbanColumn>
+            );
+          })}
+        </div>
+      </DndContext>
+
+      {/* TaskListWithDialogs と同じ詳細取得 → 編集ダイアログ → 削除ダイアログの動線。
+          重複は将来 useTaskDialogState 等で共通化する余地あり。 */}
+      {isError && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm flex items-center justify-between gap-2 mt-3"
+        >
+          <span className="text-destructive">
+            タスク詳細の取得に失敗しました
+          </span>
+          <button
+            type="button"
+            onClick={() => detailQuery.refetch()}
+            className="text-xs px-2 py-1 rounded-md border border-destructive/40 hover:bg-destructive/10"
+          >
+            再試行
+          </button>
+        </div>
+      )}
+
+      {task !== null && (
+        <EditTaskDialog
+          task={task}
+          open={!deleteOpen}
+          onOpenChange={(next) => {
+            if (!next && !deleteOpen) closeAll();
+          }}
+          onRequestDelete={() => setDeleteOpen(true)}
+        />
+      )}
+
+      {task !== null && (
+        <DeleteTaskDialog
+          task={task}
+          open={deleteOpen}
+          onOpenChange={(next) => {
+            setDeleteOpen(next);
+          }}
+          onDeleted={closeAll}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/tasks/components/KanbanCard.tsx
+++ b/apps/web/src/features/tasks/components/KanbanCard.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/utils";
+import { useDraggable } from "@dnd-kit/core";
+import type { TaskListItem } from "../types";
+import { AvatarStack } from "./AvatarStack";
+
+function isOverdue(task: TaskListItem, now: Date): boolean {
+  if (!task.dueDate) return false;
+  if (task.status === "done" || task.status === "rejected") return false;
+  return new Date(task.dueDate) < now;
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+// Kanban のカード。TaskRow より小さく、列内で複数並ぶ前提の軽量な見た目にする。
+// useDraggable で DnD 対象にし、軽いクリックではドラッグを誤発火させない activation を採用。
+// 表示: タイトル / 期日（あれば）/ 担当者アバター（最大 3）
+export function KanbanCard({
+  task,
+  onClick,
+  now,
+}: {
+  task: TaskListItem;
+  onClick?: () => void;
+  now?: Date;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: task.id });
+
+  const overdue = isOverdue(task, now ?? new Date());
+
+  return (
+    // button 要素を使うことで biome の useSemanticElements に従う。
+    // 子は inline 要素 (span) で構成し、HTML 仕様で button 内に許される表現に限定する。
+    <button
+      type="button"
+      ref={setNodeRef}
+      style={{
+        // useDraggable の transform は { x, y } を返す。translate3d で適用する。
+        transform: transform
+          ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+          : undefined,
+        // ドラッグ中は他のカード上に浮くようにする。
+        zIndex: isDragging ? 50 : undefined,
+      }}
+      {...attributes}
+      {...listeners}
+      onClick={onClick}
+      aria-label={`タスク ${task.title}`}
+      data-testid="kanban-card"
+      className={cn(
+        "rounded-md border border-border/50 bg-card p-3 text-left",
+        "flex flex-col gap-2 text-sm shadow-sm w-full",
+        isDragging ? "opacity-60" : "hover:bg-accent",
+        onClick !== undefined ? "cursor-pointer" : "cursor-default",
+      )}
+    >
+      <span className="font-medium truncate">{task.title}</span>
+      <span className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "text-xs tabular-nums",
+            overdue ? "text-destructive font-medium" : "text-muted-foreground",
+          )}
+        >
+          {task.dueDate ? `期日 ${formatShortDate(task.dueDate)}` : "—"}
+        </span>
+        <AvatarStack users={task.assignees} max={3} />
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/features/tasks/components/KanbanColumn.tsx
+++ b/apps/web/src/features/tasks/components/KanbanColumn.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { useDroppable } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import { taskStatusLabels } from "../labels";
+import type { TaskStatus } from "../types";
+
+// Kanban の 1 列。useDroppable でドロップターゲットになり、status を id にする。
+// ヘッダにラベルと件数を出し、子としてカード列を受け取る。
+export function KanbanColumn({
+  status,
+  count,
+  children,
+}: {
+  status: TaskStatus;
+  count: number;
+  children: ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+  return (
+    <section
+      aria-label={`${taskStatusLabels[status]} 列`}
+      className="flex flex-col min-w-[16rem] flex-1"
+      data-testid={`kanban-column-${status}`}
+    >
+      <header className="flex items-center justify-between px-2 py-1.5">
+        <h3 className="text-sm font-semibold">{taskStatusLabels[status]}</h3>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {count}
+        </span>
+      </header>
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "flex flex-col gap-2 p-2 rounded-md min-h-[8rem] flex-1",
+          "bg-muted/40 border border-transparent transition-colors",
+          isOver && "border-foreground/40 bg-muted/70",
+        )}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/tasks/components/ViewToggle.tsx
+++ b/apps/web/src/features/tasks/components/ViewToggle.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/lib/utils";
+import { KanbanSquareIcon, ListIcon } from "lucide-react";
+
+export type TaskView = "list" | "kanban";
+
+// List / Kanban のビュー切替トグル。URL クエリの同期は親が担う。
+// 視覚的にはセグメント化コントロール（押されたボタンが強調される）。
+export function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: TaskView;
+  onChange: (next: TaskView) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="表示モード切替"
+      className="inline-flex rounded-md border border-border/60 bg-card overflow-hidden"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "list"}
+        onClick={() => onChange("list")}
+        className={cn(
+          "flex items-center gap-1 px-3 py-1.5 text-xs",
+          view === "list"
+            ? "bg-foreground text-background"
+            : "text-muted-foreground hover:bg-accent",
+        )}
+      >
+        <ListIcon size={13} />
+        List
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "kanban"}
+        onClick={() => onChange("kanban")}
+        className={cn(
+          "flex items-center gap-1 px-3 py-1.5 text-xs",
+          view === "kanban"
+            ? "bg-foreground text-background"
+            : "text-muted-foreground hover:bg-accent",
+        )}
+      >
+        <KanbanSquareIcon size={13} />
+        Kanban
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/tasks/hooks/useKanbanStatusUpdate.ts
+++ b/apps/web/src/features/tasks/hooks/useKanbanStatusUpdate.ts
@@ -1,0 +1,64 @@
+import { api, authHeaders } from "@/lib/api";
+import {
+  type QueryKey,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+import type { ManualTaskStatus, TaskListItem } from "../types";
+import { TaskVersionConflictError } from "./useUpdateTask";
+
+// Kanban の DnD 起点でステータスを更新する mutation。
+// 一覧キャッシュを setQueryData で即座に書き換える楽観的更新を実装し、
+// 失敗時は onError で rollback、成功時は onSettled で invalidate して
+// 正しい version を取り直す（次回更新の整合性確保）。
+//
+// queryKey は呼び出し元（KanbanBoard を使うページ）から渡してもらう。
+// useMyTasks や useRecurringMeetingTasks 等が使うキャッシュキーと一致させる必要がある。
+export function useKanbanStatusUpdate(queryKey: QueryKey) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    unknown,
+    Error,
+    { taskId: string; version: number; status: ManualTaskStatus },
+    // onMutate が返すコンテキスト型
+    { prev: TaskListItem[] | undefined }
+  >({
+    mutationFn: async ({ taskId, version, status }) => {
+      const res = await api.tasks[":id"].$patch(
+        { param: { id: taskId }, json: { version, status } },
+        authHeaders(),
+      );
+      if (res.status === 409) {
+        throw new TaskVersionConflictError();
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to update task status: ${res.status}`);
+      }
+      return res.json();
+    },
+    onMutate: async ({ taskId, status }) => {
+      // 進行中のフェッチをキャンセルして上書きされないようにする。
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData<TaskListItem[]>(queryKey);
+      // 即座に新 status に書き換え。drop でカードが新列に移動する見た目を維持する。
+      queryClient.setQueryData<TaskListItem[]>(queryKey, (old) =>
+        old?.map((t) => (t.id === taskId ? { ...t, status } : t)),
+      );
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      // rollback。失敗時はカードが元の列に戻る。
+      if (ctx?.prev !== undefined) {
+        queryClient.setQueryData(queryKey, ctx.prev);
+      }
+    },
+    onSettled: () => {
+      // 成功/失敗どちらでも、一覧と詳細の両方を再フェッチして整合性を取り直す。
+      // 楽観的に書き換えた status は最新の version で再取得しないとロストアップデートになる。
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,7 +1,13 @@
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
+import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
+import {
+  ViewToggle,
+  type TaskView,
+} from "@/features/tasks/components/ViewToggle";
 import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskStatus } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
@@ -18,6 +24,7 @@ const FILTERABLE_STATUSES: TaskStatus[] = [
 
 const meetingSearchSchema = z.object({
   status: z.string().optional(),
+  view: z.enum(["list", "kanban"]).optional(),
 });
 
 type MeetingSearch = z.infer<typeof meetingSearchSchema>;
@@ -137,12 +144,23 @@ export function MeetingDetailView({
       <section aria-label="タスク" className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-semibold">タスク</h2>
-          {/* この会議由来として origin を伝播し、紐付け先の定例も初期 attach する。 */}
-          <CreateTaskDialog
-            organizationId={detail.organization.id}
-            recurringMeetingId={detail.recurringMeeting.id}
-            originMeetingId={detail.id}
-          />
+          <div className="flex items-center gap-2">
+            <ViewToggle
+              view={(search.view ?? "list") as TaskView}
+              onChange={(next) =>
+                onSearchChange({
+                  ...search,
+                  view: next === "list" ? undefined : next,
+                })
+              }
+            />
+            {/* この会議由来として origin を伝播し、紐付け先の定例も初期 attach する。 */}
+            <CreateTaskDialog
+              organizationId={detail.organization.id}
+              recurringMeetingId={detail.recurringMeeting.id}
+              originMeetingId={detail.id}
+            />
+          </div>
         </div>
 
         {/* status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
@@ -192,6 +210,16 @@ export function MeetingDetailView({
           <p className="text-muted-foreground">
             この会議から発生したタスクはまだありません
           </p>
+        ) : search.view === "kanban" ? (
+          <KanbanBoard
+            tasks={tasksQuery.data ?? []}
+            queryKey={taskQueryKeys.meeting(
+              id,
+              statusArr ? { status: statusArr } : {},
+            )}
+            ariaLabel="会議由来のタスク Kanban"
+            now={now}
+          />
         ) : (
           <TaskListWithDialogs
             tasks={tasksQuery.data ?? []}

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -8,9 +8,15 @@ import {
   parseCron,
 } from "@/features/recurring-meetings/scheduleCron";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
+import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
+import {
+  ViewToggle,
+  type TaskView,
+} from "@/features/tasks/components/ViewToggle";
 import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMeetingTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import type { TaskStatus } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
@@ -28,6 +34,7 @@ const FILTERABLE_STATUSES: TaskStatus[] = [
 // URL クエリパラメータの形。タスクセクションの status フィルタを永続化する。
 const recurringMeetingSearchSchema = z.object({
   status: z.string().optional(),
+  view: z.enum(["list", "kanban"]).optional(),
 });
 
 type RecurringMeetingSearch = z.infer<typeof recurringMeetingSearchSchema>;
@@ -191,12 +198,23 @@ export function RecurringMeetingDetailView({
       <section aria-label="タスク" className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-semibold">タスク</h2>
-          {/* タスク作成ダイアログ (#169) で実装したものを起動する。
-              現定例を初期 attach する。originMeetingId は会議詳細ページ側で扱う。 */}
-          <CreateTaskDialog
-            organizationId={detail.organizationId}
-            recurringMeetingId={detail.id}
-          />
+          <div className="flex items-center gap-2">
+            <ViewToggle
+              view={(search.view ?? "list") as TaskView}
+              onChange={(next) =>
+                onSearchChange({
+                  ...search,
+                  view: next === "list" ? undefined : next,
+                })
+              }
+            />
+            {/* タスク作成ダイアログ (#169) で実装したものを起動する。
+                現定例を初期 attach する。originMeetingId は会議詳細ページ側で扱う。 */}
+            <CreateTaskDialog
+              organizationId={detail.organizationId}
+              recurringMeetingId={detail.id}
+            />
+          </div>
         </div>
 
         {/* status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
@@ -246,6 +264,16 @@ export function RecurringMeetingDetailView({
           <p className="text-muted-foreground">
             このプロジェクトのタスクはまだありません
           </p>
+        ) : search.view === "kanban" ? (
+          <KanbanBoard
+            tasks={tasksQuery.data ?? []}
+            queryKey={taskQueryKeys.recurring(
+              id,
+              statusArr ? { status: statusArr } : {},
+            )}
+            ariaLabel="プロジェクトのタスク Kanban"
+            now={now}
+          />
         ) : (
           <TaskListWithDialogs
             tasks={tasksQuery.data ?? []}

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -1,8 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
+import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
+import {
+  ViewToggle,
+  type TaskView,
+} from "@/features/tasks/components/ViewToggle";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import type { TaskListItem, TaskStatus } from "@/features/tasks/types";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { cn } from "@/lib/utils";
@@ -28,6 +34,8 @@ const FILTERABLE_STATUSES: TaskStatus[] = [
 const tasksSearchSchema = z.object({
   status: z.string().optional(),
   orgId: z.string().optional(),
+  // List / Kanban のビュー切替。デフォルトは list。
+  view: z.enum(["list", "kanban"]).optional(),
 });
 
 type TasksSearch = z.infer<typeof tasksSearchSchema>;
@@ -112,19 +120,30 @@ export function MyTasksView({
             自分が担当中のタスクを組織横断で表示します
           </p>
         </div>
-        {/* currentOrgId が無い場合は組織を特定できないため作成不可。
-            disabled 化して title でガイダンスを出す（toast 未導入のため）。 */}
-        {currentOrgId ? (
-          <CreateTaskDialog organizationId={currentOrgId} />
-        ) : (
-          <Button
-            size="sm"
-            disabled
-            title="タスクを作成するには組織を選択してください"
-          >
-            タスクを追加
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          <ViewToggle
+            view={(search.view ?? "list") as TaskView}
+            onChange={(next) =>
+              onSearchChange({
+                ...search,
+                view: next === "list" ? undefined : next,
+              })
+            }
+          />
+          {/* currentOrgId が無い場合は組織を特定できないため作成不可。
+              disabled 化して title でガイダンスを出す（toast 未導入のため）。 */}
+          {currentOrgId ? (
+            <CreateTaskDialog organizationId={currentOrgId} />
+          ) : (
+            <Button
+              size="sm"
+              disabled
+              title="タスクを作成するには組織を選択してください"
+            >
+              タスクを追加
+            </Button>
+          )}
+        </div>
       </header>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
@@ -222,6 +241,13 @@ export function MyTasksView({
             </Button>
           )}
         </div>
+      ) : search.view === "kanban" ? (
+        <KanbanBoard
+          tasks={filtered}
+          queryKey={taskQueryKeys.me(statusArr ? { status: statusArr } : {})}
+          ariaLabel="My タスク Kanban"
+          now={now}
+        />
       ) : (
         <TaskListWithDialogs
           tasks={filtered}

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -519,6 +519,39 @@ describe("MyTasksView - フィルタ整合", () => {
   });
 });
 
+describe("MyTasksView - View 切替", () => {
+  it("デフォルト (view 未指定) では List 表示", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+    renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);
+    expect(await screen.findByLabelText("My タスク一覧")).toBeInTheDocument();
+    expect(screen.queryByTestId("kanban-board")).not.toBeInTheDocument();
+  });
+
+  it("view=kanban で KanbanBoard が描画される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+    renderWithQuery(
+      <MyTasksView search={{ view: "kanban" }} onSearchChange={() => {}} />,
+    );
+    expect(await screen.findByTestId("kanban-board")).toBeInTheDocument();
+    expect(screen.queryByLabelText("My タスク一覧")).not.toBeInTheDocument();
+  });
+
+  it("ViewToggle で kanban を選ぶと onSearchChange に view=kanban が渡る", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+    const onSearchChange = vi.fn();
+    renderWithQuery(
+      <MyTasksView search={{}} onSearchChange={onSearchChange} />,
+    );
+
+    await screen.findByLabelText("My タスク一覧");
+    await userEvent.click(screen.getByRole("tab", { name: /Kanban/ }));
+
+    expect(onSearchChange).toHaveBeenCalledWith(
+      expect.objectContaining({ view: "kanban" }),
+    );
+  });
+});
+
 describe("MyTasksView - タスク作成 CTA", () => {
   it("currentOrgId ありなら「タスクを追加」ボタンが有効になる", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));

--- a/apps/web/src/test/tasks.kanbanBoard.test.tsx
+++ b/apps/web/src/test/tasks.kanbanBoard.test.tsx
@@ -1,0 +1,196 @@
+import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
+import type { Task, TaskListItem } from "@/features/tasks/types";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    tasks: {
+      ":id": {
+        $get: vi.fn(),
+        $patch: vi.fn(),
+        $delete: vi.fn(),
+      },
+    },
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+        meetings: { $get: vi.fn() },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+function listItem(overrides: Partial<TaskListItem>): TaskListItem {
+  return {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "資料作成",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: "2026-05-17T00:00:00.000Z",
+    updatedAt: "2026-05-17T00:00:00.000Z",
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [],
+    ...overrides,
+  };
+}
+
+const detail: Task = { ...listItem({}), assignees: [] };
+
+beforeEach(() => {
+  vi.mocked(api.tasks[":id"].$get).mockResolvedValue(mockJson(detail));
+  vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+    mockJson([]),
+  );
+  vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+    mockJson([]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("KanbanBoard", () => {
+  it("4 列が描画される（todo / in_progress / done / rejected）", () => {
+    renderWithQuery(
+      <KanbanBoard
+        tasks={[]}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+    expect(screen.getByTestId("kanban-column-todo")).toBeInTheDocument();
+    expect(screen.getByTestId("kanban-column-in_progress")).toBeInTheDocument();
+    expect(screen.getByTestId("kanban-column-done")).toBeInTheDocument();
+    expect(screen.getByTestId("kanban-column-rejected")).toBeInTheDocument();
+  });
+
+  it("タスクが status に従って正しい列に配置される", () => {
+    const tasks = [
+      listItem({ id: "t1", title: "未着手のタスク", status: "todo" }),
+      listItem({ id: "t2", title: "進行中のタスク", status: "in_progress" }),
+      listItem({ id: "t3", title: "完了のタスク", status: "done" }),
+    ];
+    renderWithQuery(
+      <KanbanBoard
+        tasks={tasks}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+
+    const todoCol = screen.getByTestId("kanban-column-todo");
+    expect(within(todoCol).getByText("未着手のタスク")).toBeInTheDocument();
+
+    const inProgressCol = screen.getByTestId("kanban-column-in_progress");
+    expect(
+      within(inProgressCol).getByText("進行中のタスク"),
+    ).toBeInTheDocument();
+
+    const doneCol = screen.getByTestId("kanban-column-done");
+    expect(within(doneCol).getByText("完了のタスク")).toBeInTheDocument();
+  });
+
+  it("AI 専用 status (draft/reviewing) のタスクは表示されない", () => {
+    const tasks = [
+      listItem({ id: "ai1", title: "AI 提案中", status: "draft" }),
+      listItem({ id: "ai2", title: "レビュー中", status: "reviewing" }),
+    ];
+    renderWithQuery(
+      <KanbanBoard
+        tasks={tasks}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+    expect(screen.queryByText("AI 提案中")).not.toBeInTheDocument();
+    expect(screen.queryByText("レビュー中")).not.toBeInTheDocument();
+  });
+
+  it("空列には「タスクなし」が表示される", () => {
+    renderWithQuery(
+      <KanbanBoard
+        tasks={[listItem({ id: "t1", status: "todo" })]}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+    const inProgressCol = screen.getByTestId("kanban-column-in_progress");
+    expect(within(inProgressCol).getByText("タスクなし")).toBeInTheDocument();
+  });
+
+  it("カードをクリックすると詳細取得 → EditTaskDialog が開く", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(
+      <KanbanBoard
+        tasks={[listItem({ id: "task-1", title: "資料作成", status: "todo" })]}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+
+    const card = screen.getByTestId("kanban-card");
+    await user.click(card);
+
+    await waitFor(() => {
+      expect(api.tasks[":id"].$get).toHaveBeenCalledWith(
+        { param: { id: "task-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+    expect(
+      await screen.findByRole("heading", { name: "タスクを編集" }),
+    ).toBeInTheDocument();
+  });
+
+  it("件数表示が列ヘッダに出る", () => {
+    const tasks = [
+      listItem({ id: "t1", status: "todo" }),
+      listItem({ id: "t2", status: "todo" }),
+      listItem({ id: "t3", status: "in_progress" }),
+    ];
+    renderWithQuery(
+      <KanbanBoard
+        tasks={tasks}
+        queryKey={["tasks", "me", {}]}
+        ariaLabel="ボード"
+      />,
+    );
+    const todoCol = screen.getByTestId("kanban-column-todo");
+    // ヘッダの件数表示。列の最初の数字。
+    expect(within(todoCol).getByText("2")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/tasks.kanbanStatusUpdate.test.tsx
+++ b/apps/web/src/test/tasks.kanbanStatusUpdate.test.tsx
@@ -1,0 +1,193 @@
+import { useKanbanStatusUpdate } from "@/features/tasks/hooks/useKanbanStatusUpdate";
+import { TaskVersionConflictError } from "@/features/tasks/hooks/useUpdateTask";
+import type { TaskListItem } from "@/features/tasks/types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// グローバル fetch をモックして API 呼び出しを切り離す。
+function mockFetchOnce(init: ResponseInit, body: unknown = null) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(body === null ? null : JSON.stringify(body), init),
+  );
+}
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const baseTask = (overrides: Partial<TaskListItem> = {}): TaskListItem => ({
+  id: "task-1",
+  organizationId: "org-1",
+  originMeetingId: null,
+  decisionItemId: null,
+  title: "資料作成",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "todo",
+  priority: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  assigneeRaw: null,
+  blockingItemId: null,
+  carriedOverCount: null,
+  ambiguityFlags: null,
+  progressNote: null,
+  dueDate: null,
+  startDate: null,
+  followUpDate: null,
+  version: 0,
+  createdAt: "2026-05-17T00:00:00.000Z",
+  updatedAt: "2026-05-17T00:00:00.000Z",
+  organization: { id: "org-1", name: "ACME" },
+  originMeeting: null,
+  assignees: [],
+  recurringMeetings: [],
+  ...overrides,
+});
+
+const queryKey = ["tasks", "me", {}];
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useKanbanStatusUpdate", () => {
+  it("成功時: 楽観的に status を更新し、確定後も維持される", async () => {
+    mockFetchOnce({ status: 200 }, { id: "task-1", status: "in_progress" });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    client.setQueryData<TaskListItem[]>(queryKey, [baseTask()]);
+
+    const { result } = renderHook(() => useKanbanStatusUpdate(queryKey), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        taskId: "task-1",
+        version: 0,
+        status: "in_progress",
+      });
+    });
+
+    // setQueryData による楽観的更新が反映されている
+    const after = client.getQueryData<TaskListItem[]>(queryKey);
+    expect(after?.[0].status).toBe("in_progress");
+  });
+
+  it("非 2xx で rollback して prev に戻る", async () => {
+    mockFetchOnce({ status: 500 }, { error: "internal" });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    const prev = [baseTask()];
+    client.setQueryData<TaskListItem[]>(queryKey, prev);
+
+    const { result } = renderHook(() => useKanbanStatusUpdate(queryKey), {
+      wrapper: makeWrapper(client),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        taskId: "task-1",
+        version: 0,
+        status: "done",
+      }),
+    ).rejects.toThrow(/Failed to update task status: 500/);
+
+    // rollback で元の status に戻っている
+    await waitFor(() => {
+      const after = client.getQueryData<TaskListItem[]>(queryKey);
+      expect(after?.[0].status).toBe("todo");
+    });
+  });
+
+  it("409 は TaskVersionConflictError として throw し、rollback される", async () => {
+    mockFetchOnce({ status: 409 }, { error: "conflict" });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    client.setQueryData<TaskListItem[]>(queryKey, [baseTask()]);
+
+    const { result } = renderHook(() => useKanbanStatusUpdate(queryKey), {
+      wrapper: makeWrapper(client),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        taskId: "task-1",
+        version: 0,
+        status: "done",
+      }),
+    ).rejects.toBeInstanceOf(TaskVersionConflictError);
+
+    await waitFor(() => {
+      const after = client.getQueryData<TaskListItem[]>(queryKey);
+      expect(after?.[0].status).toBe("todo");
+    });
+  });
+
+  it("mutate 中の楽観的更新が即座に反映される（onMutate）", async () => {
+    // mutationFn は遅延させて、楽観的更新の即時性を観察する
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve(
+                new Response(JSON.stringify({ id: "task-1" }), { status: 200 }),
+              ),
+            50,
+          ),
+        ),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    client.setQueryData<TaskListItem[]>(queryKey, [baseTask()]);
+
+    const { result } = renderHook(() => useKanbanStatusUpdate(queryKey), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.mutate({
+        taskId: "task-1",
+        version: 0,
+        status: "in_progress",
+      });
+    });
+
+    // mutate 直後（API 応答前）に楽観的更新が反映されているはず
+    await waitFor(() => {
+      const optimistic = client.getQueryData<TaskListItem[]>(queryKey);
+      expect(optimistic?.[0].status).toBe("in_progress");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
@@ -461,6 +464,22 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -3510,7 +3529,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@9.0.0:
@@ -4034,6 +4053,24 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:


### PR DESCRIPTION
## 関連Issue
Closes #187

## 概要・目的
* タスクの状態遷移を視覚的に管理できる Kanban ビューを 3 ページに導入する
* `?view=kanban` で URL 永続化、トグルで List ⇄ Kanban を切り替え可能
* `@dnd-kit/core` を採用し、ドラッグ&ドロップで status を変更（楽観的更新付き）

## 背景
* List 表示だけでは進捗の俯瞰が難しく、Asana/Linear などにあるカンバン UI が欲しかった
* 状態遷移をクリックだけでなく視覚的（drag）に行えると操作感が大幅に向上する
* タスク管理 UI 改善 3 件 (#185 / #186 / #187) のうち最大スコープ

## 変更内容
* **依存追加**
  * `@dnd-kit/core`（軽量、~10KB）。sortable は不要なので core のみ

* **新規コンポーネント**
  * `features/tasks/components/ViewToggle.tsx`: List/Kanban の切替トグル
  * `features/tasks/components/KanbanBoard.tsx`: 4 列カンバン + DnD ハンドラ + 編集/削除ダイアログ管理
  * `features/tasks/components/KanbanColumn.tsx`: useDroppable 列、ヘッダに件数表示
  * `features/tasks/components/KanbanCard.tsx`: useDraggable カード（クリック=詳細編集）
  * `features/tasks/hooks/useKanbanStatusUpdate.ts`: setQueryData による楽観的更新、rollback、409 → TaskVersionConflictError

* **3 ルートに統合**
  * `routes/tasks.index.tsx`: `view` クエリ追加、ViewToggle 配置、queryKey = taskQueryKeys.me(filters)
  * `routes/recurring-meetings.\$id.tsx`: 同、queryKey = taskQueryKeys.recurring(id, filters)
  * `routes/meetings.\$id.tsx`: 同、queryKey = taskQueryKeys.meeting(id, filters)

* **挙動詳細**
  * Kanban の列: `todo / in_progress / done / rejected` の 4 列（AI 専用 draft/reviewing は非表示）
  * カードクリック → 既存の useTaskDetail → EditTaskDialog 起動（List と同じ動線）
  * DnD で別列にドロップ → 即時カード移動 + PATCH /tasks/:id、失敗時は rollback
  * 409 競合は「他のユーザーが先に更新しました」inline バナー、5xx は「ステータスの更新に失敗しました」
  * 同列への drop は no-op、AI 専用 status は対象外

* **テスト（13 件追加）**
  * `tasks.kanbanBoard.test.tsx`: 6 件（4 列描画・status 振分・AI 非表示・空状態・カードクリック編集・件数表示）
  * `tasks.kanbanStatusUpdate.test.tsx`: 4 件（成功確定・5xx rollback・409 識別・楽観的即時反映）
  * `tasks.index.test.tsx`: 3 件追加（デフォルト=List、view=kanban で Kanban、ViewToggle で view 永続化）

## 動作確認手順
1. `git checkout issue-187-kanban-view`
2. `make install`
3. `make dev` で全サービス起動
4. `/tasks`（または `/recurring-meetings/<id>`、`/meetings/<id>`）にアクセス
5. ヘッダ右の「Kanban」ボタンをクリック → URL が `?view=kanban` になり、4 列のカンバンが表示される
6. カードを別列にドラッグ → 即座にカードが新列に移動し、PATCH /tasks/:id が呼ばれる
7. カードクリック → EditTaskDialog が開く（List と同じ）
8. ネットワークを切断してドラッグ → エラーバナーが出て元の列に戻る
9. `make test` で全テスト pass（web 34 ファイル / 310 件、本 PR で 13 件追加）を確認
10. `make lint` で警告ゼロを確認

## スクリーンショット
<img width="1309" height="560" alt="image" src="https://github.com/user-attachments/assets/ab243ce4-d7dd-48a1-b333-2b2b9e5da5af" />
<img width="1314" height="554" alt="image" src="https://github.com/user-attachments/assets/ad22289a-2156-4fcf-8e71-b13e9e6db752" />