### PR TITLE
Kanban view で status フィルタ UI を非表示にする

### DIFF
--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -84,9 +84,13 @@ export function MeetingDetailView({
 }) {
   const detailQuery = useMeetingDetail(id);
   const statusArr = parseStatusParam(search.status);
+  // Kanban view では status は列として可視化されるため、フィルタ UI も API への
+  // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
+  // 復元用に保持する。
+  const isKanbanView = search.view === "kanban";
   const tasksQuery = useMeetingTasks(
     id,
-    statusArr ? { status: statusArr } : undefined,
+    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
   );
 
   if (detailQuery.isLoading) {
@@ -163,44 +167,48 @@ export function MeetingDetailView({
           </div>
         </div>
 
-        {/* status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
-            biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
-            避けるため div + role=group で代替する。 */}
-        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
-        <div
-          role="group"
-          aria-labelledby="meeting-task-status-filter-label"
-          className="flex flex-wrap items-center gap-2"
-        >
-          <span
-            id="meeting-task-status-filter-label"
-            className="text-xs text-muted-foreground"
+        {/* Kanban view では列ヘッダで status が可視化されているため、
+            フィルタ UI と二重化しないようブロックごと非表示にする。 */}
+        {!isKanbanView && (
+          // status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
+          // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+          // 避けるため div + role=group で代替する。
+          // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
+          <div
+            role="group"
+            aria-labelledby="meeting-task-status-filter-label"
+            className="flex flex-wrap items-center gap-2"
           >
-            ステータス
-          </span>
-          {FILTERABLE_STATUSES.map((s) => {
-            const checked = statusArr?.includes(s) ?? false;
-            return (
-              <label
-                key={s}
-                className={cn(
-                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-                  checked
-                    ? "bg-foreground text-background border-foreground"
-                    : "bg-card text-foreground border-border/60 hover:bg-accent",
-                )}
-              >
-                <input
-                  type="checkbox"
-                  className="sr-only"
-                  checked={checked}
-                  onChange={() => toggleStatus(s)}
-                />
-                {taskStatusLabels[s]}
-              </label>
-            );
-          })}
-        </div>
+            <span
+              id="meeting-task-status-filter-label"
+              className="text-xs text-muted-foreground"
+            >
+              ステータス
+            </span>
+            {FILTERABLE_STATUSES.map((s) => {
+              const checked = statusArr?.includes(s) ?? false;
+              return (
+                <label
+                  key={s}
+                  className={cn(
+                    "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                    checked
+                      ? "bg-foreground text-background border-foreground"
+                      : "bg-card text-foreground border-border/60 hover:bg-accent",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={checked}
+                    onChange={() => toggleStatus(s)}
+                  />
+                  {taskStatusLabels[s]}
+                </label>
+              );
+            })}
+          </div>
+        )}
 
         {tasksQuery.isLoading ? (
           <p className="text-muted-foreground">タスクを読み込み中...</p>

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -89,9 +89,13 @@ export function RecurringMeetingDetailView({
   const meetingsQuery = useRecurringMeetingMeetings(id);
 
   const statusArr = parseStatusParam(search.status);
+  // Kanban view では status は列として可視化されるため、フィルタ UI も API への
+  // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
+  // 復元用に保持する。
+  const isKanbanView = search.view === "kanban";
   const tasksQuery = useRecurringMeetingTasks(
     id,
-    statusArr ? { status: statusArr } : undefined,
+    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
   );
 
   if (detailQuery.isLoading) {
@@ -217,44 +221,48 @@ export function RecurringMeetingDetailView({
           </div>
         </div>
 
-        {/* status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
-            biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
-            避けるため div + role=group で代替する（My タスクと同じ判断）。 */}
-        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
-        <div
-          role="group"
-          aria-labelledby="rm-task-status-filter-label"
-          className="flex flex-wrap items-center gap-2"
-        >
-          <span
-            id="rm-task-status-filter-label"
-            className="text-xs text-muted-foreground"
+        {/* Kanban view では列ヘッダで status が可視化されているため、
+            フィルタ UI と二重化しないようブロックごと非表示にする。 */}
+        {!isKanbanView && (
+          // status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
+          // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+          // 避けるため div + role=group で代替する（My タスクと同じ判断）。
+          // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
+          <div
+            role="group"
+            aria-labelledby="rm-task-status-filter-label"
+            className="flex flex-wrap items-center gap-2"
           >
-            ステータス
-          </span>
-          {FILTERABLE_STATUSES.map((s) => {
-            const checked = statusArr?.includes(s) ?? false;
-            return (
-              <label
-                key={s}
-                className={cn(
-                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-                  checked
-                    ? "bg-foreground text-background border-foreground"
-                    : "bg-card text-foreground border-border/60 hover:bg-accent",
-                )}
-              >
-                <input
-                  type="checkbox"
-                  className="sr-only"
-                  checked={checked}
-                  onChange={() => toggleStatus(s)}
-                />
-                {taskStatusLabels[s]}
-              </label>
-            );
-          })}
-        </div>
+            <span
+              id="rm-task-status-filter-label"
+              className="text-xs text-muted-foreground"
+            >
+              ステータス
+            </span>
+            {FILTERABLE_STATUSES.map((s) => {
+              const checked = statusArr?.includes(s) ?? false;
+              return (
+                <label
+                  key={s}
+                  className={cn(
+                    "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                    checked
+                      ? "bg-foreground text-background border-foreground"
+                      : "bg-card text-foreground border-border/60 hover:bg-accent",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={checked}
+                    onChange={() => toggleStatus(s)}
+                  />
+                  {taskStatusLabels[s]}
+                </label>
+              );
+            })}
+          </div>
+        )}
 
         {tasksQuery.isLoading ? (
           <p className="text-muted-foreground">タスクを読み込み中...</p>

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -73,6 +73,10 @@ export function MyTasksView({
   now?: Date;
 }) {
   const statusArr = parseStatusParam(search.status);
+  // Kanban view では status は列として可視化されるため、フィルタ UI も API への
+  // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
+  // 復元用に保持する。
+  const isKanbanView = search.view === "kanban";
 
   // effective orgId の決定ロジック:
   //  - URL に orgId="all" → フィルタなし（ユーザーが明示的にすべてを選んだ）
@@ -85,7 +89,7 @@ export function MyTasksView({
   // API には組織フィルタが無いため、status のみを API に渡してクライアント側で組織を絞り込む。
   // タスクは全件返却前提のため、組織でさらに削ってもパフォーマンス問題は出ない想定。
   const { data, isLoading, isError } = useMyTasks(
-    statusArr ? { status: statusArr } : undefined,
+    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
   );
 
   const tasks = data ?? [];
@@ -147,45 +151,49 @@ export function MyTasksView({
       </header>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-        {/* fieldset/legend だと legend がブロック扱いで「ステータス」が
-            上段に押し出され、組織ラベルとベースラインが揃わない。
-            biome の useSemanticElements は fieldset を勧めるが、本ケースでは
-            視覚整列を優先し、a11y は aria-labelledby で代替する。 */}
-        {/* biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替 */}
-        <div
-          role="group"
-          aria-labelledby="status-filter-label"
-          className="flex flex-wrap items-center gap-2"
-        >
-          <span
-            id="status-filter-label"
-            className="text-xs text-muted-foreground"
+        {/* Kanban view では列ヘッダで status が可視化されているため、
+            フィルタ UI と二重化しないようブロックごと非表示にする。 */}
+        {!isKanbanView && (
+          // fieldset/legend だと legend がブロック扱いで「ステータス」が
+          // 上段に押し出され、組織ラベルとベースラインが揃わない。
+          // biome の useSemanticElements は fieldset を勧めるが、本ケースでは
+          // 視覚整列を優先し、a11y は aria-labelledby で代替する。
+          // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
+          <div
+            role="group"
+            aria-labelledby="status-filter-label"
+            className="flex flex-wrap items-center gap-2"
           >
-            ステータス
-          </span>
-          {FILTERABLE_STATUSES.map((s) => {
-            const checked = statusArr?.includes(s) ?? false;
-            return (
-              <label
-                key={s}
-                className={cn(
-                  "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-                  checked
-                    ? "bg-foreground text-background border-foreground"
-                    : "bg-card text-foreground border-border/60 hover:bg-accent",
-                )}
-              >
-                <input
-                  type="checkbox"
-                  className="sr-only"
-                  checked={checked}
-                  onChange={() => toggleStatus(s)}
-                />
-                {taskStatusLabels[s]}
-              </label>
-            );
-          })}
-        </div>
+            <span
+              id="status-filter-label"
+              className="text-xs text-muted-foreground"
+            >
+              ステータス
+            </span>
+            {FILTERABLE_STATUSES.map((s) => {
+              const checked = statusArr?.includes(s) ?? false;
+              return (
+                <label
+                  key={s}
+                  className={cn(
+                    "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                    checked
+                      ? "bg-foreground text-background border-foreground"
+                      : "bg-card text-foreground border-border/60 hover:bg-accent",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={checked}
+                    onChange={() => toggleStatus(s)}
+                  />
+                  {taskStatusLabels[s]}
+                </label>
+              );
+            })}
+          </div>
+        )}
 
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
           組織

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -216,4 +216,35 @@ describe("MeetingDetailView", () => {
       await screen.findByRole("heading", { name: "タスクを作成" }),
     ).toBeInTheDocument();
   });
+
+  it("view=kanban のとき status フィルタ UI は描画されない", async () => {
+    vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(
+      mockJson([sampleTask]),
+    );
+    renderWithQuery(
+      <MeetingDetailView id="mtg-1" search={{ view: "kanban" }} now={NOW} />,
+    );
+    await screen.findByTestId("kanban-board");
+    // Kanban のカラムヘッダにも「未着手」等のラベルがあるため、
+    // フィルタ UI 固有の group / 凡例ラベルで存在判定する。
+    expect(
+      screen.queryByRole("group", { name: "ステータス" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("ステータス")).not.toBeInTheDocument();
+  });
+
+  it("view=kanban のとき URL の status は API リクエストに乗らない（全件取得）", async () => {
+    renderWithQuery(
+      <MeetingDetailView
+        id="mtg-1"
+        search={{ view: "kanban", status: "todo" }}
+        now={NOW}
+      />,
+    );
+    await screen.findByText("タスク");
+    const call = vi.mocked(api.meetings[":id"].tasks.$get).mock.calls[0];
+    expect(
+      (call[0] as { query: { status?: string } }).query.status,
+    ).toBeUndefined();
+  });
 });

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -348,9 +348,10 @@ describe("定例詳細ページ - タスクセクション", () => {
     );
   });
 
+  type Search = { status?: string; view?: "list" | "kanban" };
   function renderWithSearch(opts?: {
-    search?: { status?: string };
-    onSearchChange?: (next: { status?: string }) => void;
+    search?: Search;
+    onSearchChange?: (next: Search) => void;
   }) {
     return renderWithQuery(
       <RecurringMeetingDetailView
@@ -422,5 +423,32 @@ describe("定例詳細ページ - タスクセクション", () => {
     expect(
       await screen.findByText("タスクの取得に失敗しました"),
     ).toBeInTheDocument();
+  });
+
+  it("view=kanban のとき status フィルタ UI は描画されない", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([sampleTask]),
+    );
+    renderWithSearch({ search: { view: "kanban" } });
+    await screen.findByTestId("kanban-board");
+    // Kanban のカラムヘッダにも「未着手」等のラベルがあるため、
+    // フィルタ UI 固有の group / 凡例ラベルで存在判定する。
+    expect(
+      screen.queryByRole("group", { name: "ステータス" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("ステータス")).not.toBeInTheDocument();
+  });
+
+  it("view=kanban のとき URL の status は API リクエストに乗らない（全件取得）", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithSearch({ search: { view: "kanban", status: "todo" } });
+    await screen.findByText("タスク");
+    const call = vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mock
+      .calls[0];
+    expect(
+      (call[0] as { query: { status?: string } }).query.status,
+    ).toBeUndefined();
   });
 });

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -550,6 +550,38 @@ describe("MyTasksView - View 切替", () => {
       expect.objectContaining({ view: "kanban" }),
     );
   });
+
+  it("view=kanban のとき status フィルタ UI は描画されない", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+    renderWithQuery(
+      <MyTasksView search={{ view: "kanban" }} onSearchChange={() => {}} />,
+    );
+    await screen.findByTestId("kanban-board");
+    // status フィルタ UI は Kanban の列で代替されるため非表示。
+    // Kanban のカラムヘッダにも「未着手」等のラベルがあるため、フィルタ UI 固有の
+    // group / 凡例ラベルで存在判定する。
+    expect(
+      screen.queryByRole("group", { name: "ステータス" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("ステータス")).not.toBeInTheDocument();
+  });
+
+  it("view=kanban のとき URL の status は API リクエストに乗らない（全件取得）", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderWithQuery(
+      <MyTasksView
+        search={{ view: "kanban", status: "todo,in_progress" }}
+        onSearchChange={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(api.tasks.me.$get).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks.me.$get).mock.calls[0];
+    expect(
+      (call[0] as { query: { status?: string } }).query.status,
+    ).toBeUndefined();
+  });
 });
 
 describe("MyTasksView - タスク作成 CTA", () => {


### PR DESCRIPTION
## 関連Issue
Closes #192

## 概要・目的
* Kanban view は列ヘッダで status を可視化しているのに、status フィルタ UI も同時に表示されており、同じ操作が 2 か所に存在する状態を解消する。
* 3 つのタスク一覧ルート (`/tasks`, `/recurring-meetings/$id`, `/meetings/$id`) で Kanban のときだけフィルタ UI を消し、API リクエストにも status を乗せない（列を切り替えても全件を見たままにする）。

## 背景
* #187 で Kanban ビューを 3 ルートに導入したが、フィルタ UI が List view と共通のままだったため、Kanban の列ヘッダとフィルタ UI で「status の選び方」が二重化していた。
* 列で絞ったのにフィルタでも絞れる挙動はレビューでも認知負荷の原因として上がりやすく、Kanban の意図（ステータスは列で表現）を保つために UI ごと外す方針にした。
* URL の `?status=...` はそのまま残し、List に戻したときに前の絞り込みが復元されるようにする運用は維持する。

## 変更内容
* 3 ルートに `const isKanbanView = search.view === "kanban";` を入れ、フィルタ UI のブロックを `{!isKanbanView && ...}` で条件レンダリング。
* 各データフック (`useMyTasks` / `useRecurringMeetingTasks` / `useMeetingTasks`) に渡す filters を Kanban のとき `undefined` にし、API クエリから `status` を外して全件取得にする。
* `parseStatusParam` の呼び出し自体は残し、URL の `?status=...` は触らない（List に戻したときに同じ statusArr で復元される）。
* テストを各ルートに 2 件ずつ追加（計 6 件）：
  - 「view=kanban のとき status フィルタ UI は描画されない」
  - 「view=kanban のとき URL に status を持っていても API リクエストに乗らない」
* `recurring-meetings.\$id.test.tsx` の `renderWithSearch` ヘルパーの search 型に `view` を追加。

## 動作確認手順
1. `git checkout issue-192-kanban-hide-status-filter`
2. `make install`（依存差分なしのはず。スキップ可）
3. `make test` で 316/316 が GREEN になることを確認。
4. `make dev` で起動し、`/tasks` を開く。
   - 既定の List view ではステータスのチェックボックス UI が出ること。
   - 「Kanban」タブに切り替えると「ステータス」ラベルとチェックボックスが消えること。
   - List に戻すと元の UI と URL の `?status=...` 状態が復元されること。
5. `/recurring-meetings/\$id` と `/meetings/\$id` の各タスクセクションでも同じ挙動を確認。
6. Kanban で URL に `?status=todo` を手で付けても列に全タスクが並ぶこと（API リクエストの query に status が乗っていないことを Network パネルで確認できる）。

## スクリーンショット
<img width="1318" height="451" alt="image" src="https://github.com/user-attachments/assets/02468113-7f04-49be-b975-31d49b8e19d7" />