### PR TITLE
タスク一覧に「期限超過のみ」クイックトグルを追加

### DIFF
--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -109,18 +109,38 @@ export const taskListQuerySchema = z.object({
     .string()
     .datetime({ message: "dueAfter は ISO8601 で指定してください" })
     .optional(),
+  // 「期限超過のみ」クイックトグル用。"true" の完全一致だけを真と扱い、
+  // それ以外の文字列（未指定含む）は false にする（z.coerce.boolean だと
+  // "false" や任意文字列も true になってしまうため避ける）。
+  overdueOnly: z
+    .string()
+    .optional()
+    .transform((v) => v === "true"),
 });
 
 export type TaskListQuery = z.infer<typeof taskListQuerySchema>;
 
+// buildTaskListWhere の戻り値型。overdueOnly と既存 status filter の併用時に
+// AND を使うため、AND 配列も含めて型を明示する。
+type TaskStatusWhere = {
+  in?: TaskListQuery["status"];
+  notIn?: Array<"done" | "rejected">;
+};
+type TaskListWhere = {
+  status?: TaskStatusWhere;
+  assignees?: { some: { userId: string } };
+  dueDate?: { gte?: Date; lte?: Date; lt?: Date };
+  AND?: Array<{ status: TaskStatusWhere }>;
+};
+
 // 一覧 API のクエリフィルタを Prisma の where 句に変換する。
 // スコープ別の where 条件（例: organizationId 等）と AND 合成する想定。
-export function buildTaskListWhere(filters: TaskListQuery) {
-  const where: {
-    status?: { in: TaskListQuery["status"] };
-    assignees?: { some: { userId: string } };
-    dueDate?: { gte?: Date; lte?: Date };
-  } = {};
+// now はテストでの注入を許すために引数化しているが、本番ではデフォルトのリクエスト時刻を使う。
+export function buildTaskListWhere(
+  filters: TaskListQuery,
+  now: Date = new Date(),
+): TaskListWhere {
+  const where: TaskListWhere = {};
   if (filters.status && filters.status.length > 0) {
     where.status = { in: filters.status };
   }
@@ -131,6 +151,22 @@ export function buildTaskListWhere(filters: TaskListQuery) {
     where.dueDate = {};
     if (filters.dueAfter) where.dueDate.gte = new Date(filters.dueAfter);
     if (filters.dueBefore) where.dueDate.lte = new Date(filters.dueBefore);
+  }
+  // overdueOnly: 「期限超過 かつ 未完了」に絞る。
+  // - dueDate.lt = now（dueBefore があれば lte と共存させる）
+  // - status は「done/rejected を外す」が、ユーザーの status filter と両立させるため
+  //   filter が既にあるときは AND で結合する（Prisma は同一フィールドの上書きになるため）。
+  if (filters.overdueOnly === true) {
+    where.dueDate = { ...(where.dueDate ?? {}), lt: now };
+    if (where.status) {
+      where.AND = [
+        { status: where.status },
+        { status: { notIn: ["done", "rejected"] } },
+      ];
+      delete where.status;
+    } else {
+      where.status = { notIn: ["done", "rejected"] };
+    }
   }
   return where;
 }

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -674,6 +674,46 @@ describe("GET /tasks/me", () => {
     expect(res.status).toBe(400);
     expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
+
+  it("overdueOnly=true で dueDate.lt と status.notIn が where に乗る", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request("/tasks/me?overdueOnly=true");
+    const where = mockTaskFindMany.mock.calls[0][0].where as {
+      dueDate?: { lt?: Date };
+      status?: { notIn?: string[] };
+    };
+    // now はサーバ側現在時刻のため、Date インスタンスが入っていることだけ確認する。
+    expect(where.dueDate?.lt).toBeInstanceOf(Date);
+    expect(where.status).toEqual({ notIn: ["done", "rejected"] });
+  });
+
+  it("overdueOnly=true と status=todo の併用は AND で結合される", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request("/tasks/me?overdueOnly=true&status=todo");
+    const where = mockTaskFindMany.mock.calls[0][0].where as {
+      AND?: Array<{ status: { in?: string[]; notIn?: string[] } }>;
+      status?: unknown;
+    };
+    // AND で「ユーザー指定の in」と「done/rejected を外す notIn」を結合し、
+    // トップレベルの status は AND に移動するので存在しないこと。
+    expect(where.AND).toEqual([
+      { status: { in: ["todo"] } },
+      { status: { notIn: ["done", "rejected"] } },
+    ]);
+    expect(where.status).toBeUndefined();
+  });
+
+  it("overdueOnly=true と dueBefore を併用すると dueDate.lt と lte の両方が乗る", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request(
+      "/tasks/me?overdueOnly=true&dueBefore=2026-05-31T00:00:00Z",
+    );
+    const where = mockTaskFindMany.mock.calls[0][0].where as {
+      dueDate?: { lt?: Date; lte?: Date };
+    };
+    expect(where.dueDate?.lt).toBeInstanceOf(Date);
+    expect(where.dueDate?.lte).toEqual(new Date("2026-05-31T00:00:00Z"));
+  });
 });
 
 describe("DELETE /tasks/:id", () => {

--- a/apps/web/src/features/tasks/components/OverdueOnlyToggle.tsx
+++ b/apps/web/src/features/tasks/components/OverdueOnlyToggle.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+
+// 「期限超過のみ」のクイックトグル。
+// 視覚的には status フィルタのチップと同じスタイルで揃え、フィルタ行に並べたときに
+// 違和感が出ないようにしている。押下状態は aria-pressed で表現する。
+export function OverdueOnlyToggle({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={value}
+      onClick={() => onChange(!value)}
+      className={cn(
+        "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+        value
+          ? "bg-foreground text-background border-foreground"
+          : "bg-card text-foreground border-border/60 hover:bg-accent",
+      )}
+    >
+      期限超過のみ
+    </button>
+  );
+}

--- a/apps/web/src/features/tasks/hooks/useTasksQuery.ts
+++ b/apps/web/src/features/tasks/hooks/useTasksQuery.ts
@@ -13,5 +13,8 @@ export function toTaskListQueryParams(
   if (filters.assigneeId) params.assigneeId = filters.assigneeId;
   if (filters.dueBefore) params.dueBefore = filters.dueBefore;
   if (filters.dueAfter) params.dueAfter = filters.dueAfter;
+  // overdueOnly は ON のときだけ URL に乗せる。OFF（false / undefined）はパラメータごと消す
+  // ことで、API 側の判定（"true" 完全一致）と整合させる。
+  if (filters.overdueOnly) params.overdueOnly = "true";
   return params;
 }

--- a/apps/web/src/features/tasks/types.ts
+++ b/apps/web/src/features/tasks/types.ts
@@ -94,4 +94,7 @@ export type TaskListFilters = {
   assigneeId?: string;
   dueBefore?: string;
   dueAfter?: string;
+  // 「期限超過のみ」クイックトグル。true のとき API 側で
+  // dueDate < now AND status NOT IN (done, rejected) で絞り込む。
+  overdueOnly?: boolean;
 };

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,6 +1,7 @@
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
+import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import {
   ViewToggle,
@@ -9,7 +10,7 @@ import {
 import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
 import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import { taskStatusLabels } from "@/features/tasks/labels";
-import type { TaskStatus } from "@/features/tasks/types";
+import type { TaskListFilters, TaskStatus } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
@@ -25,6 +26,8 @@ const FILTERABLE_STATUSES: TaskStatus[] = [
 const meetingSearchSchema = z.object({
   status: z.string().optional(),
   view: z.enum(["list", "kanban"]).optional(),
+  // 「期限超過のみ」クイックトグル。API 仕様と整合させるため "true" 文字列で永続化する。
+  overdueOnly: z.string().optional(),
 });
 
 type MeetingSearch = z.infer<typeof meetingSearchSchema>;
@@ -88,10 +91,15 @@ export function MeetingDetailView({
   // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
   // 復元用に保持する。
   const isKanbanView = search.view === "kanban";
-  const tasksQuery = useMeetingTasks(
-    id,
-    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
-  );
+  // 「期限超過のみ」トグル。Kanban view でも有効（列との情報重複なし）。
+  const overdueOnly = search.overdueOnly === "true";
+
+  const apiFilters: TaskListFilters = {};
+  if (!isKanbanView && statusArr) apiFilters.status = statusArr;
+  if (overdueOnly) apiFilters.overdueOnly = true;
+  const filtersForQuery: TaskListFilters | undefined =
+    Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
+  const tasksQuery = useMeetingTasks(id, filtersForQuery);
 
   if (detailQuery.isLoading) {
     return (
@@ -167,48 +175,61 @@ export function MeetingDetailView({
           </div>
         </div>
 
-        {/* Kanban view では列ヘッダで status が可視化されているため、
-            フィルタ UI と二重化しないようブロックごと非表示にする。 */}
-        {!isKanbanView && (
-          // status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
-          // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
-          // 避けるため div + role=group で代替する。
-          // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
-          <div
-            role="group"
-            aria-labelledby="meeting-task-status-filter-label"
-            className="flex flex-wrap items-center gap-2"
-          >
-            <span
-              id="meeting-task-status-filter-label"
-              className="text-xs text-muted-foreground"
+        {/* フィルタ行。「期限超過のみ」は両 view で表示、status フィルタは List view のみ。 */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <OverdueOnlyToggle
+            value={overdueOnly}
+            onChange={(next) =>
+              onSearchChange({
+                ...search,
+                overdueOnly: next ? "true" : undefined,
+              })
+            }
+          />
+
+          {/* Kanban view では列ヘッダで status が可視化されているため、
+              フィルタ UI と二重化しないようブロックごと非表示にする。 */}
+          {!isKanbanView && (
+            // status フィルタ。My タスク・定例詳細と同じ inline label + aria-labelledby パターン。
+            // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+            // 避けるため div + role=group で代替する。
+            // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
+            <div
+              role="group"
+              aria-labelledby="meeting-task-status-filter-label"
+              className="flex flex-wrap items-center gap-2"
             >
-              ステータス
-            </span>
-            {FILTERABLE_STATUSES.map((s) => {
-              const checked = statusArr?.includes(s) ?? false;
-              return (
-                <label
-                  key={s}
-                  className={cn(
-                    "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-                    checked
-                      ? "bg-foreground text-background border-foreground"
-                      : "bg-card text-foreground border-border/60 hover:bg-accent",
-                  )}
-                >
-                  <input
-                    type="checkbox"
-                    className="sr-only"
-                    checked={checked}
-                    onChange={() => toggleStatus(s)}
-                  />
-                  {taskStatusLabels[s]}
-                </label>
-              );
-            })}
-          </div>
-        )}
+              <span
+                id="meeting-task-status-filter-label"
+                className="text-xs text-muted-foreground"
+              >
+                ステータス
+              </span>
+              {FILTERABLE_STATUSES.map((s) => {
+                const checked = statusArr?.includes(s) ?? false;
+                return (
+                  <label
+                    key={s}
+                    className={cn(
+                      "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                      checked
+                        ? "bg-foreground text-background border-foreground"
+                        : "bg-card text-foreground border-border/60 hover:bg-accent",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={checked}
+                      onChange={() => toggleStatus(s)}
+                    />
+                    {taskStatusLabels[s]}
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         {tasksQuery.isLoading ? (
           <p className="text-muted-foreground">タスクを読み込み中...</p>
@@ -221,10 +242,7 @@ export function MeetingDetailView({
         ) : search.view === "kanban" ? (
           <KanbanBoard
             tasks={tasksQuery.data ?? []}
-            queryKey={taskQueryKeys.meeting(
-              id,
-              statusArr ? { status: statusArr } : {},
-            )}
+            queryKey={taskQueryKeys.meeting(id, filtersForQuery ?? {})}
             ariaLabel="会議由来のタスク Kanban"
             now={now}
           />

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/features/recurring-meetings/scheduleCron";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
+import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import {
   ViewToggle,
@@ -17,7 +18,7 @@ import {
 import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMeetingTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import { taskQueryKeys } from "@/features/tasks/queryKeys";
-import type { TaskStatus } from "@/features/tasks/types";
+import type { TaskListFilters, TaskStatus } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
@@ -35,6 +36,8 @@ const FILTERABLE_STATUSES: TaskStatus[] = [
 const recurringMeetingSearchSchema = z.object({
   status: z.string().optional(),
   view: z.enum(["list", "kanban"]).optional(),
+  // 「期限超過のみ」クイックトグル。API 仕様と整合させるため "true" 文字列で永続化する。
+  overdueOnly: z.string().optional(),
 });
 
 type RecurringMeetingSearch = z.infer<typeof recurringMeetingSearchSchema>;
@@ -93,10 +96,15 @@ export function RecurringMeetingDetailView({
   // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
   // 復元用に保持する。
   const isKanbanView = search.view === "kanban";
-  const tasksQuery = useRecurringMeetingTasks(
-    id,
-    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
-  );
+  // 「期限超過のみ」トグル。Kanban view でも有効（列との情報重複なし）。
+  const overdueOnly = search.overdueOnly === "true";
+
+  const apiFilters: TaskListFilters = {};
+  if (!isKanbanView && statusArr) apiFilters.status = statusArr;
+  if (overdueOnly) apiFilters.overdueOnly = true;
+  const filtersForQuery: TaskListFilters | undefined =
+    Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
+  const tasksQuery = useRecurringMeetingTasks(id, filtersForQuery);
 
   if (detailQuery.isLoading) {
     return (
@@ -221,48 +229,61 @@ export function RecurringMeetingDetailView({
           </div>
         </div>
 
-        {/* Kanban view では列ヘッダで status が可視化されているため、
-            フィルタ UI と二重化しないようブロックごと非表示にする。 */}
-        {!isKanbanView && (
-          // status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
-          // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
-          // 避けるため div + role=group で代替する（My タスクと同じ判断）。
-          // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
-          <div
-            role="group"
-            aria-labelledby="rm-task-status-filter-label"
-            className="flex flex-wrap items-center gap-2"
-          >
-            <span
-              id="rm-task-status-filter-label"
-              className="text-xs text-muted-foreground"
+        {/* フィルタ行。「期限超過のみ」は両 view で表示、status フィルタは List view のみ。 */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <OverdueOnlyToggle
+            value={overdueOnly}
+            onChange={(next) =>
+              onSearchChange({
+                ...search,
+                overdueOnly: next ? "true" : undefined,
+              })
+            }
+          />
+
+          {/* Kanban view では列ヘッダで status が可視化されているため、
+              フィルタ UI と二重化しないようブロックごと非表示にする。 */}
+          {!isKanbanView && (
+            // status フィルタ。My タスクと同じ inline label + aria-labelledby パターン。
+            // biome の useSemanticElements は fieldset を勧めるが、legend のレイアウト崩れを
+            // 避けるため div + role=group で代替する（My タスクと同じ判断）。
+            // biome-ignore lint/a11y/useSemanticElements: legend が要素を改行させるため fieldset は使えない。aria-labelledby で代替
+            <div
+              role="group"
+              aria-labelledby="rm-task-status-filter-label"
+              className="flex flex-wrap items-center gap-2"
             >
-              ステータス
-            </span>
-            {FILTERABLE_STATUSES.map((s) => {
-              const checked = statusArr?.includes(s) ?? false;
-              return (
-                <label
-                  key={s}
-                  className={cn(
-                    "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
-                    checked
-                      ? "bg-foreground text-background border-foreground"
-                      : "bg-card text-foreground border-border/60 hover:bg-accent",
-                  )}
-                >
-                  <input
-                    type="checkbox"
-                    className="sr-only"
-                    checked={checked}
-                    onChange={() => toggleStatus(s)}
-                  />
-                  {taskStatusLabels[s]}
-                </label>
-              );
-            })}
-          </div>
-        )}
+              <span
+                id="rm-task-status-filter-label"
+                className="text-xs text-muted-foreground"
+              >
+                ステータス
+              </span>
+              {FILTERABLE_STATUSES.map((s) => {
+                const checked = statusArr?.includes(s) ?? false;
+                return (
+                  <label
+                    key={s}
+                    className={cn(
+                      "text-xs px-2 py-1 rounded-md border cursor-pointer select-none",
+                      checked
+                        ? "bg-foreground text-background border-foreground"
+                        : "bg-card text-foreground border-border/60 hover:bg-accent",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={checked}
+                      onChange={() => toggleStatus(s)}
+                    />
+                    {taskStatusLabels[s]}
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         {tasksQuery.isLoading ? (
           <p className="text-muted-foreground">タスクを読み込み中...</p>
@@ -275,10 +296,7 @@ export function RecurringMeetingDetailView({
         ) : search.view === "kanban" ? (
           <KanbanBoard
             tasks={tasksQuery.data ?? []}
-            queryKey={taskQueryKeys.recurring(
-              id,
-              statusArr ? { status: statusArr } : {},
-            )}
+            queryKey={taskQueryKeys.recurring(id, filtersForQuery ?? {})}
             ariaLabel="プロジェクトのタスク Kanban"
             now={now}
           />

--- a/apps/web/src/routes/tasks.index.tsx
+++ b/apps/web/src/routes/tasks.index.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
+import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
 import { TaskListWithDialogs } from "@/features/tasks/components/TaskListWithDialogs";
 import {
   ViewToggle,
@@ -9,7 +10,11 @@ import {
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import { taskQueryKeys } from "@/features/tasks/queryKeys";
-import type { TaskListItem, TaskStatus } from "@/features/tasks/types";
+import type {
+  TaskListFilters,
+  TaskListItem,
+  TaskStatus,
+} from "@/features/tasks/types";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { cn } from "@/lib/utils";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
@@ -36,6 +41,9 @@ const tasksSearchSchema = z.object({
   orgId: z.string().optional(),
   // List / Kanban のビュー切替。デフォルトは list。
   view: z.enum(["list", "kanban"]).optional(),
+  // 「期限超過のみ」クイックトグル。API 仕様と整合させるため "true" 文字列で永続化する。
+  // OFF 時は URL からキーごと消す（toTaskListQueryParams 側の挙動と対称）。
+  overdueOnly: z.string().optional(),
 });
 
 type TasksSearch = z.infer<typeof tasksSearchSchema>;
@@ -77,6 +85,8 @@ export function MyTasksView({
   // status 絞り込みも外す（全件取得）。URL の `?status=...` 自体は List に戻したときの
   // 復元用に保持する。
   const isKanbanView = search.view === "kanban";
+  // 「期限超過のみ」トグル。URL では "true" 完全一致を真として扱う。
+  const overdueOnly = search.overdueOnly === "true";
 
   // effective orgId の決定ロジック:
   //  - URL に orgId="all" → フィルタなし（ユーザーが明示的にすべてを選んだ）
@@ -86,11 +96,15 @@ export function MyTasksView({
   const effectiveOrgId: string | null =
     search.orgId === ALL_ORGS_SENTINEL ? null : (search.orgId ?? currentOrgId);
 
-  // API には組織フィルタが無いため、status のみを API に渡してクライアント側で組織を絞り込む。
+  // API に渡すフィルタを組み立てる。Kanban view では status を外し、overdueOnly は両 view で有効。
+  const apiFilters: TaskListFilters = {};
+  if (!isKanbanView && statusArr) apiFilters.status = statusArr;
+  if (overdueOnly) apiFilters.overdueOnly = true;
+  const filtersForQuery: TaskListFilters | undefined =
+    Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
+  // API には組織フィルタが無いため、status / overdueOnly のみを API に渡し、組織はクライアントで絞り込む。
   // タスクは全件返却前提のため、組織でさらに削ってもパフォーマンス問題は出ない想定。
-  const { data, isLoading, isError } = useMyTasks(
-    isKanbanView ? undefined : statusArr ? { status: statusArr } : undefined,
-  );
+  const { data, isLoading, isError } = useMyTasks(filtersForQuery);
 
   const tasks = data ?? [];
   // 組織候補は取得した tasks から動的に構築する。useMyOrganizations を別途呼ばない方針。
@@ -151,6 +165,17 @@ export function MyTasksView({
       </header>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        {/* 「期限超過のみ」クイックトグル。Kanban view でも有効（列との情報重複なし）。 */}
+        <OverdueOnlyToggle
+          value={overdueOnly}
+          onChange={(next) =>
+            onSearchChange({
+              ...search,
+              overdueOnly: next ? "true" : undefined,
+            })
+          }
+        />
+
         {/* Kanban view では列ヘッダで status が可視化されているため、
             フィルタ UI と二重化しないようブロックごと非表示にする。 */}
         {!isKanbanView && (
@@ -252,7 +277,7 @@ export function MyTasksView({
       ) : search.view === "kanban" ? (
         <KanbanBoard
           tasks={filtered}
-          queryKey={taskQueryKeys.me(statusArr ? { status: statusArr } : {})}
+          queryKey={taskQueryKeys.me(filtersForQuery ?? {})}
           ariaLabel="My タスク Kanban"
           now={now}
         />

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -584,6 +584,55 @@ describe("MyTasksView - View 切替", () => {
   });
 });
 
+describe("MyTasksView - 期限超過のみトグル", () => {
+  it("OFF 状態のトグルをクリックすると onSearchChange に overdueOnly=true が渡る", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    const onSearchChange = vi.fn();
+    renderWithQuery(
+      <MyTasksView search={{}} onSearchChange={onSearchChange} />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("担当中のタスクはありません"),
+      ).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "期限超過のみ" }));
+    expect(onSearchChange).toHaveBeenCalledWith(
+      expect.objectContaining({ overdueOnly: "true" }),
+    );
+  });
+
+  it("初期 ?overdueOnly=true で API リクエストに overdueOnly が乗る", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderWithQuery(
+      <MyTasksView
+        search={{ overdueOnly: "true" }}
+        onSearchChange={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(api.tasks.me.$get).toHaveBeenCalled();
+    });
+    const call = vi.mocked(api.tasks.me.$get).mock.calls[0];
+    expect(
+      (call[0] as { query: { overdueOnly?: string } }).query.overdueOnly,
+    ).toBe("true");
+  });
+
+  it("view=kanban でもトグルは描画される（status フィルタとは独立）", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));
+    renderWithQuery(
+      <MyTasksView search={{ view: "kanban" }} onSearchChange={() => {}} />,
+    );
+    await screen.findByTestId("kanban-board");
+    expect(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    ).toBeInTheDocument();
+  });
+});
+
 describe("MyTasksView - タスク作成 CTA", () => {
   it("currentOrgId ありなら「タスクを追加」ボタンが有効になる", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([baseTask]));

--- a/apps/web/src/test/tasks.overdueOnlyToggle.test.tsx
+++ b/apps/web/src/test/tasks.overdueOnlyToggle.test.tsx
@@ -1,0 +1,48 @@
+import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+// 単一のトグルボタン。視覚的には status filter チップと同じスタイルで揃え、
+// aria-pressed で押下状態を表現する想定。
+
+describe("OverdueOnlyToggle", () => {
+  it("ラベル「期限超過のみ」のボタンとして描画される", () => {
+    render(<OverdueOnlyToggle value={false} onChange={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    ).toBeInTheDocument();
+  });
+
+  it("value=false のとき aria-pressed=false", () => {
+    render(<OverdueOnlyToggle value={false} onChange={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("value=true のとき aria-pressed=true", () => {
+    render(<OverdueOnlyToggle value={true} onChange={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("OFF からクリックすると onChange(true) を呼ぶ", async () => {
+    const onChange = vi.fn();
+    render(<OverdueOnlyToggle value={false} onChange={onChange} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    );
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("ON からクリックすると onChange(false) を呼ぶ", async () => {
+    const onChange = vi.fn();
+    render(<OverdueOnlyToggle value={true} onChange={onChange} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "期限超過のみ" }),
+    );
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/test/tasks.overdueOnlyToggle.test.tsx
+++ b/apps/web/src/test/tasks.overdueOnlyToggle.test.tsx
@@ -31,18 +31,14 @@ describe("OverdueOnlyToggle", () => {
   it("OFF からクリックすると onChange(true) を呼ぶ", async () => {
     const onChange = vi.fn();
     render(<OverdueOnlyToggle value={false} onChange={onChange} />);
-    await userEvent.click(
-      screen.getByRole("button", { name: "期限超過のみ" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "期限超過のみ" }));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
   it("ON からクリックすると onChange(false) を呼ぶ", async () => {
     const onChange = vi.fn();
     render(<OverdueOnlyToggle value={true} onChange={onChange} />);
-    await userEvent.click(
-      screen.getByRole("button", { name: "期限超過のみ" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "期限超過のみ" }));
     expect(onChange).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/src/test/tasks.queryParams.test.ts
+++ b/apps/web/src/test/tasks.queryParams.test.ts
@@ -50,4 +50,16 @@ describe("toTaskListQueryParams", () => {
       dueBefore: "2026-06-30T23:59:59Z",
     });
   });
+
+  it("overdueOnly が true のときは overdueOnly=\"true\" を含める", () => {
+    expect(toTaskListQueryParams({ overdueOnly: true })).toEqual({
+      overdueOnly: "true",
+    });
+  });
+
+  it("overdueOnly が false / undefined のときは URL に乗せない", () => {
+    // 「期限超過のみ」OFF 状態は URL からパラメータごと消し、API も全件扱いにする。
+    expect(toTaskListQueryParams({ overdueOnly: false })).toEqual({});
+    expect(toTaskListQueryParams({})).toEqual({});
+  });
 });

--- a/apps/web/src/test/tasks.queryParams.test.ts
+++ b/apps/web/src/test/tasks.queryParams.test.ts
@@ -51,7 +51,7 @@ describe("toTaskListQueryParams", () => {
     });
   });
 
-  it("overdueOnly が true のときは overdueOnly=\"true\" を含める", () => {
+  it('overdueOnly が true のときは overdueOnly="true" を含める', () => {
     expect(toTaskListQueryParams({ overdueOnly: true })).toEqual({
       overdueOnly: "true",
     });


### PR DESCRIPTION
## 関連Issue
Closes #194

## 概要・目的
* タスク一覧で「期限を過ぎたまま未完了のタスクだけ確認したい」場面を 1 クリックで絞り込めるよう、3 ページ全て（My タスク / 定例詳細 / 会議詳細）に「期限超過のみ」トグルを置く。
* バックエンドは `dueDate < now AND status NOT IN (done, rejected)` の where を組む API パラメータ `overdueOnly` を追加し、フロントは URL `?overdueOnly=true` で永続化する。

## 背景
* List 表示では行ごとに dueDate を赤字強調しているが、件数が増えると一覧をスクロールしないと対応漏れを拾えない。
* ステータス列で絞っても「期限超過 かつ 未完了」を一発で出せず、対応漏れチェックの手数がかかっていた。
* タスクフィルタ拡張 3 件（#191 から分割）の中規模スコープ。シンプルな割に実用度が高く、UI 改善として効果が大きい。

## 変更内容
### Backend (`apps/api`)
* `taskListQuerySchema` に `overdueOnly` を追加。`"true"` 完全一致だけを真と扱い、`"false"` や任意文字列は false（`z.coerce.boolean()` は `"false"` も true 扱いになるため避けた）。
* `buildTaskListWhere(filters, now = new Date())` に拡張し、`overdueOnly === true` のとき `dueDate.lt = now` と `status.notIn = ["done", "rejected"]` を where に追加。now はリクエスト到達時刻基準（毎リクエスト評価）。
* status filter と併用時は Prisma の `AND` で結合し、ユーザー指定 `in` と仕様の `notIn` の両方を満たすクエリにする。
* API テスト 3 件追加（単体 / status 併用 / dueBefore 併用）。

### Frontend (`apps/web`)
* `TaskListFilters` 型と `toTaskListQueryParams` に `overdueOnly?: boolean` を追加。true のときだけ `?overdueOnly=true` を URL に乗せ、false / undefined では URL からパラメータごと消す。
* `OverdueOnlyToggle` を新設。既存の status フィルタチップと同じスタイル（`text-xs px-2 py-1 rounded-md border`）で、押下時は反転色 + `aria-pressed=true`。
* 3 ルート (`/tasks`, `/recurring-meetings/\$id`, `/meetings/\$id`) の search schema に `overdueOnly` を追加し、フィルタ行に Toggle を配置。
* Kanban view でも Toggle は表示し、status フィルタだけ非表示にする（列との情報重複なし）。
* hook と KanbanBoard の queryKey 両方に同じ filters を渡し、キャッシュ整合を保つ。
* テスト追加: queryParams 2 件 / OverdueOnlyToggle 単体 5 件 / tasks.index 統合 3 件。

## 動作確認手順
1. \`git checkout issue-194-overdue-only-toggle\`
2. \`make install\`（依存差分はないのでスキップ可）
3. \`make test\` で \`apps/api\` 187 件と \`apps/web\` 326 件がすべて GREEN になることを確認。
4. \`make dev\` で起動し \`/tasks\` を開く。
   - ヘッダ下のフィルタ行に「期限超過のみ」ボタンが出ること。
   - 期限超過＋未完了のタスクが入っている状態で OFF→ON すると、未完了かつ dueDate が今より過去のタスクだけが残ること。
   - 完了済み（done）/ 却下（rejected）のタスクは ON 時に消えること。
   - ON のとき URL に \`?overdueOnly=true\` が付き、再読み込みしても状態が保たれること。
5. \`/recurring-meetings/\$id\` と \`/meetings/\$id\` でも同様にトグルが動作することを確認。
6. List view で「期限超過のみ」と「ステータス=todo」を同時に押し、todo かつ期限超過のタスクだけ表示されることを確認。
7. Kanban view に切り替えてもトグルが残り、ON のときに各列が期限超過＋未完了タスクで構成されることを確認。

## スクリーンショット
<img width="1317" height="749" alt="image" src="https://github.com/user-attachments/assets/68c811bf-d6b4-49ff-81e1-1d773f6ea646" />