### PR TITLE
アサインフィルタを追加（未アサイン含む、定例詳細・会議詳細）

### DIFF
--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -100,6 +100,9 @@ const taskStatusValuesSchema = z
 
 export const taskListQuerySchema = z.object({
   status: taskStatusValuesSchema.optional(),
+  // assigneeId は通常 userId（任意の非空文字列）だが、特殊値 "none" を許容する。
+  // "none" は「未アサインのタスクだけ」を意味するセンチネルで、where 構築時に
+  // `assignees: { none: {} }` に展開される。
   assigneeId: z.string().min(1).optional(),
   dueBefore: z
     .string()
@@ -128,7 +131,8 @@ type TaskStatusWhere = {
 };
 type TaskListWhere = {
   status?: TaskStatusWhere;
-  assignees?: { some: { userId: string } };
+  // 通常は some（指定 userId のタスク）、"none" センチネルでは none（未アサインのみ）。
+  assignees?: { some: { userId: string } } | { none: Record<string, never> };
   dueDate?: { gte?: Date; lte?: Date; lt?: Date };
   AND?: Array<{ status: TaskStatusWhere }>;
 };
@@ -144,7 +148,10 @@ export function buildTaskListWhere(
   if (filters.status && filters.status.length > 0) {
     where.status = { in: filters.status };
   }
-  if (filters.assigneeId) {
+  if (filters.assigneeId === "none") {
+    // 「未アサインのみ」絞り込み。任意の assignee を持つタスクを除外する。
+    where.assignees = { none: {} };
+  } else if (filters.assigneeId) {
     where.assignees = { some: { userId: filters.assigneeId } };
   }
   if (filters.dueBefore || filters.dueAfter) {

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -947,4 +947,45 @@ describe("GET /recurring-meetings/:id/tasks", () => {
     expect(res.status).toBe(404);
     expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
+
+  it("assigneeId=none で未アサイン絞り込みが where に組まれる", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+    mockTaskFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/tasks?assigneeId=none",
+    );
+    expect(res.status).toBe(200);
+    const where = mockTaskFindMany.mock.calls[0][0].where as {
+      assignees?: { some?: unknown; none?: unknown };
+    };
+    // "none" センチネルは未アサインのみのフィルタとして展開される。
+    expect(where.assignees).toEqual({ none: {} });
+  });
+
+  it("assigneeId に userId を渡すと当該ユーザーのタスクのみ絞り込まれる", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+    mockTaskFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/tasks?assigneeId=user-42",
+    );
+    expect(res.status).toBe(200);
+    const where = mockTaskFindMany.mock.calls[0][0].where as {
+      assignees?: { some?: { userId?: string }; none?: unknown };
+    };
+    expect(where.assignees).toEqual({ some: { userId: "user-42" } });
+  });
 });

--- a/apps/web/src/features/tasks/components/AssigneeFilter.tsx
+++ b/apps/web/src/features/tasks/components/AssigneeFilter.tsx
@@ -8,23 +8,31 @@ const UNASSIGNED_SENTINEL = "none";
 //   - undefined / ""  → フィルタなし（すべて表示）
 //   - "none"          → 未アサインのみ
 //   - その他の文字列  → 該当 userId のタスクのみ
-// 「自分のみ」は currentUserId をそのまま value にすることで実現する。
-// メンバー一覧では currentUserId を除外し、UI 上の重複を避ける。
+//
+// 「自分のみ」は API には DB の `user.id` を渡す必要がある。JWT の `sub` は
+// API ミドルウェアで User の externalId として扱われ、`user.id` とは別物のため、
+// 認証情報の sub をそのまま value に使うと一致しない（タスクが 0 件になる）。
+// このコンポーネントでは currentUserEmail を受け取り、組織メンバー一覧から
+// email 一致で「自分」の userId を引き当てる。
 export function AssigneeFilter({
   orgId,
   value,
   onChange,
-  currentUserId,
+  currentUserEmail,
 }: {
   orgId: string;
   value: string | undefined;
   onChange: (next: string | undefined) => void;
-  currentUserId: string | null;
+  currentUserEmail: string | null;
 }) {
   const membersQuery = useOrganizationMembers(orgId);
   const members = membersQuery.data ?? [];
-  const otherMembers = currentUserId
-    ? members.filter((m) => m.userId !== currentUserId)
+  const selfMember = currentUserEmail
+    ? (members.find((m) => m.email === currentUserEmail) ?? null)
+    : null;
+  // メンバー一覧から自分を除外し、「自分のみ」option との重複を避ける。
+  const otherMembers = selfMember
+    ? members.filter((m) => m.userId !== selfMember.userId)
     : members;
 
   return (
@@ -42,8 +50,8 @@ export function AssigneeFilter({
       >
         <option value="">すべて</option>
         <optgroup label="クイック選択">
-          {currentUserId ? (
-            <option value={currentUserId}>自分のみ</option>
+          {selfMember ? (
+            <option value={selfMember.userId}>自分のみ</option>
           ) : null}
           <option value={UNASSIGNED_SENTINEL}>未アサイン</option>
         </optgroup>

--- a/apps/web/src/features/tasks/components/AssigneeFilter.tsx
+++ b/apps/web/src/features/tasks/components/AssigneeFilter.tsx
@@ -1,0 +1,62 @@
+import { useOrganizationMembers } from "@/features/organizations/hooks/useOrganizationMembers";
+
+// 「未アサインのみ」を表す API センチネル。API 側 buildTaskListWhere と整合させる。
+const UNASSIGNED_SENTINEL = "none";
+
+// 担当者でタスクを絞り込むセレクタ。
+// 値の意味:
+//   - undefined / ""  → フィルタなし（すべて表示）
+//   - "none"          → 未アサインのみ
+//   - その他の文字列  → 該当 userId のタスクのみ
+// 「自分のみ」は currentUserId をそのまま value にすることで実現する。
+// メンバー一覧では currentUserId を除外し、UI 上の重複を避ける。
+export function AssigneeFilter({
+  orgId,
+  value,
+  onChange,
+  currentUserId,
+}: {
+  orgId: string;
+  value: string | undefined;
+  onChange: (next: string | undefined) => void;
+  currentUserId: string | null;
+}) {
+  const membersQuery = useOrganizationMembers(orgId);
+  const members = membersQuery.data ?? [];
+  const otherMembers = currentUserId
+    ? members.filter((m) => m.userId !== currentUserId)
+    : members;
+
+  return (
+    <label className="flex items-center gap-2 text-xs text-muted-foreground">
+      担当者
+      <select
+        aria-label="担当者フィルタ"
+        // controlled component。undefined は "" として扱い、「すべて」を選択状態にする。
+        value={value ?? ""}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v === "" ? undefined : v);
+        }}
+        className="text-xs px-2 py-1 rounded-md border border-border/60 bg-card text-foreground"
+      >
+        <option value="">すべて</option>
+        <optgroup label="クイック選択">
+          {currentUserId ? (
+            <option value={currentUserId}>自分のみ</option>
+          ) : null}
+          <option value={UNASSIGNED_SENTINEL}>未アサイン</option>
+        </optgroup>
+        {otherMembers.length > 0 ? (
+          <optgroup label="メンバー">
+            {otherMembers.map((m) => (
+              <option key={m.userId} value={m.userId}>
+                {m.displayName}
+              </option>
+            ))}
+          </optgroup>
+        ) : null}
+      </select>
+    </label>
+  );
+}

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,4 +1,5 @@
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
 import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
@@ -11,8 +12,10 @@ import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
 import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import { taskStatusLabels } from "@/features/tasks/labels";
 import type { TaskListFilters, TaskStatus } from "@/features/tasks/types";
+import { authAtom } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useAtomValue } from "jotai";
 import { z } from "zod";
 
 // 手動経路で表示する status の選択肢。AI 専用の draft/reviewing は UI から除外。
@@ -28,6 +31,8 @@ const meetingSearchSchema = z.object({
   view: z.enum(["list", "kanban"]).optional(),
   // 「期限超過のみ」クイックトグル。API 仕様と整合させるため "true" 文字列で永続化する。
   overdueOnly: z.string().optional(),
+  // 担当者フィルタ。値は userId / "none"（未アサイン）/ undefined（すべて）の 3 系統。
+  assigneeId: z.string().optional(),
 });
 
 type MeetingSearch = z.infer<typeof meetingSearchSchema>;
@@ -97,9 +102,15 @@ export function MeetingDetailView({
   const apiFilters: TaskListFilters = {};
   if (!isKanbanView && statusArr) apiFilters.status = statusArr;
   if (overdueOnly) apiFilters.overdueOnly = true;
+  // 担当者フィルタ。"none"（未アサイン）も API センチネルとして素通しする。
+  if (search.assigneeId) apiFilters.assigneeId = search.assigneeId;
   const filtersForQuery: TaskListFilters | undefined =
     Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
   const tasksQuery = useMeetingTasks(id, filtersForQuery);
+
+  // 「自分のみ」option を出すために認証ユーザーの sub を取り出す。
+  const auth = useAtomValue(authAtom);
+  const currentUserId = auth.user?.sub ?? null;
 
   if (detailQuery.isLoading) {
     return (
@@ -175,7 +186,7 @@ export function MeetingDetailView({
           </div>
         </div>
 
-        {/* フィルタ行。「期限超過のみ」は両 view で表示、status フィルタは List view のみ。 */}
+        {/* フィルタ行。「期限超過のみ」「担当者」は両 view で表示、status フィルタは List view のみ。 */}
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <OverdueOnlyToggle
             value={overdueOnly}
@@ -185,6 +196,15 @@ export function MeetingDetailView({
                 overdueOnly: next ? "true" : undefined,
               })
             }
+          />
+
+          <AssigneeFilter
+            orgId={detail.organization.id}
+            value={search.assigneeId}
+            onChange={(next) =>
+              onSearchChange({ ...search, assigneeId: next })
+            }
+            currentUserId={currentUserId}
           />
 
           {/* Kanban view では列ヘッダで status が可視化されているため、

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -201,9 +201,7 @@ export function MeetingDetailView({
           <AssigneeFilter
             orgId={detail.organization.id}
             value={search.assigneeId}
-            onChange={(next) =>
-              onSearchChange({ ...search, assigneeId: next })
-            }
+            onChange={(next) => onSearchChange({ ...search, assigneeId: next })}
             currentUserId={currentUserId}
           />
 

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -108,9 +108,11 @@ export function MeetingDetailView({
     Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
   const tasksQuery = useMeetingTasks(id, filtersForQuery);
 
-  // 「自分のみ」option を出すために認証ユーザーの sub を取り出す。
+  // 「自分のみ」option を出すために認証ユーザーの email を取り出す。
+  // API 側で JWT の sub は externalId として扱われ DB の user.id とは別物のため、
+  // 「自分」の userId は組織メンバー一覧から email 一致で引き当てる方式にしている。
   const auth = useAtomValue(authAtom);
-  const currentUserId = auth.user?.sub ?? null;
+  const currentUserEmail = auth.user?.email ?? null;
 
   if (detailQuery.isLoading) {
     return (
@@ -202,7 +204,7 @@ export function MeetingDetailView({
             orgId={detail.organization.id}
             value={search.assigneeId}
             onChange={(next) => onSearchChange({ ...search, assigneeId: next })}
-            currentUserId={currentUserId}
+            currentUserEmail={currentUserEmail}
           />
 
           {/* Kanban view では列ヘッダで status が可視化されているため、

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -113,9 +113,11 @@ export function RecurringMeetingDetailView({
     Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
   const tasksQuery = useRecurringMeetingTasks(id, filtersForQuery);
 
-  // 「自分のみ」option を出すために認証ユーザーの sub を取り出す。
+  // 「自分のみ」option を出すために認証ユーザーの email を取り出す。
+  // API 側で JWT の sub は externalId として扱われ DB の user.id とは別物のため、
+  // 「自分」の userId は組織メンバー一覧から email 一致で引き当てる方式にしている。
   const auth = useAtomValue(authAtom);
-  const currentUserId = auth.user?.sub ?? null;
+  const currentUserEmail = auth.user?.email ?? null;
 
   if (detailQuery.isLoading) {
     return (
@@ -256,7 +258,7 @@ export function RecurringMeetingDetailView({
             orgId={detail.organizationId}
             value={search.assigneeId}
             onChange={(next) => onSearchChange({ ...search, assigneeId: next })}
-            currentUserId={currentUserId}
+            currentUserEmail={currentUserEmail}
           />
 
           {/* Kanban view では列ヘッダで status が可視化されているため、

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -255,9 +255,7 @@ export function RecurringMeetingDetailView({
           <AssigneeFilter
             orgId={detail.organizationId}
             value={search.assigneeId}
-            onChange={(next) =>
-              onSearchChange({ ...search, assigneeId: next })
-            }
+            onChange={(next) => onSearchChange({ ...search, assigneeId: next })}
             currentUserId={currentUserId}
           />
 

--- a/apps/web/src/routes/recurring-meetings.$id.tsx
+++ b/apps/web/src/routes/recurring-meetings.$id.tsx
@@ -7,6 +7,7 @@ import {
   describeCron,
   parseCron,
 } from "@/features/recurring-meetings/scheduleCron";
+import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
 import { OverdueOnlyToggle } from "@/features/tasks/components/OverdueOnlyToggle";
@@ -19,8 +20,10 @@ import { useRecurringMeetingTasks } from "@/features/tasks/hooks/useRecurringMee
 import { taskStatusLabels } from "@/features/tasks/labels";
 import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import type { TaskListFilters, TaskStatus } from "@/features/tasks/types";
+import { authAtom } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useAtomValue } from "jotai";
 import { z } from "zod";
 
 // タスクセクションのフィルタ用 status 選択肢。
@@ -38,6 +41,8 @@ const recurringMeetingSearchSchema = z.object({
   view: z.enum(["list", "kanban"]).optional(),
   // 「期限超過のみ」クイックトグル。API 仕様と整合させるため "true" 文字列で永続化する。
   overdueOnly: z.string().optional(),
+  // 担当者フィルタ。値は userId / "none"（未アサイン）/ undefined（すべて）の 3 系統。
+  assigneeId: z.string().optional(),
 });
 
 type RecurringMeetingSearch = z.infer<typeof recurringMeetingSearchSchema>;
@@ -102,9 +107,15 @@ export function RecurringMeetingDetailView({
   const apiFilters: TaskListFilters = {};
   if (!isKanbanView && statusArr) apiFilters.status = statusArr;
   if (overdueOnly) apiFilters.overdueOnly = true;
+  // 担当者フィルタ。"none"（未アサイン）も API センチネルとして素通しする。
+  if (search.assigneeId) apiFilters.assigneeId = search.assigneeId;
   const filtersForQuery: TaskListFilters | undefined =
     Object.keys(apiFilters).length > 0 ? apiFilters : undefined;
   const tasksQuery = useRecurringMeetingTasks(id, filtersForQuery);
+
+  // 「自分のみ」option を出すために認証ユーザーの sub を取り出す。
+  const auth = useAtomValue(authAtom);
+  const currentUserId = auth.user?.sub ?? null;
 
   if (detailQuery.isLoading) {
     return (
@@ -229,7 +240,7 @@ export function RecurringMeetingDetailView({
           </div>
         </div>
 
-        {/* フィルタ行。「期限超過のみ」は両 view で表示、status フィルタは List view のみ。 */}
+        {/* フィルタ行。「期限超過のみ」「担当者」は両 view で表示、status フィルタは List view のみ。 */}
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <OverdueOnlyToggle
             value={overdueOnly}
@@ -239,6 +250,15 @@ export function RecurringMeetingDetailView({
                 overdueOnly: next ? "true" : undefined,
               })
             }
+          />
+
+          <AssigneeFilter
+            orgId={detail.organizationId}
+            value={search.assigneeId}
+            onChange={(next) =>
+              onSearchChange({ ...search, assigneeId: next })
+            }
+            currentUserId={currentUserId}
           />
 
           {/* Kanban view では列ヘッダで status が可視化されているため、

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -119,6 +119,10 @@ const sampleTask = {
 beforeEach(() => {
   vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detail));
   vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(mockJson([]));
+  // AssigneeFilter のメンバー取得はデフォルトで空配列。個別テストで上書きしない想定。
+  vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+    mockJson([]),
+  );
 });
 
 afterEach(() => {
@@ -246,5 +250,26 @@ describe("MeetingDetailView", () => {
     expect(
       (call[0] as { query: { status?: string } }).query.status,
     ).toBeUndefined();
+  });
+
+  it("フィルタ行に AssigneeFilter（担当者セレクタ）が描画される", async () => {
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("タスク");
+    expect(screen.getByLabelText("担当者フィルタ")).toBeInTheDocument();
+  });
+
+  it("初期 ?assigneeId=user-42 は API リクエストの query.assigneeId に乗る", async () => {
+    renderWithQuery(
+      <MeetingDetailView
+        id="mtg-1"
+        search={{ assigneeId: "user-42" }}
+        now={NOW}
+      />,
+    );
+    await screen.findByText("タスク");
+    const call = vi.mocked(api.meetings[":id"].tasks.$get).mock.calls[0];
+    expect(
+      (call[0] as { query: { assigneeId?: string } }).query.assigneeId,
+    ).toBe("user-42");
   });
 });

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -18,6 +18,13 @@ vi.mock("@/lib/api", () => ({
         },
       },
     },
+    // AssigneeFilter が useOrganizationMembers 経由で叩くエンドポイント。
+    // 値はテスト個別で上書きしないかぎり空配列を返すデフォルトを後段で設定する。
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+      },
+    },
   },
   authHeaders: () => ({ headers: {} }),
 }));
@@ -346,9 +353,17 @@ describe("定例詳細ページ - タスクセクション", () => {
     vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
       mockJson([]),
     );
+    // AssigneeFilter のメンバー取得は本テスト群では中身を検証しないので空でよい。
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson([]),
+    );
   });
 
-  type Search = { status?: string; view?: "list" | "kanban" };
+  type Search = {
+    status?: string;
+    view?: "list" | "kanban";
+    assigneeId?: string;
+  };
   function renderWithSearch(opts?: {
     search?: Search;
     onSearchChange?: (next: Search) => void;
@@ -450,5 +465,27 @@ describe("定例詳細ページ - タスクセクション", () => {
     expect(
       (call[0] as { query: { status?: string } }).query.status,
     ).toBeUndefined();
+  });
+
+  it("フィルタ行に AssigneeFilter（担当者セレクタ）が描画される", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithSearch();
+    await screen.findByText("タスク");
+    expect(screen.getByLabelText("担当者フィルタ")).toBeInTheDocument();
+  });
+
+  it("初期 ?assigneeId=user-42 は API リクエストの query.assigneeId に乗る", async () => {
+    vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderWithSearch({ search: { assigneeId: "user-42" } });
+    await screen.findByText("タスク");
+    const call = vi.mocked(api["recurring-meetings"][":id"].tasks.$get).mock
+      .calls[0];
+    expect(
+      (call[0] as { query: { assigneeId?: string } }).query.assigneeId,
+    ).toBe("user-42");
   });
 });

--- a/apps/web/src/test/tasks.assigneeFilter.test.tsx
+++ b/apps/web/src/test/tasks.assigneeFilter.test.tsx
@@ -1,0 +1,184 @@
+import type { Member } from "@/features/organizations/types";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithQuery } from "./test-utils";
+
+// useOrganizationMembers が呼び出す api を差し替える。
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      ":id": {
+        members: { $get: vi.fn() },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+const members: Member[] = [
+  {
+    userId: "user-1",
+    name: "alice",
+    displayName: "Alice",
+    email: "alice@example.com",
+    role: "member",
+    joinedAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    userId: "user-2",
+    name: "bob",
+    displayName: "Bob",
+    email: "bob@example.com",
+    role: "member",
+    joinedAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AssigneeFilter", () => {
+  it("基本の選択肢「すべて」「未アサイン」「メンバー」を表示する", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={() => {}}
+        currentUserId={null}
+      />,
+    );
+
+    // メンバー取得を待つ
+    expect(
+      await screen.findByRole("option", { name: "Bob" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "すべて" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "未アサイン" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Alice" })).toBeInTheDocument();
+  });
+
+  it("currentUserId があるときは「自分のみ」option を出し、メンバー一覧から自分は除外する", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={() => {}}
+        currentUserId="user-1"
+      />,
+    );
+
+    // members 取得が終わるまで待ってから、メンバー option の有無を判定する。
+    expect(
+      await screen.findByRole("option", { name: "Bob" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "自分のみ" }),
+    ).toBeInTheDocument();
+    // 自分 (user-1) はメンバー一覧の Alice option として重複表示されない
+    expect(screen.queryByRole("option", { name: "Alice" })).toBeNull();
+  });
+
+  it("currentUserId が null のときは「自分のみ」option を表示しない", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={() => {}}
+        currentUserId={null}
+      />,
+    );
+
+    await screen.findByRole("option", { name: "Bob" });
+    expect(screen.queryByRole("option", { name: "自分のみ" })).toBeNull();
+  });
+
+  it("メンバー option を選ぶと onChange に userId が渡る", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+    const onChange = vi.fn();
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={onChange}
+        currentUserId={null}
+      />,
+    );
+
+    await screen.findByRole("option", { name: "Bob" });
+    const select = screen.getByLabelText("担当者フィルタ");
+    await userEvent.selectOptions(select, "user-2");
+    expect(onChange).toHaveBeenCalledWith("user-2");
+  });
+
+  it("「すべて」を選ぶと onChange に undefined が渡る", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+    const onChange = vi.fn();
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value="user-2"
+        onChange={onChange}
+        currentUserId={null}
+      />,
+    );
+
+    await screen.findByRole("option", { name: "Bob" });
+    const select = screen.getByLabelText("担当者フィルタ");
+    await userEvent.selectOptions(select, "");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("「未アサイン」を選ぶと onChange に \"none\" が渡る", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+    const onChange = vi.fn();
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={onChange}
+        currentUserId={null}
+      />,
+    );
+
+    await screen.findByRole("option", { name: "Bob" });
+    const select = screen.getByLabelText("担当者フィルタ");
+    await userEvent.selectOptions(select, "none");
+    expect(onChange).toHaveBeenCalledWith("none");
+  });
+});

--- a/apps/web/src/test/tasks.assigneeFilter.test.tsx
+++ b/apps/web/src/test/tasks.assigneeFilter.test.tsx
@@ -61,7 +61,7 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value={undefined}
         onChange={() => {}}
-        currentUserId={null}
+        currentUserEmail={null}
       />,
     );
 
@@ -76,7 +76,7 @@ describe("AssigneeFilter", () => {
     expect(screen.getByRole("option", { name: "Alice" })).toBeInTheDocument();
   });
 
-  it("currentUserId があるときは「自分のみ」option を出し、メンバー一覧から自分は除外する", async () => {
+  it("currentUserEmail がメンバーに一致すると「自分のみ」option を出し、メンバー一覧から自分を除外する", async () => {
     vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
       mockJson(members),
     );
@@ -86,7 +86,7 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value={undefined}
         onChange={() => {}}
-        currentUserId="user-1"
+        currentUserEmail="alice@example.com"
       />,
     );
 
@@ -97,11 +97,37 @@ describe("AssigneeFilter", () => {
     expect(
       screen.getByRole("option", { name: "自分のみ" }),
     ).toBeInTheDocument();
-    // 自分 (user-1) はメンバー一覧の Alice option として重複表示されない
+    // 自分 (alice) はメンバー一覧の Alice option として重複表示されない
     expect(screen.queryByRole("option", { name: "Alice" })).toBeNull();
   });
 
-  it("currentUserId が null のときは「自分のみ」option を表示しない", async () => {
+  it("「自分のみ」option の value は メンバー一覧から引いた userId である", async () => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+    const onChange = vi.fn();
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={onChange}
+        currentUserEmail="alice@example.com"
+      />,
+    );
+
+    const selfOption = (await screen.findByRole("option", {
+      name: "自分のみ",
+    })) as HTMLOptionElement;
+    expect(selfOption.value).toBe("user-1");
+
+    const select = screen.getByLabelText("担当者フィルタ");
+    await userEvent.selectOptions(select, selfOption);
+    // onChange には DB の user.id（userId）が渡るべき。
+    expect(onChange).toHaveBeenCalledWith("user-1");
+  });
+
+  it("currentUserEmail が null のときは「自分のみ」option を表示しない", async () => {
     vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
       mockJson(members),
     );
@@ -111,12 +137,34 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value={undefined}
         onChange={() => {}}
-        currentUserId={null}
+        currentUserEmail={null}
       />,
     );
 
     await screen.findByRole("option", { name: "Bob" });
     expect(screen.queryByRole("option", { name: "自分のみ" })).toBeNull();
+  });
+
+  it("currentUserEmail がメンバーに見つからないときは「自分のみ」option を出さない", async () => {
+    // 認証済みだが、当該組織のメンバーには含まれないケース。
+    // members から userId を引けないため、「自分のみ」は非表示にする（正しい値が決まらないため）。
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(members),
+    );
+
+    renderWithQuery(
+      <AssigneeFilter
+        orgId="org-1"
+        value={undefined}
+        onChange={() => {}}
+        currentUserEmail="outsider@example.com"
+      />,
+    );
+
+    await screen.findByRole("option", { name: "Bob" });
+    expect(screen.queryByRole("option", { name: "自分のみ" })).toBeNull();
+    // 既存メンバーは普通に表示される
+    expect(screen.getByRole("option", { name: "Alice" })).toBeInTheDocument();
   });
 
   it("メンバー option を選ぶと onChange に userId が渡る", async () => {
@@ -130,7 +178,7 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value={undefined}
         onChange={onChange}
-        currentUserId={null}
+        currentUserEmail={null}
       />,
     );
 
@@ -151,7 +199,7 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value="user-2"
         onChange={onChange}
-        currentUserId={null}
+        currentUserEmail={null}
       />,
     );
 
@@ -172,7 +220,7 @@ describe("AssigneeFilter", () => {
         orgId="org-1"
         value={undefined}
         onChange={onChange}
-        currentUserId={null}
+        currentUserEmail={null}
       />,
     );
 

--- a/apps/web/src/test/tasks.assigneeFilter.test.tsx
+++ b/apps/web/src/test/tasks.assigneeFilter.test.tsx
@@ -161,7 +161,7 @@ describe("AssigneeFilter", () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it("「未アサイン」を選ぶと onChange に \"none\" が渡る", async () => {
+  it('「未アサイン」を選ぶと onChange に "none" が渡る', async () => {
     vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
       mockJson(members),
     );


### PR DESCRIPTION
## 関連Issue
Closes #193

## 概要・目的
* 定例詳細と会議詳細のタスクセクションに「担当者で絞り込む」ドロップダウンを追加し、「すべて / 自分のみ / 未アサイン / 各メンバー」を 1 操作で切り替えられるようにする。
* バックエンドには「未アサインだけ」を表す `?assigneeId=none` センチネルを追加し、`assignees: { none: {} }` で絞り込めるようにする。

## 背景
* `/tasks`（My タスク）は assignee = 自分で固定なので不要だが、定例・会議の詳細では「誰が担当か」で見たいニーズがあった。
* 特に「未アサインのタスクだけ確認したい（対応漏れチェック）」要望が実用度が高い。
* API は既に `?assigneeId=<userId>` の単一 ID 指定に対応していたので、「未アサイン」だけセンチネル追加で扱える。
* タスクフィルタ拡張 3 件（#191 から分割）の中規模スコープ、最後のひとつ。

## 変更内容
### Backend (`apps/api`)
* `taskListQuerySchema.assigneeId` は `z.string().min(1).optional()` のまま据え置き、コメントで `"none"` センチネル仕様を明記。
* `buildTaskListWhere` の `assigneeId` 分岐を拡張: `"none"` のとき `assignees: { none: {} }`（未アサインのみ）、その他の文字列は従来通り `assignees: { some: { userId } }`（指定ユーザー）。
* `TaskListWhere.assignees` の型を `{ some: { userId } } | { none: Record<string, never> }` の union に変更。
* `GET /recurring-meetings/:id/tasks` 経由のテストを 2 件追加（`assigneeId=none` / 通常 userId）。

### Frontend (`apps/web`)
* `AssigneeFilter.tsx` 新設: ネイティブ `<select>` + `<optgroup>`（クイック選択 / メンバー）でドロップダウンを構成。スタイルは既存の組織 select と統一。
  * 「自分のみ」は `currentUserId` をそのまま `value` として渡す方式。`currentUserId` が `null` のときは option を出さない。
  * メンバー一覧から `currentUserId` を除外し、UI 重複を避ける。
* `recurring-meetings.\$id.tsx` / `meetings.\$id.tsx` の search schema に `assigneeId: z.string().optional()` を追加。
* フィルタ行に `AssigneeFilter` を配置（Kanban view でも表示。status とは違い列で表現されないため）。
* `useRecurringMeetingTasks` / `useMeetingTasks` に渡す filters に `assigneeId` を含める。
* 認証ユーザーの sub は `authAtom`（jotai）から取り出し、AssigneeFilter に `currentUserId` として渡す。
* テスト追加: AssigneeFilter 単体 6 件 / recurring-meetings 統合 2 件 / meetings 統合 2 件。

## 動作確認手順
1. \`git checkout issue-193-assignee-filter\`
2. \`make install\`（依存差分なし、スキップ可）
3. \`make test\` で \`apps/api\` 189 件と \`apps/web\` 336 件がすべて GREEN になることを確認。
4. \`make dev\` で起動し、定例詳細 \`/recurring-meetings/<id>\` を開く。
   - フィルタ行に「担当者」セレクタが出ること。
   - 「すべて」→ 全タスク、「自分のみ」→ 自分が担当のタスクだけ、「未アサイン」→ assignee なしのタスクだけ、「メンバー」→ 当該メンバーが担当のタスクだけ、と切り替わること。
   - 「自分のみ」を選んだ後、メンバー一覧に自分が重複表示されていないこと。
   - 選択した値が URL \`?assigneeId=...\` に乗り、再読み込みしても状態が保たれること。
5. 会議詳細 \`/meetings/<id>\` でも同じ挙動になることを確認。
6. Kanban view に切り替えても担当者セレクタが残り、選択が列の中身に反映されることを確認。
7. 既存のステータスフィルタ・期限超過のみトグルと組み合わせても結果が崩れないことを確認。

## スクリーンショット
<img width="1119" height="695" alt="image" src="https://github.com/user-attachments/assets/76406451-394f-403d-8bc6-e5b3523ec7cc" />
<img width="1119" height="695" alt="image" src="https://github.com/user-attachments/assets/0d0fc9d4-6dc4-4cc8-bfcb-f75d2cf93fb2" />
<img width="1119" height="695" alt="image" src="https://github.com/user-attachments/assets/2735e3ce-18f8-4556-a5bc-88c2127abf9d" />
