### PR TITLE
feat: 組織配下の次回会議を集約取得する API と hook を追加

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -39,6 +39,13 @@ const updateSchema = z
     message: "更新する項目を 1 つ以上指定してください",
   });
 
+// ダッシュボードの「次回会議」表示用に、組織配下の定例の会議のうち
+// heldAt が現在以降のものを最大 limit 件取得する。limit は無制限を許すと
+// 一覧 API と区別が付かなくなるため必須 + 1〜50 で制限する。
+const nextMeetingsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50),
+});
+
 // owner ロールの招待は不可（owner は組織作成者のみ）。
 // expiresInDays は 1〜365 日。email はサーバ側で trim + 小文字化して保存・比較する。
 const inviteSchema = z.object({
@@ -309,6 +316,45 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     });
     return c.json(meetings);
   })
+  .get(
+    "/:id/next-meetings",
+    zValidator("query", nextMeetingsQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const { limit } = c.req.valid("query");
+
+      const guard = await requireMembership(c, id);
+      if (!guard.ok) return guard.res;
+
+      // ダッシュボード「次回会議」セクションの N+1 解消のため、
+      // 組織配下の全定例を横断して heldAt 昇順で limit 件を 1 クエリで取得する。
+      // 単発会議（recurringMeetingId が null）は関係フィルタで自然に除外される。
+      const now = new Date();
+      const meetings = await prisma.meeting.findMany({
+        where: {
+          recurringMeeting: { organizationId: id },
+          heldAt: { gte: now },
+        },
+        orderBy: { heldAt: "asc" },
+        take: limit,
+        select: {
+          id: true,
+          title: true,
+          heldAt: true,
+          estimatedDurationMinutes: true,
+          recurringMeetingId: true,
+          recurringMeeting: { select: { name: true } },
+        },
+      });
+
+      // クライアント側で扱いやすいよう recurringMeeting.name を平坦化する。
+      const result = meetings.map(({ recurringMeeting, ...m }) => ({
+        ...m,
+        recurringMeetingName: recurringMeeting?.name ?? null,
+      }));
+      return c.json(result);
+    },
+  )
   .post(
     "/:id/meetings",
     zValidator("json", recurringMeetingCreateSchema),

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -25,6 +25,9 @@ vi.mock("../src/lib/prisma.js", () => ({
     task: {
       findMany: vi.fn(),
     },
+    meeting: {
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -83,6 +86,7 @@ const mockMembershipFindMany = vi.mocked(
 const mockMembershipDelete = vi.mocked(prisma.organizationMembership.delete);
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
 const mockTaskFindMany = vi.mocked(prisma.task.findMany);
+const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
 
 const sampleOrg = {
@@ -1280,5 +1284,175 @@ describe("GET /organizations/:id/tasks", () => {
         }),
       }),
     );
+  });
+});
+
+describe("GET /organizations/:id/next-meetings", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => resetAuthUser());
+
+  function membership(role: "owner" | "admin" | "member" = "member") {
+    return {
+      userId: "user-1",
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  // findMany が select 句で返す形（recurringMeeting がネスト）
+  const sampleMeetingRows = [
+    {
+      id: "mtg-near",
+      title: "週次定例 2026-05-20",
+      heldAt: new Date("2026-05-20T01:00:00Z"),
+      estimatedDurationMinutes: 60,
+      recurringMeetingId: "rmtg-1",
+      recurringMeeting: { name: "週次定例" },
+    },
+    {
+      id: "mtg-far",
+      title: "月次レビュー 2026-06-01",
+      heldAt: new Date("2026-06-01T00:00:00Z"),
+      estimatedDurationMinutes: 90,
+      recurringMeetingId: "rmtg-2",
+      recurringMeeting: { name: "月次レビュー" },
+    },
+  ];
+
+  it("組織メンバーは 200 で upcoming な会議を limit 件まで取得できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindMany.mockResolvedValue(sampleMeetingRows as never);
+
+    const res = await app.request("/organizations/org-1/next-meetings?limit=5");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      title: string;
+      heldAt: string;
+      estimatedDurationMinutes: number | null;
+      recurringMeetingId: string | null;
+      recurringMeetingName: string | null;
+    }>;
+    expect(body).toHaveLength(2);
+    expect(body[0]).toEqual({
+      id: "mtg-near",
+      title: "週次定例 2026-05-20",
+      heldAt: "2026-05-20T01:00:00.000Z",
+      estimatedDurationMinutes: 60,
+      recurringMeetingId: "rmtg-1",
+      recurringMeetingName: "週次定例",
+    });
+    // ネストされた recurringMeeting は平坦化され、レスポンスに残らないこと
+    expect(body[0]).not.toHaveProperty("recurringMeeting");
+  });
+
+  it("組織配下の定例の会議のみを heldAt 昇順・upcoming のみで take する", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindMany.mockResolvedValue([]);
+
+    await app.request("/organizations/org-1/next-meetings?limit=3");
+
+    expect(mockMeetingFindMany).toHaveBeenCalledTimes(1);
+    const args = mockMeetingFindMany.mock.calls[0][0] as {
+      where: {
+        recurringMeeting: { organizationId: string };
+        heldAt: { gte: Date };
+      };
+      orderBy: { heldAt: "asc" };
+      take: number;
+      select: Record<string, unknown>;
+    };
+    expect(args.where.recurringMeeting).toEqual({ organizationId: "org-1" });
+    expect(args.where.heldAt.gte).toBeInstanceOf(Date);
+    expect(args.orderBy).toEqual({ heldAt: "asc" });
+    expect(args.take).toBe(3);
+    // recurringMeeting.name を含めて select している
+    expect(args.select).toMatchObject({
+      id: true,
+      title: true,
+      heldAt: true,
+      estimatedDurationMinutes: true,
+      recurringMeetingId: true,
+      recurringMeeting: { select: { name: true } },
+    });
+  });
+
+  it("結果 0 件のときは空配列を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/organizations/org-1/next-meetings?limit=10",
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("非メンバーは 404 を返し findMany は呼ばれない", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/organizations/org-1/next-meetings?limit=5");
+    expect(res.status).toBe(404);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("limit 未指定は 400 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/organizations/org-1/next-meetings");
+    expect(res.status).toBe(400);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("limit=0 は 400 を返す（下限 1）", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/organizations/org-1/next-meetings?limit=0");
+    expect(res.status).toBe(400);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("limit=51 は 400 を返す（上限 50）", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request(
+      "/organizations/org-1/next-meetings?limit=51",
+    );
+    expect(res.status).toBe(400);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("limit が数値でない場合は 400 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request(
+      "/organizations/org-1/next-meetings?limit=abc",
+    );
+    expect(res.status).toBe(400);
+    expect(mockMeetingFindMany).not.toHaveBeenCalled();
+  });
+
+  it("recurringMeetingName が null のときも安全に直列化される", async () => {
+    // 防御的ケース: include の関係フィルタにより通常は発生しないが、
+    // recurringMeeting 側が null の場合に NPE を起こさないことを担保する。
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockMeetingFindMany.mockResolvedValue([
+      {
+        id: "mtg-x",
+        title: "edge",
+        heldAt: new Date("2026-05-20T01:00:00Z"),
+        estimatedDurationMinutes: null,
+        recurringMeetingId: null,
+        recurringMeeting: null,
+      },
+    ] as never);
+
+    const res = await app.request("/organizations/org-1/next-meetings?limit=1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      recurringMeetingName: string | null;
+    }>;
+    expect(body[0].recurringMeetingName).toBeNull();
   });
 });

--- a/apps/web/src/features/recurring-meetings/hooks/useOrganizationNextMeetings.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useOrganizationNextMeetings.ts
@@ -1,0 +1,39 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+// ダッシュボード「次回会議」セクション用の応答型。
+// GET /organizations/:id/next-meetings はサーバ側で recurringMeeting.name を
+// 平坦化し、recurringMeetingName としてフラットに返している。
+export type NextMeetingItem = {
+  id: string;
+  title: string;
+  heldAt: string;
+  estimatedDurationMinutes: number | null;
+  recurringMeetingId: string | null;
+  recurringMeetingName: string | null;
+};
+
+// 組織配下の upcoming な会議を limit 件まで 1 リクエストで取得する hook。
+// 旧実装の useQueries による N+1 を解消するために導入。
+// orgId が null の場合は API を呼ばずに無効化する。
+// limit を queryKey に含め、表示件数が変わった際に独立したキャッシュとして扱う。
+export function useOrganizationNextMeetings(
+  orgId: string | null,
+  limit: number,
+) {
+  return useQuery<NextMeetingItem[]>({
+    queryKey: ["organizations", orgId ?? "__none__", "next-meetings", limit],
+    queryFn: async () => {
+      if (!orgId) return [];
+      const res = await api.organizations[":id"]["next-meetings"].$get(
+        { param: { id: orgId }, query: { limit: String(limit) } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch next meetings: ${res.status}`);
+      }
+      return (await res.json()) as NextMeetingItem[];
+    },
+    enabled: orgId !== null,
+  });
+}

--- a/apps/web/src/test/useOrganizationNextMeetings.test.tsx
+++ b/apps/web/src/test/useOrganizationNextMeetings.test.tsx
@@ -1,0 +1,118 @@
+import { useOrganizationNextMeetings } from "@/features/recurring-meetings/hooks/useOrganizationNextMeetings";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// グローバル fetch をモックして API 呼び出しを切り離す。各テストでレスポンスを上書きする。
+function mockFetchOnce(init: ResponseInit, body: unknown = null) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(body === null ? null : JSON.stringify(body), init),
+  );
+}
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe("useOrganizationNextMeetings", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("orgId が null のときは API を呼ばず無効化される", async () => {
+    const client = makeClient();
+    const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useOrganizationNextMeetings(null, 5), {
+      wrapper: makeWrapper(client),
+    });
+
+    // enabled: false の状態は fetchStatus === "idle" + data === undefined で確認する。
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("orgId 指定時は limit クエリ付きで取得し、レスポンスを返す", async () => {
+    const payload = [
+      {
+        id: "mtg-1",
+        title: "週次定例 2026-05-20",
+        heldAt: "2026-05-20T01:00:00.000Z",
+        estimatedDurationMinutes: 60,
+        recurringMeetingId: "rmtg-1",
+        recurringMeetingName: "週次定例",
+      },
+    ];
+    mockFetchOnce({ status: 200 }, payload);
+
+    const client = makeClient();
+    const { result } = renderHook(
+      () => useOrganizationNextMeetings("org-1", 5),
+      { wrapper: makeWrapper(client) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(payload);
+    });
+
+    const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = (fetchSpy.mock.calls[0][0] as Request | string).toString();
+    expect(url).toContain("/organizations/org-1/next-meetings");
+    expect(url).toContain("limit=5");
+  });
+
+  it("limit が異なれば別キャッシュとして再フェッチされる", async () => {
+    mockFetchOnce({ status: 200 }, []);
+    mockFetchOnce({ status: 200 }, [{ id: "mtg-2" }]);
+
+    const client = makeClient();
+    const { result, rerender } = renderHook(
+      ({ limit }: { limit: number }) =>
+        useOrganizationNextMeetings("org-1", limit),
+      {
+        wrapper: makeWrapper(client),
+        initialProps: { limit: 3 },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    rerender({ limit: 5 });
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: "mtg-2" }]);
+    });
+
+    const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("非 2xx レスポンスのときは isError になる", async () => {
+    mockFetchOnce({ status: 500 }, { error: "boom" });
+
+    const client = makeClient();
+    const { result } = renderHook(
+      () => useOrganizationNextMeetings("org-1", 5),
+      { wrapper: makeWrapper(client) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #199

## 概要・目的
* ダッシュボードの「次回会議」セクションが組織内の定例数 N に対して `GET /recurring-meetings/:id/meetings` を N 回叩く N+1 構造になっていたため、組織配下の upcoming な会議を 1 リクエストで集約取得する専用 API と、それを呼び出す Web 側 hook を追加する。
* ダッシュボードの差し替えは本 PR では行わず、PR #197 のマージ後に別 PR で対応する。

## 背景
* PR #197（`feature/issue-172-dashboard-ui`、未マージ）の `NextMeetingsSection` が `useOrganizationMeetings` で取得した全定例に対して `useQueries` で N 個並列に会議一覧を叩く実装になっていた。
* 各レスポンスは過去会議を含む全会議を返すが、`partitionMeetings` 後に `upcoming[0]` だけしか参照されておらず、過去会議分の payload が無駄になっていた。
* 詳細は `docs/reviews/pr-197-dashboard-ui-20260518.md` の「3. N+1 リクエスト」「4. ローディング集約戦略の体感劣化」。
* 既存 `GET /recurring-meetings/:id/meetings` は定例詳細画面で使われているため温存し、ダッシュボード用途には専用エンドポイントを別に切る方針を採用した。

## 変更内容
* `apps/api/src/routes/organizations.ts` に `GET /:id/next-meetings?limit=N` を追加。
  * Prisma の関係フィルタ `where: { recurringMeeting: { organizationId }, heldAt: { gte: now } }` + `orderBy: { heldAt: 'asc' }` + `take: limit` でサーバ側集約。
  * `select` 句で必要フィールドのみに絞り、`recurringMeeting.name` を `recurringMeetingName` として平坦化して返す。
  * `limit` は Zod スキーマで必須かつ 1〜50 に制限し、無制限取得を防止。
  * 認可は既存 `requireMembership` に準拠（非メンバーは 404）。
* `apps/web/src/features/recurring-meetings/hooks/useOrganizationNextMeetings.ts` を新規追加。
  * `orgId === null` は `enabled: false` で API を呼ばない。
  * `limit` を queryKey に含め、表示件数変更で別キャッシュとして扱う。
* テスト追加（API 9 ケース / Web 4 ケース）。`where` の組成・`take` の値・`recurringMeetingName` の平坦化、`limit` バリデーションの境界値、Web hook の disabled 挙動とキャッシュ分離まで網羅。

## 動作確認手順
1. ブランチを checkout: `git checkout feature/issue-199-organization-next-meetings-api`
2. 依存をインストール: `make install`
3. 自動テストを実行: `make test`（api 198 件 / web 344 件すべて PASS、新規 13 ケース含む）
4. lint / typecheck: `make lint` / `pnpm turbo run typecheck`
5. Docker 起動: `make dev-build`（DB マイグレーションの追加はなく、Prisma Client 再生成も不要）
6. API を curl で確認（`<TOKEN>` は fake-auth から発行されたアクセストークン）:
   ```sh
   curl -s -H "Authorization: Bearer <TOKEN>" \
     'http://localhost:3001/organizations/<org-id>/next-meetings?limit=3' | jq .
   ```
   - 組織メンバーで `limit=3` → `heldAt` が現在以降の会議が昇順で最大 3 件、`recurringMeetingName` が含まれて返る。
   - `limit` 未指定 / `limit=0` / `limit=51` → 400 を返す。
   - 非メンバーの組織 ID → 404 を返す。

### 実機確認結果（make dev-fresh 環境）
ローカル Docker（`make dev-fresh`）で実 API を起動し、`POST /login`（fake-auth）で `id_token` を取得して curl で次の各ケースを確認しました。会議データは定例配下に過去 2 件・未来 3 件を POST で投入。

| ケース | 期待 | 結果 |
|---|---|---|
| `limit=5` (会議 0 件) | 200, `[]` | OK |
| `limit` 未指定 | 400 (Zod) | OK |
| `limit=0` | 400 (min) | OK |
| `limit=51` | 400 (max) | OK |
| `limit=abc` | 400 (型) | OK |
| Bearer なし | 401 | OK |
| 非メンバー組織 ID | 404 | OK |
| 過去会議の除外 | 過去 2 件除外 | OK |
| `heldAt` 昇順 | 05-25 → 06-01 → 07-01 | OK |
| `limit=2` の take | 2 件で打ち切り | OK |
| `limit=1` の take | 1 件で打ち切り | OK |
| `recurringMeetingName` 平坦化 | `"hoge"` フラット | OK |
| `estimatedDurationMinutes` | 60 / 90 が正しく返却 | OK |

サーバ側での「過去会議除外 + heldAt 昇順 + take」が PostgreSQL 上で意図どおり動くことを確認済み。

## スクリーンショット
* API のみの変更のため UI 変更なし。レスポンス例:
  ```json
  [
    {
      "id": "mtg-near",
      "title": "週次定例 2026-05-20",
      "heldAt": "2026-05-20T01:00:00.000Z",
      "estimatedDurationMinutes": 60,
      "recurringMeetingId": "rmtg-1",
      "recurringMeetingName": "週次定例"
    }
  ]
  ```

## 補足
* 動作確認中に既存実装の別問題（`POST /recurring-meetings/:id/meetings` が `estimatedDurationMinutes: null` を 400 で弾く、スキーマとハンドラの食い違い）を発見したため、本 PR の範囲外として #209 に切り出した。本 PR では対応しない。
