### PR TITLE
fix(api): リクエストスキーマと ?? フォールバックの齟齬を 3 エンドポイントで解消

### DIFF
--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -19,12 +19,15 @@ const idArraySchema = z
 
 // 共通の入力可能フィールド（POST/PATCH で共有）。
 // AI 由来 (sourceQuote / dueDateRaw / ambiguityFlags 等) や decisionItemId は受け付けない。
+// assigneeUserIds / recurringMeetingIds は省略・null のいずれも「未指定」として扱い、
+// ハンドラ側で `?? []` に丸めて空配列扱いにする。JSON では undefined を表現できない
+// ため、クライアントが「未指定」を null で送る慣習に合わせる。
 const taskInputBaseSchema = z.object({
   title: z.string().min(1, "title は必須です"),
   body: z.string().optional(),
   priority: taskPrioritySchema.optional(),
-  assigneeUserIds: idArraySchema.optional(),
-  recurringMeetingIds: idArraySchema.optional(),
+  assigneeUserIds: idArraySchema.nullable().optional(),
+  recurringMeetingIds: idArraySchema.nullable().optional(),
   originMeetingId: z.string().min(1).optional(),
   dueDate: z
     .string()

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -48,10 +48,13 @@ const nextMeetingsQuerySchema = z.object({
 
 // owner ロールの招待は不可（owner は組織作成者のみ）。
 // expiresInDays は 1〜365 日。email はサーバ側で trim + 小文字化して保存・比較する。
+// role / expiresInDays は省略・null のいずれも「未指定」として扱い、
+// ハンドラ側で role="member" / 7 日のデフォルトにフォールバックする。
+// JSON では undefined を表現できないため、クライアントが null で送る慣習に合わせる。
 const inviteSchema = z.object({
   email: z.string().trim().toLowerCase().email(),
-  role: z.enum(["admin", "member"]).optional(),
-  expiresInDays: z.number().int().positive().max(365).optional(),
+  role: z.enum(["admin", "member"]).nullable().optional(),
+  expiresInDays: z.number().int().positive().max(365).nullable().optional(),
 });
 
 // 認証ユーザーが対象組織に所属していることを確認する。

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -17,7 +17,10 @@ import {
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
 // 定例配下に紐付ける Meeting 作成リクエストの schema。
-// estimatedDurationMinutes 未指定なら定例の defaultDurationMinutes を採用する。
+// estimatedDurationMinutes は省略・null・数値の 3 形態を許容し、省略 / null は
+// 「未指定」として扱ってハンドラ側で defaultDurationMinutes へフォールバックする。
+// JSON では undefined を表現できないため、クライアントは「未指定」を null で送る
+// ことが多い。許容範囲を広げるだけで、不正値（範囲外・型違い）は従来どおり 400。
 // 範囲は RecurringMeeting.defaultDurationMinutes と同じ 1〜480 分。
 const createMeetingSchema = z.object({
   title: z.string().min(1, "title は必須です"),
@@ -29,6 +32,7 @@ const createMeetingSchema = z.object({
     .int()
     .min(1, "estimatedDurationMinutes は 1 分以上で指定してください")
     .max(480, "estimatedDurationMinutes は 480 分以下で指定してください")
+    .nullable()
     .optional(),
 });
 

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -817,6 +817,33 @@ describe("POST /organizations/:id/invite", () => {
     });
   });
 
+  it("role / expiresInDays に null を渡しても未指定と同じデフォルトが採用される", async () => {
+    // JSON では undefined を表現できず、クライアントが「未指定」を null で送る
+    // 慣習があるため、null をスキーマで弾かずに ?? フォールバックへ載せる。
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationCreate.mockResolvedValue(sampleInvitation);
+
+    const res = await app.request("/organizations/org-1/invite", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "bob@example.com",
+        role: null,
+        expiresInDays: null,
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockInvitationCreate).toHaveBeenCalledWith({
+      data: {
+        organizationId: "org-1",
+        email: "bob@example.com",
+        invitedBy: "user-1",
+        role: "member",
+        expiresAt: new Date("2026-05-13T00:00:00Z"),
+      },
+    });
+  });
+
   it("member は 403 を返す", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     const res = await app.request("/organizations/org-1/invite", {

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -789,6 +789,35 @@ describe("POST /recurring-meetings/:id/meetings", () => {
     });
   });
 
+  it("estimatedDurationMinutes: null は未指定とみなし defaultDurationMinutes を採用する", async () => {
+    // JSON では undefined を表現できないため、クライアントが「未指定」を null で
+    // 送るのは一般的な慣習。スキーマがそれを拒否せず、ハンドラ側の ?? フォールバックに
+    // 載せて defaultDurationMinutes (60) を採用することを検証する。
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+    mockMeetingCreate.mockResolvedValue(createdMeeting as never);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "週次定例 2026-05-20",
+        heldAt: "2026-05-20T01:00:00.000Z",
+        estimatedDurationMinutes: null,
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockMeetingCreate).toHaveBeenCalledWith({
+      data: {
+        title: "週次定例 2026-05-20",
+        heldAt: new Date("2026-05-20T01:00:00.000Z"),
+        estimatedDurationMinutes: 60,
+        recurringMeetingId: "rmtg-1",
+      },
+      select: expect.any(Object),
+    });
+  });
+
   it("title 欠落は 400 を返す", async () => {
     const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
       method: "POST",

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -138,6 +138,30 @@ describe("POST /tasks", () => {
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
+  it("assigneeUserIds / recurringMeetingIds に null を渡しても 201 を返す（空配列扱い）", async () => {
+    // JSON では undefined を表現できないため、クライアントが「未指定」を null で
+    // 送る慣習がある。スキーマで弾かず、ハンドラ側の `?? []` フォールバックに載せて
+    // 空配列として扱う。validate 関数は空配列で早期 true を返すため副作用は無い。
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue(sampleTask);
+
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: "org-1",
+        title: "資料作成",
+        assigneeUserIds: null,
+        recurringMeetingIds: null,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    // 空配列扱いになるため、中間テーブル整合の DB 問い合わせは行われない。
+    expect(mockMembershipFindMany).not.toHaveBeenCalled();
+    expect(mockRecurringFindMany).not.toHaveBeenCalled();
+  });
+
   it("assignees / recurringMeetings / originMeeting を含む 201", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
     // 担当候補が全員 org メンバーであることの検証


### PR DESCRIPTION
## 関連Issue
Closes #209

## 概要・目的
* リクエストスキーマが `.optional()` のみで `null` を弾く一方、ハンドラ側は `??` フォールバックで「未指定」として処理する構えになっており、両者が齟齬を起こしていた 3 箇所のエンドポイントを一括で修正する
* JSON では `undefined` を表現できず、クライアントが「未指定」を `null` で送る慣習にスキーマ側を合わせる

## 背景
* 起点は #209 の `POST /recurring-meetings/:id/meetings` の `estimatedDurationMinutes` で、`{ "estimatedDurationMinutes": null }` を送ると 400 が返る齟齬を PR #208 のローカル動作確認で発見した
* 本ブランチで修正範囲を見直したところ、同一パターン（スキーマが `.optional()` のみ × ハンドラ側で `??` フォールバック）が他に 2 箇所存在することが判明した
  * `POST /organizations/:id/invite` の `role` / `expiresInDays`
  * `POST /tasks` の `assigneeUserIds` / `recurringMeetingIds`
* いずれも修正パターンが完全に同一（`.nullable().optional()` を付与）で、別 Issue / 別 PR に切るオーバーヘッドの方が大きいため、#209 のスコープを拡大して本 PR に取り込んだ（Issue にもコメント済み）
* コミットはエンドポイント単位で 3 本に分割し、レビュー単位の独立性は維持する

## 変更内容
* `POST /recurring-meetings/:id/meetings`
  * `apps/api/src/routes/recurring-meetings.ts` の `createMeetingSchema.estimatedDurationMinutes` を `.nullable().optional()` に変更
  * `null` を渡しても 201 で作成され、`defaultDurationMinutes` が採用されるテストを追加
* `POST /organizations/:id/invite`
  * `apps/api/src/routes/organizations.ts` の `inviteSchema.role` / `inviteSchema.expiresInDays` を `.nullable().optional()` に変更
  * `null` を渡しても 201 で `role="member"` / 7 日後がデフォルト採用されるテストを追加
* `POST /tasks`
  * `apps/api/src/lib/schemas/task.ts` の `taskInputBaseSchema.assigneeUserIds` / `recurringMeetingIds` を `.nullable().optional()` に変更
  * `null` を渡しても 201 が返り、中間テーブル整合チェックが行われないテストを追加
  * `taskUpdateSchema` 側は「`undefined` = 変更なし / 空配列 = 全削除」を意図的に区別しているため変更しない
* いずれもハンドラ本体 (`??` フォールバック) は無変更
* 既存スキーマ `apps/api/src/lib/schemas/task.ts:60-63` が `.nullable().optional()` 形式を採用しているため、`.nullish()` ではなくこちらに合わせた

## 動作確認手順
1. `fix/issue-209-allow-null-estimated-duration-minutes` ブランチを checkout
2. `make install` で依存関係をインストール
3. `make test` を実行し、`apps/api` 配下の vitest が全 GREEN になることを確認（追加 3 テストを含む 201 件）
4. 追加した以下のケースが pass していることを確認
   * `recurring-meetings.test.ts`: 「`estimatedDurationMinutes: null` は未指定とみなし `defaultDurationMinutes` を採用する」
   * `organizations.test.ts`: 「`role` / `expiresInDays` に `null` を渡しても未指定と同じデフォルトが採用される」
   * `tasks.test.ts`: 「`assigneeUserIds` / `recurringMeetingIds` に `null` を渡しても 201 を返す（空配列扱い）」
5. 既存ケース（数値・列挙値・配列の正常系／省略／範囲外で 400）が引き続き想定どおり動くことを確認

## スクリーンショット
* `POST /recurring-meetings/:id/meetings` リクエスト例（`defaultDurationMinutes: 60` の定例に対して送信）
  ```json
  POST /recurring-meetings/rmtg-1/meetings
  {
    "title": "週次定例 2026-05-20",
    "heldAt": "2026-05-20T01:00:00.000Z",
    "estimatedDurationMinutes": null
  }
  ```
  レスポンス（201 Created、定例の `defaultDurationMinutes` を採用）
  ```json
  {
    "id": "mtg-new",
    "title": "週次定例 2026-05-20",
    "heldAt": "2026-05-20T01:00:00.000Z",
    "estimatedDurationMinutes": 60,
    "recurringMeetingId": "rmtg-1"
  }
  ```
* `POST /organizations/:id/invite` リクエスト例
  ```json
  POST /organizations/org-1/invite
  {
    "email": "bob@example.com",
    "role": null,
    "expiresInDays": null
  }
  ```
  レスポンス（201 Created、`role="member"` / 7 日後の `expiresAt` を採用）
* `POST /tasks` リクエスト例
  ```json
  POST /tasks
  {
    "organizationId": "org-1",
    "title": "資料作成",
    "assigneeUserIds": null,
    "recurringMeetingIds": null
  }
  ```
  レスポンス（201 Created、中間テーブル整合チェックなしで作成）

## 特に見てほしい箇所
* `taskUpdateSchema` 側（`apps/api/src/lib/schemas/task.ts:51-79`）は「`undefined` = 変更なし / 空配列 = 全削除」のセマンティクスを意図して区別しているため、本 PR では変更しない判断とした。この判断が妥当か
* `POST /tasks` のテストで `mockMembershipFindMany` / `mockRecurringFindMany` が呼ばれないことを検証している。これは validate 関数が空配列で早期 `true` を返す挙動に依存している（`apps/api/src/routes/tasks.ts:43, 56`）
* Issue #209 のスコープを後から拡大した経緯（Non-goals の解除）について、Issue 本文ではなくコメントで記録した。本文を書き換えると履歴が分かりにくくなるためコメント方式を選んだが、運用上問題ないか
