### PR TITLE
feat(api): グローバル onError と CORS ミドルウェアを追加

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { healthRoute } from "./routes/health.js";
 import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
@@ -6,6 +7,38 @@ import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
 import { tasksRoute } from "./routes/tasks.js";
 
 const app = new Hono();
+
+// CORS: 本番は web と api が別ホスト想定のため、ALLOWED_ORIGINS で許可オリジンを指定する。
+// 未設定時は暫定で全許可（dev / 初回デプロイ用）。本番環境では必ず設定すること。
+const allowedOriginsEnv = process.env.ALLOWED_ORIGINS;
+const allowedOrigins = allowedOriginsEnv
+  ? allowedOriginsEnv
+      .split(",")
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0)
+  : null;
+
+app.use(
+  "*",
+  cors({
+    origin: (origin) => {
+      if (!allowedOrigins) {
+        return "*";
+      }
+      return allowedOrigins.includes(origin) ? origin : null;
+    },
+    credentials: false,
+  }),
+);
+
+// 未捕捉例外を構造化レスポンスに変換する。内部実装に依存した文字列の露出を防ぐ。
+app.onError((err, c) => {
+  console.error("[app.onError] 未捕捉例外:", err);
+  return c.json({ error: "Internal Server Error" }, 500);
+});
+
+// 未定義パスを JSON 404 に統一する。
+app.notFound((c) => c.json({ error: "Not Found" }, 404));
 
 const routes = app
   .route("/health", healthRoute)

--- a/apps/api/test/app-middleware.test.ts
+++ b/apps/api/test/app-middleware.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// テスト用に毎回 app を組み直すため、import.meta.resolve のキャッシュを避けて動的 import する。
+// CORS と onError は app.ts 側のグローバル設定なので、env を差し替えてから import し直す。
+
+const ORIGINAL_ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
+
+afterEach(() => {
+  if (ORIGINAL_ALLOWED_ORIGINS === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = ORIGINAL_ALLOWED_ORIGINS;
+  }
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("app.notFound", () => {
+  it("未定義パスに対して 404 と JSON エラーを返す", async () => {
+    delete process.env.ALLOWED_ORIGINS;
+    vi.resetModules();
+    const { app } = await import("../src/app.js");
+    const res = await app.request("/undefined-path-xyz");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Not Found");
+  });
+});
+
+describe("app.onError", () => {
+  it("ハンドラ内の未捕捉例外を 500 と JSON エラーに変換する", async () => {
+    delete process.env.ALLOWED_ORIGINS;
+    vi.resetModules();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { app: baseApp } = await import("../src/app.js");
+    // 既存 app のミドルウェア (onError) を活かしたまま、強制的に throw するルートを追加して検証する
+    const testApp = new Hono();
+    testApp.onError(baseApp.errorHandler);
+    testApp.get("/_explode", () => {
+      throw new Error("boom");
+    });
+    const res = await testApp.request("/_explode");
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Internal Server Error");
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});
+
+describe("CORS ミドルウェア", () => {
+  it("ALLOWED_ORIGINS 未設定時は Access-Control-Allow-Origin に * を返す", async () => {
+    delete process.env.ALLOWED_ORIGINS;
+    vi.resetModules();
+    const { app } = await import("../src/app.js");
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://example.com",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    // hono/cors の preflight は 204 を返す
+    expect([200, 204]).toContain(res.status);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("ALLOWED_ORIGINS 設定時は許可オリジンのみ Access-Control-Allow-Origin に反映する", async () => {
+    process.env.ALLOWED_ORIGINS =
+      "https://app.example.com,https://staging.example.com";
+    vi.resetModules();
+    const { app } = await import("../src/app.js");
+    const allowed = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.example.com",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect(allowed.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.example.com",
+    );
+
+    const denied = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://malicious.example.com",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect(denied.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("GET レスポンスにも Access-Control-Allow-Origin が付く（実リクエスト）", async () => {
+    process.env.ALLOWED_ORIGINS = "https://app.example.com";
+    vi.resetModules();
+    const { app } = await import("../src/app.js");
+    const res = await app.request("/health", {
+      headers: { Origin: "https://app.example.com" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.example.com",
+    );
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #202

## 概要・目的
* 未捕捉例外を構造化された 500 レスポンスに統一し、内部実装の文字列露出を防ぐ
* 本番デプロイで web と api が別ホストになる構成に備えて、`hono/cors` を導入する

## 背景
* `apps/api/src/app.ts` には `app.onError` と CORS のいずれも設定されていなかった
* `auth.ts` の `throw e` や Prisma の `P2025` などで未捕捉例外が出ると Hono 既定の 500 がプレーン文字列で返り、内部実装が露出する
* 現状の web は Vite proxy で同一オリジン扱いだが、本番 (Azure Container Apps) で別ホストになるとブラウザでクロスオリジン拒否される
* レビュー: `docs/reviews/apps-codebase-review-20260518.md` 🔴 #2

## 変更内容
* `apps/api/src/app.ts`
  * `app.use("*", cors({ origin: ..., credentials: false }))` を追加
  * `ALLOWED_ORIGINS` (カンマ区切り) から許可オリジンを読み込み、含まれないオリジンには `Access-Control-Allow-Origin` を返さない
  * 未設定時は暫定で `*` を返す（本番環境では必ず設定する想定）
  * `app.onError` で `console.error` + `c.json({ error: "Internal Server Error" }, 500)` を返す
  * `app.notFound` で `c.json({ error: "Not Found" }, 404)` を返す
* `apps/api/test/app-middleware.test.ts`
  * notFound / onError / CORS preflight / CORS 実リクエストの 5 ケースを追加

## 動作確認手順
1. `make dev-build` でコンテナを起動する
2. `curl -i http://localhost:3001/undefined-path` を叩き、`404` + `{"error":"Not Found"}` を確認する
3. `curl -i -H "Origin: https://app.example.com" http://localhost:3001/health` を叩き、`Access-Control-Allow-Origin: *` がレスポンスに含まれることを確認する
4. `ALLOWED_ORIGINS=https://app.example.com` 環境で api を起動し、許可オリジンのみ `Access-Control-Allow-Origin` が返ることを確認する
5. `pnpm --filter api test` で全件 (206) GREEN を確認する

## スクリーンショット
* API ミドルウェアの追加のみで UI 変更なし