### PR TITLE
fix(api): auth ミドルウェアの prisma.user.upsert を差分更新に変更

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -45,19 +45,27 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
     );
   }
 
-  // 既存ユーザーは IdP 側で email / name が変更され得るためログイン都度同期する。
-  // displayName はユーザーがアプリ側で編集する想定のため update 対象から外す（プロフィール編集 API は別 Issue で対応）。
-  // 新規作成時のみ displayName を name で初期化する。
-  let user: User;
+  // まず findUnique で取得し、差分があるときのみ update / 不在なら create を発行する。
+  // upsert を毎リクエスト走らせると、同一ユーザーに対する並列リクエストで
+  // 不要な UPDATE 競合を生むため、書き込みは「変更があった時のみ」に絞る。
+  // displayName はユーザーがアプリ側で編集する想定のため update 対象から外す
+  // （プロフィール編集 API は別 Issue）。新規作成時のみ displayName を name で初期化する。
+  let user: User | null;
   try {
-    user = await prisma.user.upsert({
-      where: { externalId },
-      create: { externalId, email, name, displayName: name },
-      update: { email, name },
-    });
+    user = await prisma.user.findUnique({ where: { externalId } });
+    if (!user) {
+      user = await prisma.user.create({
+        data: { externalId, email, name, displayName: name },
+      });
+    } else if (user.email !== email || user.name !== name) {
+      user = await prisma.user.update({
+        where: { externalId },
+        data: { email, name },
+      });
+    }
   } catch (e) {
     // email は @unique のため、別ユーザーが既に同一メールを保有している場合は P2002 になる。
-    // 利用者向けには「メールが他アカウントで使用中」であることを 409 で返し、500 で握り潰さない。
+    // create / update いずれで起きても 409 で利用者向けに通知する。
     if (
       e instanceof Prisma.PrismaClientKnownRequestError &&
       e.code === "P2002"

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -9,7 +9,9 @@ vi.mock("jose", () => ({
 vi.mock("../src/lib/prisma.js", () => ({
   prisma: {
     user: {
-      upsert: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -26,7 +28,9 @@ import { prisma } from "../src/lib/prisma.js";
 import { auth } from "../src/middleware/auth.js";
 
 const mockJwtVerify = vi.mocked(jwtVerify);
-const mockUpsert = vi.mocked(prisma.user.upsert);
+const mockFindUnique = vi.mocked(prisma.user.findUnique);
+const mockCreate = vi.mocked(prisma.user.create);
+const mockUpdate = vi.mocked(prisma.user.update);
 
 const sampleUser = {
   id: "cuid-user-1",
@@ -59,7 +63,7 @@ describe("auth middleware", () => {
     const res = await app.request("/whoami");
     expect(res.status).toBe(401);
     expect(mockJwtVerify).not.toHaveBeenCalled();
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
   it("Bearer プレフィックスが無い場合は 401 を返す", async () => {
@@ -78,7 +82,7 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer invalid-token" },
     });
     expect(res.status).toBe(401);
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
   it("jwtVerify には issuer / audience が渡される", async () => {
@@ -86,7 +90,7 @@ describe("auth middleware", () => {
       payload: { sub: "ext-1", email: "alice@example.com", name: "alice" },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockResolvedValueOnce(sampleUser);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     await app.request("/whoami", {
       headers: { Authorization: "Bearer good-token" },
@@ -107,7 +111,7 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(401);
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
   it("payload.email が無い場合は 401 を返す", async () => {
@@ -120,7 +124,7 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(401);
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
   it("payload.name が無い場合は 401 を返す", async () => {
@@ -133,15 +137,15 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(401);
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
-  it("既存ユーザーがいる場合はそのユーザーを c.var.user にセットする", async () => {
+  it("既存ユーザーで email/name が一致する場合は update を発行しない", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: { sub: "ext-1", email: "alice@example.com", name: "alice" },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockResolvedValueOnce(sampleUser);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -149,14 +153,17 @@ describe("auth middleware", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { id: string; externalId: string };
     expect(body).toEqual({ id: "cuid-user-1", externalId: "ext-1" });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  it("未登録ユーザーは externalId/email/name/displayName=name で upsert.create される", async () => {
+  it("未登録ユーザーは externalId/email/name/displayName=name で create される", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: { sub: "ext-2", email: "bob@example.com", name: "bob" },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockResolvedValueOnce({
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({
       ...sampleUser,
       id: "cuid-user-2",
       externalId: "ext-2",
@@ -169,46 +176,65 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(200);
-    expect(mockUpsert).toHaveBeenCalledWith({
-      where: { externalId: "ext-2" },
-      create: {
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
         externalId: "ext-2",
         email: "bob@example.com",
         name: "bob",
         displayName: "bob",
       },
-      update: { email: "bob@example.com", name: "bob" },
     });
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it("既存ユーザーは IdP 側の email / name 変更を upsert.update で同期する", async () => {
+  it("既存ユーザーは IdP 側で email が変更された場合 update が発行される", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: {
         sub: "ext-1",
         email: "alice-renamed@example.com",
+        name: "alice",
+      },
+      protectedHeader: { alg: "RS256" },
+    } as never);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    mockUpdate.mockResolvedValueOnce({
+      ...sampleUser,
+      email: "alice-renamed@example.com",
+    });
+    const app = buildTestApp();
+    await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { externalId: "ext-1" },
+      data: { email: "alice-renamed@example.com", name: "alice" },
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("既存ユーザーは IdP 側で name が変更された場合 update が発行される", async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "ext-1",
+        email: "alice@example.com",
         name: "alice-renamed",
       },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockResolvedValueOnce({
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
-      email: "alice-renamed@example.com",
       name: "alice-renamed",
     });
     const app = buildTestApp();
     await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
     });
-    expect(mockUpsert).toHaveBeenCalledWith({
+    expect(mockUpdate).toHaveBeenCalledWith({
       where: { externalId: "ext-1" },
-      create: {
-        externalId: "ext-1",
-        email: "alice-renamed@example.com",
-        name: "alice-renamed",
-        displayName: "alice-renamed",
-      },
-      update: { email: "alice-renamed@example.com", name: "alice-renamed" },
+      data: { email: "alice@example.com", name: "alice-renamed" },
     });
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("payload.sub が文字列以外の場合は 401 を返す", async () => {
@@ -221,15 +247,16 @@ describe("auth middleware", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(401);
-    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
-  it("email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
+  it("create 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: { sub: "ext-3", email: "alice@example.com", name: "carol" },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockRejectedValueOnce(
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
         "Unique constraint failed on the fields: (`email`)",
         { code: "P2002", clientVersion: "test" },
@@ -244,19 +271,42 @@ describe("auth middleware", () => {
     expect(body.error).toContain("メールアドレス");
   });
 
+  it("update 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "ext-1",
+        email: "carol@example.com",
+        name: "alice",
+      },
+      protectedHeader: { alg: "RS256" },
+    } as never);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    mockUpdate.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed on the fields: (`email`)",
+        { code: "P2002", clientVersion: "test" },
+      ),
+    );
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(409);
+  });
+
   it("P2002 以外の Prisma 既知エラーは握り潰さず例外として伝播する", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: { sub: "ext-4", email: "dave@example.com", name: "dave" },
       protectedHeader: { alg: "RS256" },
     } as never);
-    mockUpsert.mockRejectedValueOnce(
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("connection lost", {
         code: "P1017",
         clientVersion: "test",
       }),
     );
     const app = buildTestApp();
-    // Hono は未捕捉例外を 500 で返す既定動作
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
     });


### PR DESCRIPTION
## 関連Issue
Closes #203

## 概要・目的
* 認証済みリクエスト毎に走っていた `prisma.user.upsert` の UPDATE 競合を解消するため、`findUnique` + 「差分があるときのみ update」方式に切り替える
* IdP 側の email / name 変更は引き続き同期する

## 背景
* `apps/api/src/middleware/auth.ts:48-57` で、認証済みリクエストごとに `prisma.user.upsert` を実行し、`email` と `name` を毎回 UPDATE していた
* タスク一覧や組織詳細など、`useQuery` が 3-4 並列に走る画面では、同一 `User` 行に対して同時に 3-4 回 UPDATE が発行され、書き込み競合を生んでいた
* コメントは「ログイン都度同期する」と書いていたが、実装は「リクエスト都度同期」になっており意図と乖離していた
* レビュー: `docs/reviews/apps-codebase-review-20260518.md` 🔴 #3

## 変更内容
* `apps/api/src/middleware/auth.ts`
  * `prisma.user.findUnique` で先に取得し、不在なら `create`、`email` または `name` が JWT クレームと異なる場合のみ `update` を発行するよう変更
  * `P2002` (email 重複) ハンドリングは `create` / `update` 両方に対応
  * コメントを実装と一致させた
* `apps/api/test/auth.test.ts`
  * モックを `upsert` から `findUnique` / `create` / `update` に書き換え
  * 「既存ユーザーで差分なし時に `update` が発行されない」検証を追加
  * 「email 変更時のみ update」「name 変更時のみ update」のケースを分離

## 動作確認手順
1. `make dev-build` でコンテナを起動する
2. fake-auth でログインし、ダッシュボードを開く
3. DB を直接観察し、初回ログイン後に何度遷移しても `User` 行の `updatedAt` が更新されないことを確認する
4. fake-auth 側で同一ユーザーの `name` を変更してログインし直すと、次のリクエストで `update` が走り、`name` が同期されることを確認する
5. `pnpm --filter api test` で全件 (203) GREEN を確認する

## スクリーンショット
* バックエンド変更のみで UI 変更なし