### PR TITLE
refactor(api): 組織所属ガードを middleware/authz.ts に集約

### DIFF
--- a/apps/api/src/middleware/authz.ts
+++ b/apps/api/src/middleware/authz.ts
@@ -8,9 +8,7 @@ import type { AuthVariables } from "./auth.js";
 // 単一の真実源として集約する。`organizations.ts` / `tasks.ts` /
 // `recurring-meetings.ts` で重複していた実装を本モジュールで一本化する。
 
-type Guard<T> =
-  | { ok: true; membership: T }
-  | { ok: false; res: Response };
+type Guard<T> = { ok: true; membership: T } | { ok: false; res: Response };
 
 // 認証ユーザーが対象組織に所属していることを確認する。
 // 所属していない場合は組織の存在自体を露出させないため 404 で統一する。

--- a/apps/api/src/middleware/authz.ts
+++ b/apps/api/src/middleware/authz.ts
@@ -1,4 +1,4 @@
-import type { OrganizationMembership, OrgRole } from "@prisma/client";
+import type { OrganizationMembership, OrgRole, User } from "@prisma/client";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
 import type { AuthVariables } from "./auth.js";
@@ -10,18 +10,27 @@ import type { AuthVariables } from "./auth.js";
 
 type Guard<T> = { ok: true; membership: T } | { ok: false; res: Response };
 
+// 認可判定のための最小単位: membership を引いて返すだけ。
+// 「404 を返すか」「メッセージを差し替えるか」など Response の構築は呼び出し側に委ねる
+// （recurring-meetings のように `定例が見つかりません` で統一したい場合に活用する）。
+export function findOrgMembership(
+  user: User,
+  organizationId: string,
+): Promise<OrganizationMembership | null> {
+  return prisma.organizationMembership.findUnique({
+    where: {
+      userId_organizationId: { userId: user.id, organizationId },
+    },
+  });
+}
+
 // 認証ユーザーが対象組織に所属していることを確認する。
 // 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
 export async function requireOrgMembership(
   c: Context<{ Variables: AuthVariables }>,
   organizationId: string,
 ): Promise<Guard<OrganizationMembership>> {
-  const user = c.var.user;
-  const membership = await prisma.organizationMembership.findUnique({
-    where: {
-      userId_organizationId: { userId: user.id, organizationId },
-    },
-  });
+  const membership = await findOrgMembership(c.var.user, organizationId);
   if (!membership) {
     return {
       ok: false,

--- a/apps/api/src/middleware/authz.ts
+++ b/apps/api/src/middleware/authz.ts
@@ -1,0 +1,53 @@
+import type { OrganizationMembership, OrgRole } from "@prisma/client";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import type { AuthVariables } from "./auth.js";
+
+// 認可ガード共通モジュール。
+// 「認証ユーザーが対象組織に所属しているか」「許可ロールに含まれるか」を
+// 単一の真実源として集約する。`organizations.ts` / `tasks.ts` /
+// `recurring-meetings.ts` で重複していた実装を本モジュールで一本化する。
+
+type Guard<T> =
+  | { ok: true; membership: T }
+  | { ok: false; res: Response };
+
+// 認証ユーザーが対象組織に所属していることを確認する。
+// 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
+export async function requireOrgMembership(
+  c: Context<{ Variables: AuthVariables }>,
+  organizationId: string,
+): Promise<Guard<OrganizationMembership>> {
+  const user = c.var.user;
+  const membership = await prisma.organizationMembership.findUnique({
+    where: {
+      userId_organizationId: { userId: user.id, organizationId },
+    },
+  });
+  if (!membership) {
+    return {
+      ok: false,
+      res: c.json({ error: "組織が見つかりません" }, 404),
+    };
+  }
+  return { ok: true, membership };
+}
+
+// 所属確認 + 許容ロールチェック。所属なし→404、ロール不足→403。
+// 403 のメッセージは呼び出し側が文脈に応じて与える。
+export async function requireOrgRole(
+  c: Context<{ Variables: AuthVariables }>,
+  organizationId: string,
+  allowed: OrgRole[],
+  forbiddenMessage: string,
+): Promise<Guard<OrganizationMembership>> {
+  const guard = await requireOrgMembership(c, organizationId);
+  if (!guard.ok) return guard;
+  if (!allowed.includes(guard.membership.role)) {
+    return {
+      ok: false,
+      res: c.json({ error: forbiddenMessage }, 403),
+    };
+  }
+  return guard;
+}

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -1,11 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
-import {
-  type OrganizationMembership,
-  type OrgRole,
-  Prisma,
-} from "@prisma/client";
+import { type OrgRole, Prisma } from "@prisma/client";
 import { Hono } from "hono";
-import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { recurringMeetingCreateSchema } from "../lib/schemas/recurring-meeting.js";
@@ -19,6 +14,10 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
+import {
+  requireOrgMembership,
+  requireOrgRole,
+} from "../middleware/authz.js";
 
 const createSchema = z.object({
   name: z.string().min(1),
@@ -57,52 +56,9 @@ const inviteSchema = z.object({
   expiresInDays: z.number().int().positive().max(365).nullable().optional(),
 });
 
-// 認証ユーザーが対象組織に所属していることを確認する。
-// 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
-// 詳細閲覧 (GET /:id) のように「所属していれば誰でも可」のケースで使う。
-async function requireMembership(
-  c: Context<{ Variables: AuthVariables }>,
-  organizationId: string,
-): Promise<
-  | { ok: true; membership: OrganizationMembership }
-  | { ok: false; res: Response }
-> {
-  const user = c.var.user;
-  const membership = await prisma.organizationMembership.findUnique({
-    where: {
-      userId_organizationId: { userId: user.id, organizationId },
-    },
-  });
-  if (!membership) {
-    return {
-      ok: false,
-      res: c.json({ error: "組織が見つかりません" }, 404),
-    };
-  }
-  return { ok: true, membership };
-}
-
-// 所属確認に加えて、許容ロールに含まれているかを判定する。
-// 所属していなければ 404、ロール不足なら 403。
-async function requireRole(
-  c: Context<{ Variables: AuthVariables }>,
-  organizationId: string,
-  allowed: OrgRole[],
-  forbiddenMessage: string,
-): Promise<
-  | { ok: true; membership: OrganizationMembership }
-  | { ok: false; res: Response }
-> {
-  const guard = await requireMembership(c, organizationId);
-  if (!guard.ok) return guard;
-  if (!allowed.includes(guard.membership.role)) {
-    return {
-      ok: false,
-      res: c.json({ error: forbiddenMessage }, 403),
-    };
-  }
-  return guard;
-}
+// 認可ガードは `middleware/authz.ts` に集約済み。
+// 旧 requireMembership / requireRole はそちらの requireOrgMembership /
+// requireOrgRole に統合した。
 
 export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
@@ -161,7 +117,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .get("/:id", async (c) => {
     const id = c.req.param("id");
 
-    const guard = await requireMembership(c, id);
+    const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
     // 自分の role はガードで確定済みのものを流用し、追加クエリを避ける。
@@ -182,7 +138,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .get("/:id/members", async (c) => {
     const id = c.req.param("id");
 
-    const guard = await requireMembership(c, id);
+    const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
     // OrgRole enum を DB 側で owner→admin→member 順に並べる手段がないため
@@ -217,7 +173,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const targetUserId = c.req.param("userId");
     const callerUserId = c.var.user.id;
 
-    const guard = await requireRole(
+    const guard = await requireOrgRole(
       c,
       id,
       ["owner"],
@@ -259,7 +215,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const id = c.req.param("id");
     const data = c.req.valid("json");
 
-    const guard = await requireRole(
+    const guard = await requireOrgRole(
       c,
       id,
       ["owner", "admin"],
@@ -276,7 +232,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .delete("/:id", async (c) => {
     const id = c.req.param("id");
 
-    const guard = await requireRole(c, id, ["owner"], "削除権限がありません");
+    const guard = await requireOrgRole(c, id, ["owner"], "削除権限がありません");
     if (!guard.ok) return guard.res;
 
     // schema 側で Membership / Invitation / RecurringMeeting / MeetingMember は
@@ -289,7 +245,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const id = c.req.param("id");
     const filters = c.req.valid("query");
 
-    const guard = await requireMembership(c, id);
+    const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
     // 組織配下の全タスクをフィルタしつつ返す。フィルタは buildTaskListWhere で
@@ -307,7 +263,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .get("/:id/meetings", async (c) => {
     const id = c.req.param("id");
 
-    const guard = await requireMembership(c, id);
+    const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
     // 一覧画面でメンバー数バッジを出せるよう _count.members を併せて取得する。
@@ -326,7 +282,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
       const id = c.req.param("id");
       const { limit } = c.req.valid("query");
 
-      const guard = await requireMembership(c, id);
+      const guard = await requireOrgMembership(c, id);
       if (!guard.ok) return guard.res;
 
       // ダッシュボード「次回会議」セクションの N+1 解消のため、
@@ -367,7 +323,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
       const { name, description, scheduleCron, defaultDurationMinutes } =
         c.req.valid("json");
 
-      const guard = await requireMembership(c, id);
+      const guard = await requireOrgMembership(c, id);
       if (!guard.ok) return guard.res;
 
       // RecurringMeeting 作成と作成者を MeetingMember.owner として登録する処理は
@@ -400,7 +356,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const user = c.var.user;
     const { email, role, expiresInDays } = c.req.valid("json");
 
-    const guard = await requireRole(
+    const guard = await requireOrgRole(
       c,
       id,
       ["owner", "admin"],

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -14,10 +14,7 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
-import {
-  requireOrgMembership,
-  requireOrgRole,
-} from "../middleware/authz.js";
+import { requireOrgMembership, requireOrgRole } from "../middleware/authz.js";
 
 const createSchema = z.object({
   name: z.string().min(1),
@@ -232,7 +229,12 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
   .delete("/:id", async (c) => {
     const id = c.req.param("id");
 
-    const guard = await requireOrgRole(c, id, ["owner"], "削除権限がありません");
+    const guard = await requireOrgRole(
+      c,
+      id,
+      ["owner"],
+      "削除権限がありません",
+    );
     if (!guard.ok) return guard.res;
 
     // schema 側で Membership / Invitation / RecurringMeeting / MeetingMember は

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -15,6 +15,7 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
 
 // 定例配下に紐付ける Meeting 作成リクエストの schema。
 // estimatedDurationMinutes は省略・null・数値の 3 形態を許容し、省略 / null は
@@ -36,9 +37,9 @@ const createMeetingSchema = z.object({
     .optional(),
 });
 
-// 認証ユーザーが定例の所属組織のメンバーであるかを確認する共通ガード。
-// 定例不存在・所属なしいずれも 404 で統一し、組織や定例の存在自体を
-// 露出させない（organizations.ts の requireMembership と同方針）。
+// 定例 + 所属組織のメンバーシップを確認する薄いラッパー。
+// 定例不存在・組織非所属いずれも 404 で統一し、定例・組織の存在自体を露出させない。
+// 認可判定は `middleware/authz.ts` の requireOrgMembership に委ねる。
 async function requireRecurringAccess<T extends RecurringMeeting>(
   c: Context<{ Variables: AuthVariables }>,
   meeting: T | null,
@@ -49,16 +50,9 @@ async function requireRecurringAccess<T extends RecurringMeeting>(
       res: c.json({ error: "定例が見つかりません" }, 404),
     };
   }
-  const user = c.var.user;
-  const membership = await prisma.organizationMembership.findUnique({
-    where: {
-      userId_organizationId: {
-        userId: user.id,
-        organizationId: meeting.organizationId,
-      },
-    },
-  });
-  if (!membership) {
+  const guard = await requireOrgMembership(c, meeting.organizationId);
+  if (!guard.ok) {
+    // 組織非所属の場合も「定例が見つかりません」で統一する
     return {
       ok: false,
       res: c.json({ error: "定例が見つかりません" }, 404),

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -15,7 +15,7 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
-import { requireOrgMembership } from "../middleware/authz.js";
+import { findOrgMembership } from "../middleware/authz.js";
 
 // 定例配下に紐付ける Meeting 作成リクエストの schema。
 // estimatedDurationMinutes は省略・null・数値の 3 形態を許容し、省略 / null は
@@ -39,7 +39,8 @@ const createMeetingSchema = z.object({
 
 // 定例 + 所属組織のメンバーシップを確認する薄いラッパー。
 // 定例不存在・組織非所属いずれも 404 で統一し、定例・組織の存在自体を露出させない。
-// 認可判定は `middleware/authz.ts` の requireOrgMembership に委ねる。
+// 組織判定の DB 問い合わせは `middleware/authz.ts` の findOrgMembership に委ね、
+// レスポンス文言だけ「定例が見つかりません」で揃える。
 async function requireRecurringAccess<T extends RecurringMeeting>(
   c: Context<{ Variables: AuthVariables }>,
   meeting: T | null,
@@ -50,9 +51,11 @@ async function requireRecurringAccess<T extends RecurringMeeting>(
       res: c.json({ error: "定例が見つかりません" }, 404),
     };
   }
-  const guard = await requireOrgMembership(c, meeting.organizationId);
-  if (!guard.ok) {
-    // 組織非所属の場合も「定例が見つかりません」で統一する
+  const membership = await findOrgMembership(
+    c.var.user,
+    meeting.organizationId,
+  );
+  if (!membership) {
     return {
       ok: false,
       res: c.json({ error: "定例が見つかりません" }, 404),

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -15,24 +15,7 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
-
-// 認証ユーザーが対象組織に所属しているか確認する。
-// 所属していない場合は組織の存在自体を露出させないため 404 で統一する。
-async function requireOrgMembership(
-  c: Context<{ Variables: AuthVariables }>,
-  organizationId: string,
-): Promise<{ ok: true } | { ok: false; res: Response }> {
-  const user = c.var.user;
-  const membership = await prisma.organizationMembership.findUnique({
-    where: {
-      userId_organizationId: { userId: user.id, organizationId },
-    },
-  });
-  if (!membership) {
-    return { ok: false, res: c.json({ error: "組織が見つかりません" }, 404) };
-  }
-  return { ok: true };
-}
+import { requireOrgMembership } from "../middleware/authz.js";
 
 // assigneeUserIds が全員 organizationId のメンバーであるかを検証する。
 // 一括 findMany → 件数比較で OK / NG を判定する。

--- a/apps/api/test/authz.test.ts
+++ b/apps/api/test/authz.test.ts
@@ -1,0 +1,151 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../src/lib/prisma.js";
+import {
+  requireOrgMembership,
+  requireOrgRole,
+} from "../src/middleware/authz.js";
+
+const mockFindUnique = vi.mocked(prisma.organizationMembership.findUnique);
+
+// テスト用のユーザーを c.var.user にセットしてくれる小さいラッパー
+function buildContextApp(handler: (c: import("hono").Context) => Promise<Response>) {
+  const app = new Hono();
+  app.get("/probe/:orgId", async (c) => {
+    c.set("user", {
+      id: "user-1",
+      externalId: "ext-1",
+      email: "alice@example.com",
+      name: "alice",
+      displayName: "alice",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return handler(c);
+  });
+  return app;
+}
+
+describe("requireOrgMembership", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("メンバーシップが存在すれば ok:true と membership を返す", async () => {
+    const sampleMembership = {
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member" as const,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+    mockFindUnique.mockResolvedValueOnce(sampleMembership);
+
+    const app = buildContextApp(async (c) => {
+      const guard = await requireOrgMembership(c, "org-1");
+      if (!guard.ok) return guard.res;
+      return c.json({ role: guard.membership.role });
+    });
+
+    const res = await app.request("/probe/org-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { role: string };
+    expect(body.role).toBe("member");
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: {
+        userId_organizationId: { userId: "user-1", organizationId: "org-1" },
+      },
+    });
+  });
+
+  it("メンバーシップが存在しなければ 404 を返す", async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+
+    const app = buildContextApp(async (c) => {
+      const guard = await requireOrgMembership(c, "org-1");
+      if (!guard.ok) return guard.res;
+      return c.json({ role: guard.membership.role });
+    });
+
+    const res = await app.request("/probe/org-1");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("組織が見つかりません");
+  });
+});
+
+describe("requireOrgRole", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("許可ロールに含まれていれば ok:true を返す", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "owner",
+      joinedAt: new Date(),
+    });
+
+    const app = buildContextApp(async (c) => {
+      const guard = await requireOrgRole(
+        c,
+        "org-1",
+        ["owner", "admin"],
+        "権限がありません",
+      );
+      if (!guard.ok) return guard.res;
+      return c.json({ role: guard.membership.role });
+    });
+
+    const res = await app.request("/probe/org-1");
+    expect(res.status).toBe(200);
+  });
+
+  it("メンバーシップが無い場合は 404 を返す（ロール判定より優先）", async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+
+    const app = buildContextApp(async (c) => {
+      const guard = await requireOrgRole(
+        c,
+        "org-1",
+        ["owner"],
+        "権限がありません",
+      );
+      if (!guard.ok) return guard.res;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/probe/org-1");
+    expect(res.status).toBe(404);
+  });
+
+  it("メンバーだがロール不足の場合は 403 と指定の forbiddenMessage を返す", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+
+    const app = buildContextApp(async (c) => {
+      const guard = await requireOrgRole(
+        c,
+        "org-1",
+        ["owner", "admin"],
+        "管理者のみ実行できます",
+      );
+      if (!guard.ok) return guard.res;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/probe/org-1");
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("管理者のみ実行できます");
+  });
+});

--- a/apps/api/test/authz.test.ts
+++ b/apps/api/test/authz.test.ts
@@ -18,7 +18,9 @@ import {
 const mockFindUnique = vi.mocked(prisma.organizationMembership.findUnique);
 
 // テスト用のユーザーを c.var.user にセットしてくれる小さいラッパー
-function buildContextApp(handler: (c: import("hono").Context) => Promise<Response>) {
+function buildContextApp(
+  handler: (c: import("hono").Context) => Promise<Response>,
+) {
   const app = new Hono();
   app.get("/probe/:orgId", async (c) => {
     c.set("user", {


### PR DESCRIPTION
## 関連Issue
Closes #204

## 概要・目的
* 3 ファイルに重複していた「組織所属ガード」を `middleware/authz.ts` に集約し、認可判定の真実源を一本化する
* レスポンス (404 / 403) は維持し、挙動の変更はない

## 背景
* 認可ガードが 3 ファイルに重複して実装されていた:
  * `apps/api/src/routes/organizations.ts:53-95` (`requireMembership` / `requireRole`)
  * `apps/api/src/routes/tasks.ts:21-35` (`requireOrgMembership`)
  * `apps/api/src/routes/recurring-meetings.ts:38-64` (`requireRecurringAccess`)
* いずれも `prisma.organizationMembership.findUnique({ where: { userId_organizationId } })` を呼び、未所属なら 404 / ロール不足なら 403 を返す同形ロジック
* レビュー: `docs/reviews/apps-codebase-review-20260518.md` 🟡 #4

## 変更内容
* `apps/api/src/middleware/authz.ts` を新設
  * `requireOrgMembership(c, orgId)` - 所属していなければ 404
  * `requireOrgRole(c, orgId, allowed, forbiddenMessage)` - 所属していなければ 404 / ロール不足なら 403
  * 戻り値型は `{ ok: true; membership } | { ok: false; res: Response }` で統一
* `apps/api/src/routes/organizations.ts`
  * ローカル `requireMembership` / `requireRole` を削除
  * 全箇所を新ヘルパーに置き換え (関数名のみリネーム、挙動は同等)
* `apps/api/src/routes/tasks.ts`
  * ローカル `requireOrgMembership` を削除し、新ヘルパーを利用
* `apps/api/src/routes/recurring-meetings.ts`
  * `requireRecurringAccess` を「定例を引いて `requireOrgMembership` を呼ぶ」薄いラッパーに作り直す（「定例が見つかりません」のメッセージ統一は維持）
* `apps/api/test/authz.test.ts` を追加（5 ケース）

## 動作確認手順
1. `make dev-build` でコンテナを起動する
2. ログイン後に自分が所属する組織配下のページ (`/organizations/:id`, `/tasks` など) を開き、従来どおり表示されることを確認する
3. 所属していない組織 ID で直接 URL を叩き、404 が返ることを確認する
4. `member` ロールで `PATCH /organizations/:id` を叩いて 403 が返ることを確認する
5. `pnpm --filter api test` で全件 (206) GREEN を確認する

## スクリーンショット
* 内部リファクタリングで UI 変更なし