### PR TITLE
refactor(api): serializeTask の any を Prisma.TaskGetPayload で型付けする

### DIFF
--- a/apps/api/src/lib/task-serialization.ts
+++ b/apps/api/src/lib/task-serialization.ts
@@ -40,6 +40,17 @@ export const taskListInclude = {
   organization: { select: { id: true, name: true } },
 } as const satisfies Prisma.TaskInclude;
 
+// `taskDetailInclude` / `taskListInclude` を Prisma の include 引数として使った場合に
+// 得られる Task のペイロード型。`serializeTask` の引数で `any` を使わずに済むようにし、
+// 中間テーブル (TaskAssignee / TaskRecurringMeeting) の構造を型レベルで保証する。
+// list 側は assignees.user に email を含めない差分のみで、構造は detail と同じ。
+export type TaskWithDetail = Prisma.TaskGetPayload<{
+  include: typeof taskDetailInclude;
+}>;
+export type TaskWithList = Prisma.TaskGetPayload<{
+  include: typeof taskListInclude;
+}>;
+
 // 一覧のデフォルト並び順。期限が近いタスク優先で、期限未設定 (NULL) は末尾、
 // 同期限内は最近更新されたものを上に出す。
 export const taskListOrderBy: Prisma.TaskOrderByWithRelationInput[] = [
@@ -48,15 +59,12 @@ export const taskListOrderBy: Prisma.TaskOrderByWithRelationInput[] = [
 ];
 
 // Prisma が返す中間テーブル経由の構造をフロント向けに平坦化する。
-// detail / list の両方で共通利用する。
-// biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
-export function serializeTask(task: any) {
+// detail / list の両方で共通利用するためユニオン型を受ける。
+export function serializeTask(task: TaskWithDetail | TaskWithList) {
   const { assignees, recurringMeetings, ...rest } = task;
   return {
     ...rest,
-    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
-    assignees: assignees.map((a: any) => a.user),
-    // biome-ignore lint/suspicious/noExplicitAny: 中間テーブルの行型
-    recurringMeetings: recurringMeetings.map((r: any) => r.recurringMeeting),
+    assignees: assignees.map((a) => a.user),
+    recurringMeetings: recurringMeetings.map((r) => r.recurringMeeting),
   };
 }

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -82,10 +82,7 @@ async function validateOriginMeetingInOrg(
 async function requireTaskAccess(
   c: Context<{ Variables: AuthVariables }>,
   taskId: string,
-): Promise<
-  | { ok: true; task: TaskWithDetail }
-  | { ok: false; res: Response }
-> {
+): Promise<{ ok: true; task: TaskWithDetail } | { ok: false; res: Response }> {
   const task = await prisma.task.findUnique({
     where: { id: taskId },
     include: taskDetailInclude,

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -13,6 +13,7 @@ import {
   taskDetailInclude,
   taskListInclude,
   taskListOrderBy,
+  type TaskWithDetail,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 
@@ -82,8 +83,8 @@ async function requireTaskAccess(
   c: Context<{ Variables: AuthVariables }>,
   taskId: string,
 ): Promise<
-  // biome-ignore lint/suspicious/noExplicitAny: include 結果の型が広いので any で受ける
-  { ok: true; task: any } | { ok: false; res: Response }
+  | { ok: true; task: TaskWithDetail }
+  | { ok: false; res: Response }
 > {
   const task = await prisma.task.findUnique({
     where: { id: taskId },
@@ -186,7 +187,8 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
           })),
         });
       }
-      return tx.task.findUnique({
+      // 直前に作成済みなので必ず存在する。型上も null を排除するため findUniqueOrThrow を使う。
+      return tx.task.findUniqueOrThrow({
         where: { id: task.id },
         include: taskDetailInclude,
       });
@@ -207,7 +209,7 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     const guard = await requireTaskAccess(c, id);
     if (!guard.ok) return guard.res;
 
-    const organizationId = guard.task.organizationId as string;
+    const organizationId = guard.task.organizationId;
 
     // assignees / recurringMeetings の置換が指定されたら、クロス組織を再検証する。
     // 作成時と同じ整合性ルール（同一組織内のみ許可）。
@@ -298,7 +300,8 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
           });
         }
       }
-      const task = await tx.task.findUnique({
+      // updateMany が count > 0 を返した直後なので必ず存在する。
+      const task = await tx.task.findUniqueOrThrow({
         where: { id },
         include: taskDetailInclude,
       });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -444,7 +444,7 @@ describe("PATCH /tasks/:id", () => {
       const tx = {
         task: {
           updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-          findUnique: vi
+          findUniqueOrThrow: vi
             .fn()
             .mockResolvedValue({ ...sampleTask, title: "更新後", version: 1 }),
         },
@@ -516,7 +516,7 @@ describe("PATCH /tasks/:id", () => {
       const tx = {
         task: {
           updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-          findUnique: vi.fn().mockResolvedValue({
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
             ...sampleTask,
             status: "in_progress",
             version: 1,
@@ -602,7 +602,7 @@ describe("PATCH /tasks/:id", () => {
       const tx = {
         task: {
           updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-          findUnique: vi.fn().mockResolvedValue(sampleTask),
+          findUniqueOrThrow: vi.fn().mockResolvedValue(sampleTask),
         },
         taskAssignee: {
           deleteMany: vi.fn(() => {


### PR DESCRIPTION
## 関連Issue
Closes #205

## 概要・目的
* `serializeTask` の `any` を排除し、Prisma の `GetPayload` から派生した正確な型を入出力に与える
* `tasks.ts` の `requireTaskAccess` 戻り値の `task` も同じ型に揃え、`as string` キャストを削除する

## 背景
* `apps/api/src/lib/task-serialization.ts:53,58,60` で `task: any` / `a: any` / `r: any` が使われ、`biome-ignore` も 3 箇所付いていた
* `apps/api/src/routes/tasks.ts:85-86` の `requireTaskAccess` 戻り値 `task` も `any` のままで、ハンドラ内で `guard.task.organizationId as string` のキャストが必要だった
* レビュー: `docs/reviews/apps-codebase-review-20260518.md` 🟡 #5

## 変更内容
* `apps/api/src/lib/task-serialization.ts`
  * `TaskWithDetail = Prisma.TaskGetPayload<{ include: typeof taskDetailInclude }>` と `TaskWithList = Prisma.TaskGetPayload<{ include: typeof taskListInclude }>` を新設
  * `serializeTask` の引数を `TaskWithDetail | TaskWithList` に変更し、`assignees.map((a) => ...)` / `recurringMeetings.map((r) => ...)` の中間テーブル要素型を Prisma に推論させる
  * `biome-ignore` コメントを削除
* `apps/api/src/routes/tasks.ts`
  * `requireTaskAccess` 戻り値の `task: any` を `TaskWithDetail` に置換
  * `guard.task.organizationId as string` を `guard.task.organizationId` に簡素化
  * `\$transaction` 内の `findUnique` を `findUniqueOrThrow` に変更（直前に作成 / 更新済みで null 不変）
* `apps/api/test/tasks.test.ts`
  * `tx.task` モックの `findUnique` を `findUniqueOrThrow` に追従

## 動作確認手順
1. `pnpm --filter api typecheck` で型エラーが出ないことを確認する
2. `pnpm --filter api test` で全件 (201) GREEN を確認する
3. `make dev-build` で起動し、タスク一覧・詳細・PATCH のレスポンス JSON 構造に変化がないことを確認する

## スクリーンショット
* 型のみのリファクタリングで挙動の変更なし