### PR TITLE
feat(api): 必須 env が prod 未設定なら fail-fast する requireEnv を導入

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,0 +1,17 @@
+// 必須 env が本番 (NODE_ENV=production) で未設定なら起動時に throw する fail-fast ヘルパー。
+// 開発 / テスト環境では devFallback を返し、ローカル起動の利便性を保つ。
+// 本番デプロイで env 漏れがあった場合、誤って fake-auth / ローカル DB に接続したまま
+// アプリが起動するのを防ぐ。
+
+export function requireEnv(key: string, devFallback: string): string {
+  const value = process.env[key];
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      `Required env "${key}" is not set. Set it before starting in production.`,
+    );
+  }
+  return devFallback;
+}

--- a/apps/api/src/lib/oidc.ts
+++ b/apps/api/src/lib/oidc.ts
@@ -1,15 +1,17 @@
 import { createRemoteJWKSet } from "jose";
+import { requireEnv } from "./env.js";
 
-// 既定値は services/fake-auth と整合する。本番（Entra ID）移行時は env で上書きする。
+// 開発 / テスト時のフォールバック値は services/fake-auth と整合する。
+// 本番（Entra ID）では env 必須。NODE_ENV=production で未設定なら起動時に throw する。
 const DEFAULT_ISSUER_URL = "http://localhost:3007";
 const DEFAULT_AUDIENCE = "fake-auth-client";
 
 export function getIssuerUrl(): string {
-  return process.env.OIDC_ISSUER_URL ?? DEFAULT_ISSUER_URL;
+  return requireEnv("OIDC_ISSUER_URL", DEFAULT_ISSUER_URL);
 }
 
 export function getAudience(): string {
-  return process.env.OIDC_AUDIENCE ?? DEFAULT_AUDIENCE;
+  return requireEnv("OIDC_AUDIENCE", DEFAULT_AUDIENCE);
 }
 
 export function getJwksUrl(): URL {

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -1,9 +1,13 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
+import { requireEnv } from "./env.js";
 
-const connectionString =
-  process.env.DATABASE_URL ??
-  "postgresql://postgres:postgres@localhost:5432/decision_loop";
+// 本番 (NODE_ENV=production) で DATABASE_URL が未設定だと起動時に throw する。
+// 開発 / テスト時は docker-compose の既定値にフォールバックする。
+const connectionString = requireEnv(
+  "DATABASE_URL",
+  "postgresql://postgres:postgres@localhost:5432/decision_loop",
+);
 
 const adapter = new PrismaPg({ connectionString });
 export const prisma = new PrismaClient({ adapter });

--- a/apps/api/test/env.test.ts
+++ b/apps/api/test/env.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { requireEnv } from "../src/lib/env.js";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_KEY = "MY_TEST_KEY";
+
+afterEach(() => {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  }
+  delete process.env[ORIGINAL_KEY];
+});
+
+describe("requireEnv", () => {
+  beforeEach(() => {
+    delete process.env[ORIGINAL_KEY];
+  });
+
+  it("env が設定されていれば その値を返す（NODE_ENV に依らない）", () => {
+    process.env.NODE_ENV = "production";
+    process.env[ORIGINAL_KEY] = "actual-value";
+    expect(requireEnv(ORIGINAL_KEY, "dev-fallback")).toBe("actual-value");
+  });
+
+  it("env が未設定で NODE_ENV=production の場合は throw する", () => {
+    process.env.NODE_ENV = "production";
+    expect(() => requireEnv(ORIGINAL_KEY, "dev-fallback")).toThrowError(
+      /MY_TEST_KEY/,
+    );
+  });
+
+  it("env が空文字で NODE_ENV=production の場合も throw する", () => {
+    process.env.NODE_ENV = "production";
+    process.env[ORIGINAL_KEY] = "";
+    expect(() => requireEnv(ORIGINAL_KEY, "dev-fallback")).toThrowError(
+      /MY_TEST_KEY/,
+    );
+  });
+
+  it("env が未設定で NODE_ENV=development の場合は devFallback を返す", () => {
+    process.env.NODE_ENV = "development";
+    expect(requireEnv(ORIGINAL_KEY, "dev-fallback")).toBe("dev-fallback");
+  });
+
+  it("env が未設定で NODE_ENV=test の場合も devFallback を返す（prod 分岐に入らない）", () => {
+    process.env.NODE_ENV = "test";
+    expect(requireEnv(ORIGINAL_KEY, "dev-fallback")).toBe("dev-fallback");
+  });
+
+  it("env が未設定で NODE_ENV が undefined の場合は devFallback を返す", () => {
+    delete process.env.NODE_ENV;
+    expect(requireEnv(ORIGINAL_KEY, "dev-fallback")).toBe("dev-fallback");
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #206

## 概要・目的
* 本番環境で必須 env (DATABASE_URL / OIDC_ISSUER_URL / OIDC_AUDIENCE) が抜けていた場合に起動時点で落として、誤接続を防ぐ
* 開発・テスト時は従来どおりフォールバック値で起動できる

## 背景
* `apps/api/src/lib/prisma.ts:4-6` は `DATABASE_URL` 未設定時に `postgresql://postgres:postgres@localhost:5432/decision_loop` へ黙ってフォールバックしていた
* `apps/api/src/lib/oidc.ts:4-13` は `OIDC_ISSUER_URL` / `OIDC_AUDIENCE` 未設定時に fake-auth のローカル既定値にフォールバックしていた
* 本番 (Azure Container Apps) で env 漏れがあると、ローカル DB に接続したり fake-auth issuer を信用する状態でアプリが起動してしまう
* web 側は `apps/web/src/lib/env.ts` の `readRequiredViteEnv` で「prod なら throw、dev なら fallback」のパターンを既に採用しており、API 側だけ揃っていなかった
* レビュー: `docs/reviews/apps-codebase-review-20260518.md` 🟡 #6

## 変更内容
* `apps/api/src/lib/env.ts` を新設
  * `requireEnv(key, devFallback)` を実装
  * 判定は `process.env.NODE_ENV === "production"` で行う
  * env が空文字列の場合も「未設定」として扱う
* `apps/api/src/lib/prisma.ts`
  * `DATABASE_URL` 読み出しを `requireEnv` 経由に切り替え
* `apps/api/src/lib/oidc.ts`
  * `getIssuerUrl` / `getAudience` を `requireEnv` 経由に切り替え
* `apps/api/test/env.test.ts`
  * 6 ケース: 値あり / prod 未設定 throw / prod 空文字 throw / dev fallback / test fallback / NODE_ENV undefined fallback

## 動作確認手順
1. `pnpm --filter api test` で全件 (207) GREEN を確認する
2. `make dev` で `DATABASE_URL` 未設定のまま起動できることを確認（dev フォールバック）
3. `NODE_ENV=production` かつ `DATABASE_URL` 未設定で `node dist/index.js` を実行し、起動時に `Required env "DATABASE_URL" is not set` エラーで落ちることを確認する
4. CI (NODE_ENV=test) で既存挙動が変わらないことを確認する

## スクリーンショット
* バックエンドの内部変更のみで UI 変更なし