### PR TITLE
feat(web): 組織の説明欄を Textarea にする

### DIFF
--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,10 +1,7 @@
 import { cn } from "@/lib/utils";
 import type * as React from "react";
 
-function Textarea({
-  className,
-  ...props
-}: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+import type * as React from "react";
+
+function Textarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
+++ b/apps/web/src/features/organizations/components/CreateOrganizationDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { api, authHeaders } from "@/lib/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -130,9 +131,10 @@ export function CreateOrganizationDialog({
           </div>
           <div className="flex flex-col gap-2">
             <Label htmlFor={descriptionId}>説明</Label>
-            <Input
+            <Textarea
               id={descriptionId}
               placeholder="組織の説明（任意）"
+              rows={3}
               {...register("description")}
             />
           </div>

--- a/apps/web/src/features/organizations/components/EditOrganizationDialog.tsx
+++ b/apps/web/src/features/organizations/components/EditOrganizationDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { useUpdateOrganization } from "@/features/organizations/hooks/useUpdateOrganization";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useId, useState } from "react";
@@ -94,7 +95,11 @@ export function EditOrganizationDialog({
           </div>
           <div className="flex flex-col gap-2">
             <Label htmlFor={descriptionId}>説明</Label>
-            <Input id={descriptionId} {...register("description")} />
+            <Textarea
+              id={descriptionId}
+              rows={3}
+              {...register("description")}
+            />
           </div>
           {mutation.isError && (
             <p className="text-destructive text-sm">更新に失敗しました</p>

--- a/apps/web/src/test/organizations.editOrganizationDialog.test.tsx
+++ b/apps/web/src/test/organizations.editOrganizationDialog.test.tsx
@@ -114,6 +114,19 @@ describe("組織詳細ページ - 組織情報編集ダイアログ", () => {
     );
   });
 
+  it("説明欄は複数行入力ができる textarea で描画される", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await user.click(
+      await screen.findByRole("button", { name: "組織情報を編集" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "組織情報を編集",
+    });
+    const descriptionInput = within(dialog).getByLabelText("説明");
+    expect(descriptionInput.tagName).toBe("TEXTAREA");
+  });
+
   it("編集ダイアログを開くと現在の name/description がプレフィルされる", async () => {
     const user = userEvent.setup();
     renderDetail();

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -173,6 +173,18 @@ describe("組織作成モーダル", () => {
     ).toBeInTheDocument();
   });
 
+  it("説明欄は複数行入力ができる textarea で描画される", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<OrganizationsPage />);
+
+    await user.click(screen.getByRole("button", { name: "組織を作成" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新しい組織を作成",
+    });
+    const descriptionInput = within(dialog).getByLabelText("説明");
+    expect(descriptionInput.tagName).toBe("TEXTAREA");
+  });
+
   it("name が空のとき送信できずバリデーションエラーが出る", async () => {
     const user = userEvent.setup();
     renderWithQuery(<OrganizationsPage />);


### PR DESCRIPTION
## 関連Issue
Closes #133

## 概要・目的
* 組織の `description` 入力を単行 `Input` から複数行入力可能な `Textarea` に変更し、長文の説明を自然に入力できるようにする。

## 背景
* PR #132 のレビュー §3.3 にて、`description` が `<Input type=\"text\">` のため複数行入力できず、長文が横スクロールで切れる UX 問題が指摘されていた。
* PR #145 で組織作成ダイアログが `CreateOrganizationDialog` に切り出されたため、対象は作成・編集の 2 箇所。

## 変更内容
* 新規: `apps/web/src/components/ui/textarea.tsx` を追加（shadcn/ui 標準の Textarea コンポーネント）
* `CreateOrganizationDialog.tsx` の `description` 入力を `Textarea`（rows=3）に変更
* `EditOrganizationDialog.tsx` の `description` 入力を `Textarea`（rows=3）に変更
* テスト追加: 作成・編集ダイアログともに「説明欄が textarea として描画される」アサーションを追加

## 動作確認手順
1. \`make dev\` でローカル環境を起動
2. \`/organizations\` を開き、「組織を作成」ボタンを押す
3. 「説明」欄が複数行入力できる Textarea（rows=3）で表示されることを確認
4. 改行を含む説明を入力 → 作成し、API に正しく送信されることを確認
5. 既存組織を開き、「組織情報を編集」 → 「説明」欄が Textarea で表示され、長文の編集ができることを確認

## スクリーンショット
* （差分は input → textarea のタグ変更のみで視覚差は軽微。実機確認推奨）

## チェックリスト
- [x] 全テスト GREEN（342 件）
- [x] lint / typecheck パス
- [x] a11y: Label / htmlFor 連携を維持
- [x] 既存テストの `getByLabelText(\"説明\")` 互換性維持