### PR TITLE
ci: schema.dbml のドリフトを検知する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
       - name: Prisma クライアント生成
         run: pnpm --filter api exec prisma generate
 
+      - name: schema.dbml のドリフト検知
+        # schema.prisma を変更したのに prisma-dbml-generator の出力をコミットし忘れた
+        # PR を検知する。差分があれば非ゼロ終了して CI を失敗させる。
+        run: |
+          if ! git diff --exit-code apps/api/prisma/dbml/schema.dbml; then
+            echo "::error::apps/api/prisma/dbml/schema.dbml がコミットされた内容と一致しません。"
+            echo "::error::ローカルで 'pnpm --filter api exec prisma generate' を実行し、生成された schema.dbml をコミットしてください。"
+            exit 1
+          fi
+
       - name: Lint (Biome)
         run: pnpm turbo run lint
 
@@ -113,6 +123,16 @@ jobs:
 
       - name: Prisma クライアント生成
         run: pnpm --filter api exec prisma generate
+
+      - name: schema.dbml のドリフト検知
+        # lint-typecheck-ts でも同じ検査を行うが、片方のジョブだけがリトライ実行
+        # されたケースでも漏れなく検知できるよう、test-ts 側でも二重に担保する。
+        run: |
+          if ! git diff --exit-code apps/api/prisma/dbml/schema.dbml; then
+            echo "::error::apps/api/prisma/dbml/schema.dbml がコミットされた内容と一致しません。"
+            echo "::error::ローカルで 'pnpm --filter api exec prisma generate' を実行し、生成された schema.dbml をコミットしてください。"
+            exit 1
+          fi
 
       - name: テスト (Vitest)
         run: pnpm turbo run test


### PR DESCRIPTION
## 関連Issue
Closes #148

## 概要・目的
* schema.prisma を変更したのに `pnpm --filter api exec prisma generate` を忘れて schema.dbml がドリフトしている PR を、CI で機械的に検知して fail させる。

## 背景
* PR #147 で `prisma-dbml-generator` を導入し、生成物 `apps/api/prisma/dbml/schema.dbml` をコミットする運用にした。
* しかし現状の CI では `prisma generate` 後に `schema.dbml` の差分検査をしておらず、生成忘れの PR が通過しうる。
* 結果として、運用ルール（手で再生成 → コミット）への依存が残ったままだった。

## 変更内容
* `.github/workflows/ci.yml` に以下を追加:
  * `lint-typecheck-ts` ジョブの `prisma generate` 直後に schema.dbml の diff 検査ステップ
  * `test-ts` ジョブにも同じ検査を追加（片方のジョブが個別に再実行されても漏れなく検知するため）
* 失敗時のエラーメッセージで `pnpm --filter api exec prisma generate` の実行とコミットを促す。

## 動作確認手順
1. ローカルで `apps/api/prisma/dbml/schema.dbml` に意図的な変更を加え、`git diff --exit-code apps/api/prisma/dbml/schema.dbml` が非ゼロ終了することを確認
2. `git checkout apps/api/prisma/dbml/schema.dbml` で戻し、`pnpm --filter api exec prisma generate` 実行後に同コマンドがゼロ終了することを確認
3. 本 PR の CI 自体は schema.dbml がコミット済みのため通過する想定（GREEN になることを確認）
4. 動作確認用に schema.prisma を改変した別 PR を作成して fail を確認できると望ましい（フォローアップ）

## スクリーンショット
* CI 設定変更のため不要。失敗時のエラーメッセージ例:
  > apps/api/prisma/dbml/schema.dbml がコミットされた内容と一致しません。
  > ローカルで 'pnpm --filter api exec prisma generate' を実行し、生成された schema.dbml をコミットしてください。

## チェックリスト
- [x] ローカルでドリフト検知ロジックが期待通り動作することを確認
- [x] 既存ジョブの実行順序・並列性は変更なし
- [x] lint 通過