### PR TITLE
feat(api): auth ミドルウェアで User.email を正規化する

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -35,7 +35,8 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
 
   // 自動作成に必要な claim が揃っていることを保証する
   const externalId = typeof payload.sub === "string" ? payload.sub : undefined;
-  const rawEmail = typeof payload.email === "string" ? payload.email : undefined;
+  const rawEmail =
+    typeof payload.email === "string" ? payload.email : undefined;
   const name = typeof payload.name === "string" ? payload.name : undefined;
 
   if (!externalId || !rawEmail || !name) {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -35,15 +35,20 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
 
   // 自動作成に必要な claim が揃っていることを保証する
   const externalId = typeof payload.sub === "string" ? payload.sub : undefined;
-  const email = typeof payload.email === "string" ? payload.email : undefined;
+  const rawEmail = typeof payload.email === "string" ? payload.email : undefined;
   const name = typeof payload.name === "string" ? payload.name : undefined;
 
-  if (!externalId || !email || !name) {
+  if (!externalId || !rawEmail || !name) {
     return c.json(
       { error: "トークンに必要な claim (sub/email/name) が含まれていません" },
       401,
     );
   }
+
+  // IdP が返す email は大文字や前後空白を含み得るため、保存前に正規化する。
+  // 招待 (`OrganizationInvitation.email`) も小文字化済みで保存しているため、
+  // 比較経路全体で正規化を一貫させる必要がある。
+  const email = rawEmail.trim().toLowerCase();
 
   // まず findUnique で取得し、差分があるときのみ update / 不在なら create を発行する。
   // upsert を毎リクエスト走らせると、同一ユーザーに対する並列リクエストで

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -428,10 +428,8 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     // （expired への自動遷移はバッチジョブ前提）。
     // 外側の existing チェックは高速パスとして残し、並列 /join による
     // membership 主キー (userId, organizationId) 重複は P2002 を捕捉して 409 にする。
-    // 招待は invite 側で email を trim + 小文字化して保存しているため、
-    // 認証ユーザーの email も同様に正規化してから照合する（IdP が大文字を
-    // 含む email を返してもマッチさせるため）。
-    const normalizedEmail = user.email.trim().toLowerCase();
+    // 招待 (invite 側) と user.email (auth ミドルウェア側) の双方が保存前に
+    // trim + 小文字化されている前提で raw 比較する。
     let result: {
       userId: string;
       organizationId: string;
@@ -442,7 +440,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
         const invitation = await tx.organizationInvitation.findFirst({
           where: {
             organizationId: id,
-            email: normalizedEmail,
+            email: user.email,
             status: "pending",
             expiresAt: { gt: new Date() },
           },

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -237,6 +237,82 @@ describe("auth middleware", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
+  it("新規ユーザー作成時 email は trim + 小文字化された値で保存される", async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "ext-5",
+        email: "  Bob@Example.COM  ",
+        name: "bob",
+      },
+      protectedHeader: { alg: "RS256" },
+    } as never);
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({
+      ...sampleUser,
+      id: "cuid-user-5",
+      externalId: "ext-5",
+      email: "bob@example.com",
+      name: "bob",
+      displayName: "bob",
+    });
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        externalId: "ext-5",
+        email: "bob@example.com",
+        name: "bob",
+        displayName: "bob",
+      },
+    });
+  });
+
+  it("既存ユーザーは payload email の大文字小文字差では update されない（正規化後一致）", async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "ext-1",
+        email: "Alice@Example.COM",
+        name: "alice",
+      },
+      protectedHeader: { alg: "RS256" },
+    } as never);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("既存ユーザーの IdP 側 email 変更時は正規化済みの値で update される", async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "ext-1",
+        email: "  Alice-Renamed@Example.COM  ",
+        name: "alice",
+      },
+      protectedHeader: { alg: "RS256" },
+    } as never);
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    mockUpdate.mockResolvedValueOnce({
+      ...sampleUser,
+      email: "alice-renamed@example.com",
+    });
+    const app = buildTestApp();
+    await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { externalId: "ext-1" },
+      data: { email: "alice-renamed@example.com", name: "alice" },
+    });
+  });
+
   it("payload.sub が文字列以外の場合は 401 を返す", async () => {
     mockJwtVerify.mockResolvedValueOnce({
       payload: { sub: 123, email: "alice@example.com", name: "alice" },

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -1186,48 +1186,9 @@ describe("POST /organizations/:id/join", () => {
     expect(res.status).toBe(500);
   });
 
-  it("認証ユーザーの email に大文字や前後空白が含まれていても招待を一致させる", async () => {
-    // IdP が "  Alice@Example.COM  " のように非正規化された email を返した場合でも、
-    // 招待保存時と同じく trim + 小文字化してから照合する必要がある（さもないと
-    // 招待を出したのに /join が永久に 404 になる）。
-    authState.current = {
-      ...authState.current,
-      email: "  Alice@Example.COM  ",
-    };
-    mockMembershipFindUnique.mockResolvedValue(null);
-
-    let observedEmail: string | undefined;
-    mockTransaction.mockImplementation(async (fn) => {
-      const tx = {
-        organizationInvitation: {
-          findFirst: vi.fn(async (args: { where: { email: string } }) => {
-            observedEmail = args.where.email;
-            return pendingInvitation;
-          }),
-          update: vi.fn().mockResolvedValue({
-            ...pendingInvitation,
-            status: "accepted",
-          }),
-        },
-        organizationMembership: {
-          create: vi.fn().mockResolvedValue({
-            userId: "user-1",
-            organizationId: "org-1",
-            role: "member",
-            joinedAt: new Date("2026-05-06T00:00:00Z"),
-          }),
-        },
-      };
-      // biome-ignore lint/suspicious/noExplicitAny: テスト用のミニマルな tx スタブ
-      return await (fn as (t: any) => Promise<unknown>)(tx);
-    });
-
-    const res = await app.request("/organizations/org-1/join", {
-      method: "POST",
-    });
-    expect(res.status).toBe(200);
-    expect(observedEmail).toBe("alice@example.com");
-  });
+  // 注: 「user.email が非正規化な場合でも /join で正規化する」テストは
+  // auth ミドルウェア側に正規化責務が移った (#103) ため削除した。
+  // 非正規化 email の正規化は test/auth.test.ts でカバー済み。
 });
 
 describe("GET /organizations/:id/tasks", () => {


### PR DESCRIPTION
## 関連Issue
Closes #103

## 概要・目的
* IdP が返す email を auth ミドルウェアで `trim + toLowerCase` してから保存・比較に使うようにし、招待 (invite 側は既に正規化済み) と一貫させる。
* PR #95 で入れた `/organizations/:id/join` 内の手作業正規化は不要になるため撤去する。

## 背景
* PR #95 のレビューで、IdP が大文字混じり email を返した場合に `/join` で招待 (= 小文字化済み) と `user.email` (= 未正規化) が照合できないバグが発覚し、ハンドラ側で都度 `trim().toLowerCase()` する暫定対応を入れていた。
* `user.email` を直接比較する他経路でも同じ問題が起こるため、保存時点で正規化しておくのが恒久対応。

## 変更内容
* `apps/api/src/middleware/auth.ts`:
  * JWT payload の email を `rawEmail` として受け取り、保存前に `email = rawEmail.trim().toLowerCase()` で正規化
  * 以降の `prisma.user.create / update / 比較` ではすべて正規化済み `email` を使用
* `apps/api/src/routes/organizations.ts`:
  * `/join` 内の `const normalizedEmail = user.email.trim().toLowerCase()` を撤去し、`user.email` を直接使用
* `apps/api/test/auth.test.ts`:
  * 大文字＋前後空白付き email でも DB には小文字保存される (create 経路)
  * 既存ユーザーに大文字差分が来ても update されない (正規化後一致)
  * IdP 側で email 変更時、正規化済みの値で update される
* `apps/api/test/organizations.test.ts`:
  * 暫定対応時代の「user.email が非正規化な場合でも /join で正規化する」テストは責務が auth に移ったため削除

## 動作確認手順
1. `make dev` で local 環境を起動
2. fake-auth で大文字混じり email (例: `Alice@Example.COM`) のユーザーとしてログイン
3. PostgreSQL の users テーブルを確認: `email` カラムが `alice@example.com` で保存されていること
4. 別ユーザーから当該 email 宛 (大文字小文字いずれの記法でも) の組織招待を発行
5. ログイン中のユーザーが `POST /organizations/:id/join` で 200 になること
6. `pnpm vitest run` (apps/api): 214 件全テスト GREEN

## 既存データへの影響
* 既存大文字 email ユーザーは再ログイン時に正規化済み値で `update` される (自然移行)
* PostgreSQL の `String @unique` は case-sensitive のため、`A@example.com` と `a@example.com` が既に共存している場合、正規化時に P2002 が発生して再ログインが失敗する。本リポジトリのハッカソン段階 DB ではこのケースが発生しない前提で進める (本番運用時に必要なら別 Issue で一括正規化マイグレーションを切る)。

## チェックリスト
- [x] 全テスト GREEN (api 214 件)
- [x] lint / typecheck パス (本 PR の差分由来のエラー 0)
- [x] PR #95 由来の暫定対応を撤去