### PR TITLE
feat: 自分宛招待一覧 API と /invitations 受諾画面を追加

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { healthRoute } from "./routes/health.js";
+import { meRoute } from "./routes/me.js";
 import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
 import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
@@ -42,6 +43,7 @@ app.notFound((c) => c.json({ error: "Not Found" }, 404));
 
 const routes = app
   .route("/health", healthRoute)
+  .route("/me", meRoute)
   .route("/meetings", meetingsRoute)
   .route("/organizations", organizationsRoute)
   .route("/recurring-meetings", recurringMeetingsRoute)

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,0 +1,39 @@
+import { Hono } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+
+// 認証ユーザー個人のリソース（招待・通知・プロフィール等）を集約するルート。
+// 招待は自分宛 (= user.email と一致) の pending かつ非期限切れのもののみ返す。
+// 期限切れの自動 status 遷移はバッチジョブ前提のため、ここでは status=pending の
+// うち expiresAt > now でフィルタする（DB 側の status は変えない）。
+export const meRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .get("/invitations", async (c) => {
+    const user = c.var.user;
+    const invitations = await prisma.organizationInvitation.findMany({
+      where: {
+        email: user.email,
+        status: "pending",
+        expiresAt: { gt: new Date() },
+      },
+      orderBy: { createdAt: "desc" },
+      include: {
+        organization: { select: { id: true, name: true } },
+        inviter: {
+          select: { id: true, name: true, displayName: true, email: true },
+        },
+      },
+    });
+
+    // クライアント向けに必要なフィールドのみ平坦化して返す。
+    // organization は { id, name } のみ、inviter は表示用最小セットに絞る。
+    const result = invitations.map((inv) => ({
+      id: inv.id,
+      role: inv.role,
+      expiresAt: inv.expiresAt,
+      createdAt: inv.createdAt,
+      organization: inv.organization,
+      inviter: inv.inviter,
+    }));
+    return c.json(result);
+  });

--- a/apps/api/test/me.test.ts
+++ b/apps/api/test/me.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma を全モックしてルートロジックのみ検証する。
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationInvitation: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+// auth ミドルウェアを差し替え、認証済みユーザーを c.var.user に注入する。
+// テストごとに email を上書きできるよう mutable な hoisted state を介す。
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return {
+    defaultUser,
+    current: { ...defaultUser },
+  };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+const mockInvitationFindMany = vi.mocked(prisma.organizationInvitation.findMany);
+
+function buildInvitation(
+  overrides: Partial<{
+    id: string;
+    organizationId: string;
+    email: string;
+    invitedBy: string;
+    role: "admin" | "member";
+    expiresAt: Date;
+    status: "pending" | "accepted" | "expired";
+    createdAt: Date;
+    organization: { id: string; name: string };
+    inviter: { id: string; name: string; displayName: string; email: string };
+  }> = {},
+) {
+  return {
+    id: "inv-1",
+    organizationId: "org-1",
+    email: "alice@example.com",
+    invitedBy: "user-2",
+    role: "member" as const,
+    expiresAt: new Date("2099-01-01T00:00:00Z"),
+    status: "pending" as const,
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    organization: { id: "org-1", name: "ACME 株式会社" },
+    inviter: {
+      id: "user-2",
+      name: "bob",
+      displayName: "Bob",
+      email: "bob@example.com",
+    },
+    ...overrides,
+  };
+}
+
+describe("GET /me/invitations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.current = { ...authState.defaultUser };
+  });
+
+  it("認証ユーザーの email に一致する pending 非期限切れの招待を返す", async () => {
+    const inv = buildInvitation();
+    mockInvitationFindMany.mockResolvedValue([inv] as never);
+
+    const res = await app.request("/me/invitations");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      organization: { id: string; name: string };
+      role: string;
+      inviter: { name: string; email: string };
+      expiresAt: string;
+    }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("inv-1");
+    expect(body[0].organization).toEqual({ id: "org-1", name: "ACME 株式会社" });
+    expect(body[0].role).toBe("member");
+    expect(body[0].inviter.name).toBe("bob");
+    expect(body[0].inviter.email).toBe("bob@example.com");
+  });
+
+  it("認証ユーザーの email・pending・期限内で findMany が呼ばれる", async () => {
+    mockInvitationFindMany.mockResolvedValue([] as never);
+
+    await app.request("/me/invitations");
+    expect(mockInvitationFindMany).toHaveBeenCalledTimes(1);
+    const callArg = mockInvitationFindMany.mock.calls[0]?.[0];
+    expect(callArg?.where).toMatchObject({
+      email: "alice@example.com",
+      status: "pending",
+    });
+    // 期限切れ除外: expiresAt > 現在時刻
+    expect(callArg?.where?.expiresAt).toBeDefined();
+    expect(callArg?.where?.expiresAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("該当する招待が無い場合は空配列を返す", async () => {
+    mockInvitationFindMany.mockResolvedValue([] as never);
+
+    const res = await app.request("/me/invitations");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("organization と inviter を include して返す", async () => {
+    mockInvitationFindMany.mockResolvedValue([] as never);
+
+    await app.request("/me/invitations");
+    const callArg = mockInvitationFindMany.mock.calls[0]?.[0];
+    expect(callArg?.include).toBeDefined();
+    expect(callArg?.include?.organization).toBeTruthy();
+    expect(callArg?.include?.inviter).toBeTruthy();
+  });
+
+  it("複数件は createdAt 降順で返す（新しい招待を上に）", async () => {
+    mockInvitationFindMany.mockResolvedValue([] as never);
+
+    await app.request("/me/invitations");
+    const callArg = mockInvitationFindMany.mock.calls[0]?.[0];
+    expect(callArg?.orderBy).toEqual({ createdAt: "desc" });
+  });
+});

--- a/apps/api/test/me.test.ts
+++ b/apps/api/test/me.test.ts
@@ -40,7 +40,9 @@ vi.mock("../src/middleware/auth.js", () => ({
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
 
-const mockInvitationFindMany = vi.mocked(prisma.organizationInvitation.findMany);
+const mockInvitationFindMany = vi.mocked(
+  prisma.organizationInvitation.findMany,
+);
 
 function buildInvitation(
   overrides: Partial<{
@@ -97,7 +99,10 @@ describe("GET /me/invitations", () => {
     }>;
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe("inv-1");
-    expect(body[0].organization).toEqual({ id: "org-1", name: "ACME 株式会社" });
+    expect(body[0].organization).toEqual({
+      id: "org-1",
+      name: "ACME 株式会社",
+    });
     expect(body[0].role).toBe("member");
     expect(body[0].inviter.name).toBe("bob");
     expect(body[0].inviter.email).toBe("bob@example.com");

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -8,8 +8,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { authAtom, logoutAtom } from "@/lib/auth";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useNavigate } from "@tanstack/react-router";
-import { Settings } from "lucide-react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Mail, Settings } from "lucide-react";
 
 // 名前の頭文字を取り出す。サロゲートペアを Array.from で正しく扱う。
 function initial(name: string | null | undefined): string {
@@ -63,6 +63,18 @@ export function Topbar() {
       {/* アプリ名: index.tsx の h1 と重複するため "Decision Loop" は使わない */}
       <span className="font-semibold text-base tracking-tight">App Name</span>
       <div className="ml-auto flex items-center gap-1">
+        {/* 自分宛の招待一覧への導線。未受諾招待数バッジ表示は follow-up 予定。 */}
+        <Link
+          to="/invitations"
+          aria-label="招待一覧"
+          className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          activeProps={{
+            className:
+              "p-2 rounded-md bg-muted text-foreground transition-colors",
+          }}
+        >
+          <Mail size={18} />
+        </Link>
         {/* 設定ボタン（未実装） */}
         <button
           type="button"

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as InvitationsRouteImport } from './routes/invitations'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TasksIndexRouteImport } from './routes/tasks.index'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
@@ -26,6 +27,11 @@ const OrganizationsRoute = OrganizationsRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InvitationsRoute = InvitationsRouteImport.update({
+  id: '/invitations',
+  path: '/invitations',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -61,6 +67,7 @@ const MeetingsIdRoute = MeetingsIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/invitations': typeof InvitationsRoute
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/meetings/$id': typeof MeetingsIdRoute
@@ -71,6 +78,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/invitations': typeof InvitationsRoute
   '/login': typeof LoginRoute
   '/meetings/$id': typeof MeetingsIdRoute
   '/organizations/$id': typeof OrganizationsIdRoute
@@ -81,6 +89,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/invitations': typeof InvitationsRoute
   '/login': typeof LoginRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/meetings/$id': typeof MeetingsIdRoute
@@ -93,6 +102,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/invitations'
     | '/login'
     | '/organizations'
     | '/meetings/$id'
@@ -103,6 +113,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/invitations'
     | '/login'
     | '/meetings/$id'
     | '/organizations/$id'
@@ -112,6 +123,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/invitations'
     | '/login'
     | '/organizations'
     | '/meetings/$id'
@@ -123,6 +135,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  InvitationsRoute: typeof InvitationsRoute
   LoginRoute: typeof LoginRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
   MeetingsIdRoute: typeof MeetingsIdRoute
@@ -144,6 +157,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/invitations': {
+      id: '/invitations'
+      path: '/invitations'
+      fullPath: '/invitations'
+      preLoaderRoute: typeof InvitationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -207,6 +227,7 @@ const OrganizationsRouteWithChildren = OrganizationsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  InvitationsRoute: InvitationsRoute,
   LoginRoute: LoginRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
   MeetingsIdRoute: MeetingsIdRoute,

--- a/apps/web/src/routes/invitations.tsx
+++ b/apps/web/src/routes/invitations.tsx
@@ -1,0 +1,140 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { RoleBadge } from "@/features/organizations/components/RoleBadge";
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+
+export const Route = createFileRoute("/invitations")({
+  component: InvitationsPage,
+});
+
+type Invitation = {
+  id: string;
+  role: "admin" | "member";
+  expiresAt: string;
+  createdAt: string;
+  organization: { id: string; name: string };
+  inviter: { id: string; name: string; displayName: string; email: string };
+};
+
+// 招待一覧クエリの key。受諾 (mutation) 成功時に組織一覧と一緒に invalidate する。
+const INVITATIONS_QUERY_KEY = ["me", "invitations"] as const;
+
+export function InvitationsPage() {
+  const queryClient = useQueryClient();
+  // 受諾失敗時に「どの招待 id」がエラーになったかを行単位で表示するため、id をキーに持つ。
+  const [acceptErrorId, setAcceptErrorId] = useState<string | null>(null);
+
+  const {
+    data: invitations = [],
+    isLoading,
+    isError,
+  } = useQuery<Invitation[]>({
+    queryKey: INVITATIONS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await api.me.invitations.$get(undefined, authHeaders());
+      if (!res.ok) {
+        throw new Error(`Failed to fetch invitations: ${res.status}`);
+      }
+      return (await res.json()) as Invitation[];
+    },
+  });
+
+  const acceptMutation = useMutation({
+    mutationFn: async (organizationId: string) => {
+      const res = await api.organizations[":id"].join.$post(
+        { param: { id: organizationId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to accept invitation: ${res.status}`);
+      }
+      return organizationId;
+    },
+    onSuccess: () => {
+      // 招待一覧と組織一覧の双方を再取得する。組織側はサイドバー等での
+      // 「所属組織」表示を即時更新するために必須。
+      queryClient.invalidateQueries({ queryKey: INVITATIONS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ["organizations"] });
+      setAcceptErrorId(null);
+    },
+    onError: (_err, organizationId) => {
+      setAcceptErrorId(organizationId);
+    },
+  });
+
+  return (
+    <section
+      aria-labelledby="invitations-title"
+      className="container mx-auto p-8 space-y-6"
+    >
+      <header className="space-y-2">
+        <h1 id="invitations-title" className="text-2xl font-bold">
+          招待
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          自分宛に届いている組織への招待を確認し、受諾できます。
+        </p>
+      </header>
+
+      {isLoading ? (
+        <p>読み込み中...</p>
+      ) : isError ? (
+        <p>取得に失敗しました</p>
+      ) : invitations.length === 0 ? (
+        <p className="text-muted-foreground">受信中の招待はありません</p>
+      ) : (
+        <ul aria-label="招待一覧" className="space-y-3">
+          {invitations.map((inv) => (
+            <li key={inv.id}>
+              <Card>
+                <CardHeader>
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex flex-col gap-1">
+                      <CardTitle className="text-base">
+                        {inv.organization.name}
+                      </CardTitle>
+                      <CardDescription>
+                        招待者: {inv.inviter.displayName} ({inv.inviter.email})
+                      </CardDescription>
+                      <CardDescription>
+                        期限:{" "}
+                        {new Date(inv.expiresAt).toLocaleDateString("ja-JP")}
+                      </CardDescription>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <RoleBadge role={inv.role} />
+                      <Button
+                        onClick={() =>
+                          acceptMutation.mutate(inv.organization.id)
+                        }
+                        disabled={
+                          acceptMutation.isPending &&
+                          acceptMutation.variables === inv.organization.id
+                        }
+                      >
+                        受諾
+                      </Button>
+                    </div>
+                  </div>
+                  {acceptErrorId === inv.organization.id && (
+                    <p className="text-destructive text-sm">
+                      受諾に失敗しました
+                    </p>
+                  )}
+                </CardHeader>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/test/invitations.test.tsx
+++ b/apps/web/src/test/invitations.test.tsx
@@ -1,0 +1,210 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InvitationsPage } from "../routes/invitations";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    me: {
+      invitations: {
+        $get: vi.fn(),
+      },
+    },
+    organizations: {
+      ":id": {
+        join: {
+          $post: vi.fn(),
+        },
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  const navigateMock = vi.fn();
+  return {
+    ...actual,
+    Link: ({
+      to,
+      params,
+      children,
+      className,
+    }: {
+      to: string;
+      params?: Record<string, string>;
+      children?: React.ReactNode;
+      className?: string;
+    }) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+    useNavigate: () => navigateMock,
+  };
+});
+
+import { api } from "@/lib/api";
+
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}
+
+type Invitation = {
+  id: string;
+  role: "admin" | "member";
+  expiresAt: string;
+  createdAt: string;
+  organization: { id: string; name: string };
+  inviter: { id: string; name: string; displayName: string; email: string };
+};
+
+const sampleInvitations: Invitation[] = [
+  {
+    id: "inv-1",
+    role: "member",
+    expiresAt: "2099-12-31T00:00:00.000Z",
+    createdAt: "2026-05-10T00:00:00.000Z",
+    organization: { id: "org-1", name: "ACME 株式会社" },
+    inviter: {
+      id: "user-2",
+      name: "bob",
+      displayName: "Bob",
+      email: "bob@example.com",
+    },
+  },
+  {
+    id: "inv-2",
+    role: "admin",
+    expiresAt: "2099-12-31T00:00:00.000Z",
+    createdAt: "2026-05-09T00:00:00.000Z",
+    organization: { id: "org-2", name: "別の組織" },
+    inviter: {
+      id: "user-3",
+      name: "carol",
+      displayName: "Carol",
+      email: "carol@example.com",
+    },
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("招待一覧ページ", () => {
+  it("認証ユーザーに届いた招待一覧を組織名・ロール・招待者と共に表示する", async () => {
+    vi.mocked(api.me.invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+
+    renderWithQuery(<InvitationsPage />);
+
+    expect(await screen.findByText("ACME 株式会社")).toBeInTheDocument();
+    expect(screen.getByText("別の組織")).toBeInTheDocument();
+    // ロール表示
+    expect(screen.getByText("メンバー")).toBeInTheDocument();
+    expect(screen.getByText("管理者")).toBeInTheDocument();
+    // 招待者名 (displayName)
+    expect(screen.getByText(/Bob/)).toBeInTheDocument();
+    expect(screen.getByText(/Carol/)).toBeInTheDocument();
+  });
+
+  it("招待が無いときは空状態メッセージが表示される", async () => {
+    vi.mocked(api.me.invitations.$get).mockResolvedValue(mockJson([]));
+
+    renderWithQuery(<InvitationsPage />);
+
+    expect(
+      await screen.findByText("受信中の招待はありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("読み込み中はローディング表示が出る", () => {
+    vi.mocked(api.me.invitations.$get).mockImplementation(
+      () => new Promise(() => {}),
+    );
+    renderWithQuery(<InvitationsPage />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("取得失敗時はエラー表示が出る", async () => {
+    vi.mocked(api.me.invitations.$get).mockRejectedValue(new Error("network"));
+    renderWithQuery(<InvitationsPage />);
+    expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
+  });
+
+  it("受諾ボタンを押すと /organizations/:id/join が呼ばれ一覧から消える", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.me.invitations.$get)
+      .mockResolvedValueOnce(mockJson(sampleInvitations))
+      .mockResolvedValueOnce(mockJson([sampleInvitations[1]]));
+    vi.mocked(api.organizations[":id"].join.$post).mockResolvedValue(
+      mockJson({
+        userId: "user-1",
+        organizationId: "org-1",
+        role: "member",
+        joinedAt: "2026-05-19T00:00:00.000Z",
+      }),
+    );
+
+    renderWithQuery(<InvitationsPage />);
+
+    const acmeRow = (await screen.findByText("ACME 株式会社")).closest("li");
+    expect(acmeRow).not.toBeNull();
+    if (!acmeRow) return;
+    const acceptButton = within(acmeRow as HTMLElement).getByRole("button", {
+      name: "受諾",
+    });
+    await user.click(acceptButton);
+
+    await waitFor(() => {
+      expect(api.organizations[":id"].join.$post).toHaveBeenCalledWith(
+        { param: { id: "org-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+
+    // 受諾後は一覧が再取得され、受諾した招待が消える
+    await waitFor(() => {
+      expect(screen.queryByText("ACME 株式会社")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("別の組織")).toBeInTheDocument();
+  });
+
+  it("受諾失敗時にはエラー表示が出て一覧は維持される", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.me.invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+    vi.mocked(api.organizations[":id"].join.$post).mockResolvedValue(
+      mockJson({ error: "招待が見つかりません" }, 404),
+    );
+
+    renderWithQuery(<InvitationsPage />);
+
+    const acmeRow = (await screen.findByText("ACME 株式会社")).closest("li");
+    if (!acmeRow) return;
+    await user.click(
+      within(acmeRow as HTMLElement).getByRole("button", { name: "受諾" }),
+    );
+
+    expect(await screen.findByText("受諾に失敗しました")).toBeInTheDocument();
+    // 一覧は消えない
+    expect(screen.getByText("ACME 株式会社")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/test/topbar.test.tsx
+++ b/apps/web/src/test/topbar.test.tsx
@@ -8,12 +8,33 @@ import { makeFakeIdToken } from "./helpers/auth";
 
 const navigateMock = vi.fn();
 
+// TanStack Router の Link は RouterProvider 配下でないと落ちるため、
+// テスト中は href を持つ <a> として描画するモックに差し替える。
+// 同テスト内でユーザーメニュー → ログアウトの useNavigate も検証するため
+// useNavigate もモックに含める。
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
     "@tanstack/react-router",
   );
+  type MockLinkProps = {
+    to: string;
+    children?: React.ReactNode;
+    className?: string;
+    "aria-label"?: string;
+    activeProps?: unknown;
+  };
   return {
     ...actual,
+    Link: ({
+      to,
+      children,
+      className,
+      "aria-label": ariaLabel,
+    }: MockLinkProps) => (
+      <a href={to} className={className} aria-label={ariaLabel}>
+        {children}
+      </a>
+    ),
     useNavigate: () => navigateMock,
   };
 });
@@ -37,6 +58,12 @@ describe("Topbar", () => {
     expect(
       screen.getByRole("button", { name: "ユーザーメニュー" }),
     ).toHaveTextContent("田");
+  });
+
+  it("招待一覧へのリンクが /invitations を指して表示される", () => {
+    renderTopbar();
+    const link = screen.getByRole("link", { name: "招待一覧" });
+    expect(link).toHaveAttribute("href", "/invitations");
   });
 
   it("ログアウトをクリックすると /login へ遷移する", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #121
Closes #122 (メール送信機能のスコープを縮小し、サイト内招待動線で吸収)

## 概要・目的
* 自分宛に届いた組織への招待を、メール送信に依存せずサイト内から一覧・受諾できる動線を追加する。
* 招待を出された側がアプリ内で完結できる UX を確立する。

## 背景
* PR #95 で組織招待 API (\`POST /organizations/:id/invite\` / \`POST /organizations/:id/join\`) を実装したが、招待された側が自分宛の招待をアプリ内で確認する手段が無かった。
* 当初 #122 でメール送信機構を導入する案もあったが、ローカル fake-auth ユーザーには実メールが無く検証できないこと、プロバイダ選定コストが重いことから、まずアプリ内動線で完結させる方針に縮小した (Issue #122 に注記済み)。

## 変更内容
### Backend
* \`apps/api/src/routes/me.ts\` (新規):
  * \`GET /me/invitations\`: 認証ユーザー自身の email に一致する \`status=pending\` かつ \`expiresAt > now\` の招待を返す
  * レスポンスは \`organization (id, name)\` と \`inviter (id, name, displayName, email)\` を include し、\`createdAt\` 降順で返却
* \`apps/api/src/app.ts\`: \`/me\` パスに \`meRoute\` をマウント
* \`apps/api/test/me.test.ts\` (新規): 5 件のテスト

### Frontend
* \`apps/web/src/routes/invitations.tsx\` (新規):
  * 招待カード一覧（組織名・付与予定ロール・招待者・期限・受諾ボタン）
  * 受諾 → \`POST /organizations/:id/join\` 呼出 → \`[\"me\", \"invitations\"]\` と \`[\"organizations\"]\` クエリを invalidate
  * 受諾失敗時は該当行に「受諾に失敗しました」を表示、一覧は維持
* \`apps/web/src/test/invitations.test.tsx\` (新規): 6 件のテスト
* \`apps/web/src/routeTree.gen.ts\`: TanStack Router の自動生成更新
* \`apps/web/src/components/layout/Topbar.tsx\`: Settings ボタン左隣に Mail アイコンの \`/invitations\` リンクを追加（全画面共通の導線。未受諾数バッジは follow-up）
* \`apps/web/src/test/topbar.test.tsx\`: 招待リンクの href 検証テストを追加

## 動作確認手順
1. \`make dev\` で local 環境を起動
2. fake-auth で User A としてログインし、組織を作成
3. User A から User B の email 宛に招待を発行 (組織詳細画面 → 招待ダイアログ)
4. 別ブラウザ/シークレットで User B としてログイン
5. トップバー右側の Mail アイコン（または直接 \`/invitations\`）を開き、招待カードが表示されることを確認 (組織名・ロール・招待者・期限)
6. 「受諾」ボタンを押下し、組織一覧 \`/organizations\` に該当組織が追加され、\`/invitations\` から消えることを確認


## スクリーンショット
<img width="1119" height="695" alt="image" src="https://github.com/user-attachments/assets/b1b446b0-2482-4b64-a9fb-a360c648fad5" />
<img width="1037" height="695" alt="image" src="https://github.com/user-attachments/assets/5390f2a0-434d-4c36-ad97-c630c6f25eb5" />
<img width="1037" height="695" alt="image" src="https://github.com/user-attachments/assets/624d040a-db7e-4ef0-a267-8fbaffbd0d2a" />

## チェックリスト
- [x] 全テスト GREEN (api 217 件 / web 347 件)
- [x] lint / typecheck パス
- [x] auth ミドルウェアで正規化された email との比較を前提に動作確認
