### PR TITLE
feat: 組織側の招待管理（一覧・取消）を追加

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -440,6 +440,7 @@ Enum InvitationStatus {
   pending
   accepted
   expired
+  revoked
 }
 
 Enum MeetingRole {

--- a/apps/api/prisma/migrations/20260518182946_add_invitation_revoked_status/migration.sql
+++ b/apps/api/prisma/migrations/20260518182946_add_invitation_revoked_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "InvitationStatus" ADD VALUE 'revoked';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -178,11 +178,14 @@ enum OrgRole {
   member
 }
 
-// 組織への招待状態。pending → accepted/expired のいずれかに遷移する。
+// 組織への招待状態。pending → accepted/expired/revoked のいずれかに遷移する。
+// revoked は owner/admin が招待を取り消したケース。@@unique(organizationId, email, status)
+// の制約により、取消後 (status=revoked) は同一 email への再招待が pending として作成可能。
 enum InvitationStatus {
   pending
   accepted
   expired
+  revoked
 }
 
 // 組織。所属メンバーと配下定例の親エンティティ。

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -353,6 +353,82 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
       return c.json(meeting, 201);
     },
   )
+  .get("/:id/invitations", async (c) => {
+    const id = c.req.param("id");
+
+    const guard = await requireOrgRole(
+      c,
+      id,
+      ["owner", "admin"],
+      "招待管理権限がありません",
+    );
+    if (!guard.ok) return guard.res;
+
+    // status=pending のみ取得し、期限切れ判定はレスポンス側の expired フィールドで返す。
+    // expired→DB 値の自動遷移はバッチジョブ前提のため、ここでは status を変更しない。
+    const invitations = await prisma.organizationInvitation.findMany({
+      where: { organizationId: id, status: "pending" },
+      orderBy: { createdAt: "desc" },
+      include: {
+        inviter: {
+          select: { id: true, name: true, displayName: true, email: true },
+        },
+      },
+    });
+
+    const now = new Date();
+    const result = invitations.map((inv) => ({
+      id: inv.id,
+      email: inv.email,
+      role: inv.role,
+      status: inv.status,
+      expiresAt: inv.expiresAt,
+      createdAt: inv.createdAt,
+      expired: inv.expiresAt <= now,
+      inviter: inv.inviter,
+    }));
+    return c.json(result);
+  })
+  .delete("/:id/invitations/:invitationId", async (c) => {
+    const id = c.req.param("id");
+    const invitationId = c.req.param("invitationId");
+
+    const guard = await requireOrgRole(
+      c,
+      id,
+      ["owner", "admin"],
+      "招待管理権限がありません",
+    );
+    if (!guard.ok) return guard.res;
+
+    const invitation = await prisma.organizationInvitation.findUnique({
+      where: { id: invitationId },
+    });
+
+    // 404 条件:
+    //   - 招待が存在しない
+    //   - 招待が path で指定された別組織のもの（横断アクセス防止）
+    if (!invitation || invitation.organizationId !== id) {
+      return c.json({ error: "招待が見つかりません" }, 404);
+    }
+
+    // 既に accepted ⇒ メンバーは既に組織に居るため取消不可。409 で明示する。
+    if (invitation.status === "accepted") {
+      return c.json({ error: "既に受諾済みの招待は取消できません" }, 409);
+    }
+
+    // 既に revoked ⇒ 冪等として 204 を返す。expired は revoke を許す
+    //（owner/admin が「期限切れ招待を整理する」意図を尊重）。
+    if (invitation.status === "revoked") {
+      return c.body(null, 204);
+    }
+
+    await prisma.organizationInvitation.update({
+      where: { id: invitationId },
+      data: { status: "revoked" },
+    });
+    return c.body(null, 204);
+  })
   .post("/:id/invite", zValidator("json", inviteSchema), async (c) => {
     const id = c.req.param("id");
     const user = c.var.user;

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -20,6 +20,8 @@ vi.mock("../src/lib/prisma.js", () => ({
     organizationInvitation: {
       create: vi.fn(),
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
       update: vi.fn(),
     },
     task: {
@@ -85,6 +87,13 @@ const mockMembershipFindMany = vi.mocked(
 );
 const mockMembershipDelete = vi.mocked(prisma.organizationMembership.delete);
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
+const mockInvitationFindUnique = vi.mocked(
+  prisma.organizationInvitation.findUnique,
+);
+const mockInvitationFindMany = vi.mocked(
+  prisma.organizationInvitation.findMany,
+);
+const mockInvitationUpdate = vi.mocked(prisma.organizationInvitation.update);
 const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
@@ -983,6 +992,248 @@ describe("POST /organizations/:id/invite", () => {
       },
     });
     expect(mockInvitationCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /organizations/:id/invitations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-19T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function membership(role: "owner" | "admin" | "member") {
+    return {
+      userId: "user-1",
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  const pendingInvitation = {
+    id: "inv-1",
+    organizationId: "org-1",
+    email: "bob@example.com",
+    invitedBy: "user-1",
+    role: "member" as const,
+    expiresAt: new Date("2026-05-26T00:00:00Z"),
+    status: "pending" as const,
+    createdAt: new Date("2026-05-19T00:00:00Z"),
+    inviter: {
+      id: "user-1",
+      name: "alice",
+      displayName: "alice",
+      email: "alice@example.com",
+    },
+  };
+
+  it("owner は pending 招待一覧を取得できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindMany.mockResolvedValue([pendingInvitation] as never);
+
+    const res = await app.request("/organizations/org-1/invitations");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      email: string;
+      role: string;
+      status: string;
+      expired: boolean;
+    }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("inv-1");
+    expect(body[0].email).toBe("bob@example.com");
+    expect(body[0].role).toBe("member");
+    expect(body[0].expired).toBe(false);
+  });
+
+  it("admin も pending 招待一覧を取得できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("admin"));
+    mockInvitationFindMany.mockResolvedValue([] as never);
+
+    const res = await app.request("/organizations/org-1/invitations");
+    expect(res.status).toBe(200);
+  });
+
+  it("member は 403 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+
+    const res = await app.request("/organizations/org-1/invitations");
+    expect(res.status).toBe(403);
+    expect(mockInvitationFindMany).not.toHaveBeenCalled();
+  });
+
+  it("未所属ユーザーは 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/organizations/org-1/invitations");
+    expect(res.status).toBe(404);
+    expect(mockInvitationFindMany).not.toHaveBeenCalled();
+  });
+
+  it("status=pending で findMany が呼ばれ、期限切れ判定は expired フィールドで返る", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    const expiredInvitation = {
+      ...pendingInvitation,
+      id: "inv-expired",
+      expiresAt: new Date("2026-05-10T00:00:00Z"),
+    };
+    mockInvitationFindMany.mockResolvedValue([
+      pendingInvitation,
+      expiredInvitation,
+    ] as never);
+
+    const res = await app.request("/organizations/org-1/invitations");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      id: string;
+      expired: boolean;
+    }>;
+    expect(mockInvitationFindMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1", status: "pending" },
+      orderBy: { createdAt: "desc" },
+      include: {
+        inviter: {
+          select: { id: true, name: true, displayName: true, email: true },
+        },
+      },
+    });
+    // 期限切れは末尾のはず（findMany のソート順は createdAt 降順だが、
+    // 「期限切れは末尾」要件があるならハンドラ側で並べ替え。仕様: createdAt desc
+    // でクライアントが expired フィールドを使って色分けする想定）
+    expect(body).toHaveLength(2);
+    const expiredEntry = body.find((b) => b.id === "inv-expired");
+    expect(expiredEntry?.expired).toBe(true);
+    const liveEntry = body.find((b) => b.id === "inv-1");
+    expect(liveEntry?.expired).toBe(false);
+  });
+});
+
+describe("DELETE /organizations/:id/invitations/:invitationId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function membership(role: "owner" | "admin" | "member") {
+    return {
+      userId: "user-1",
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  const pendingInvitation = {
+    id: "inv-1",
+    organizationId: "org-1",
+    email: "bob@example.com",
+    invitedBy: "user-1",
+    role: "member" as const,
+    expiresAt: new Date("2026-05-26T00:00:00Z"),
+    status: "pending" as const,
+    createdAt: new Date("2026-05-19T00:00:00Z"),
+  };
+
+  it("owner は pending 招待を取消できる (204)", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindUnique.mockResolvedValue(pendingInvitation as never);
+    mockInvitationUpdate.mockResolvedValue({
+      ...pendingInvitation,
+      status: "revoked",
+    } as never);
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(mockInvitationUpdate).toHaveBeenCalledWith({
+      where: { id: "inv-1" },
+      data: { status: "revoked" },
+    });
+  });
+
+  it("admin も pending 招待を取消できる", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("admin"));
+    mockInvitationFindUnique.mockResolvedValue(pendingInvitation as never);
+    mockInvitationUpdate.mockResolvedValue({
+      ...pendingInvitation,
+      status: "revoked",
+    } as never);
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("member は 403 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockInvitationUpdate).not.toHaveBeenCalled();
+  });
+
+  it("組織に存在しない招待 ID は 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindUnique.mockResolvedValue(null);
+
+    const res = await app.request(
+      "/organizations/org-1/invitations/not-found",
+      { method: "DELETE" },
+    );
+    expect(res.status).toBe(404);
+    expect(mockInvitationUpdate).not.toHaveBeenCalled();
+  });
+
+  it("他組織の招待 ID は 404 を返す（path 組織と invitation.organizationId が一致しない）", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindUnique.mockResolvedValue({
+      ...pendingInvitation,
+      organizationId: "other-org",
+    } as never);
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockInvitationUpdate).not.toHaveBeenCalled();
+  });
+
+  it("既に accepted の招待は 409 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindUnique.mockResolvedValue({
+      ...pendingInvitation,
+      status: "accepted",
+    } as never);
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(409);
+    expect(mockInvitationUpdate).not.toHaveBeenCalled();
+  });
+
+  it("既に revoked の招待は冪等として 204 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValue(membership("owner"));
+    mockInvitationFindUnique.mockResolvedValue({
+      ...pendingInvitation,
+      status: "revoked",
+    } as never);
+
+    const res = await app.request("/organizations/org-1/invitations/inv-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    // 既に revoked なので update を発行しない
+    expect(mockInvitationUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/features/organizations/components/PendingInvitationsList.tsx
+++ b/apps/web/src/features/organizations/components/PendingInvitationsList.tsx
@@ -1,0 +1,77 @@
+import { Button } from "@/components/ui/button";
+import { RoleBadge } from "@/features/organizations/components/RoleBadge";
+import { usePendingInvitations } from "@/features/organizations/hooks/usePendingInvitations";
+import { useRevokeInvitation } from "@/features/organizations/hooks/useRevokeInvitation";
+import { useState } from "react";
+
+// 組織詳細ページの「招待管理」セクション。owner/admin のみ表示される想定。
+// 取消ボタン押下で DELETE → 一覧 invalidate。失敗時は該当行にエラーを表示する。
+export function PendingInvitationsList({ orgId }: { orgId: string }) {
+  const {
+    data: invitations = [],
+    isLoading,
+    isError,
+  } = usePendingInvitations(orgId);
+  const revoke = useRevokeInvitation(orgId);
+  // 取消失敗時にどの招待 id で失敗したかを行単位で表示するため id をキーに持つ。
+  const [errorId, setErrorId] = useState<string | null>(null);
+
+  const handleRevoke = (invitationId: string) => {
+    setErrorId(null);
+    revoke.mutate(invitationId, {
+      onError: () => setErrorId(invitationId),
+    });
+  };
+
+  return (
+    <section aria-label="招待管理" className="space-y-3 rounded-md border p-4">
+      <h2 className="text-lg font-semibold">招待管理</h2>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : isError ? (
+        <p className="text-destructive text-sm">招待の取得に失敗しました</p>
+      ) : invitations.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          ペンディング中の招待はありません
+        </p>
+      ) : (
+        <ul aria-label="招待一覧" className="divide-y rounded-md border">
+          {invitations.map((inv) => (
+            <li
+              key={inv.id}
+              className="flex items-center justify-between gap-3 px-4 py-3"
+            >
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">{inv.email}</span>
+                <span className="text-sm text-muted-foreground">
+                  招待者: {inv.inviter.displayName} ({inv.inviter.email})
+                </span>
+                {errorId === inv.id && (
+                  <span className="text-destructive text-sm">
+                    取消に失敗しました
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <RoleBadge role={inv.role} />
+                {inv.expired && (
+                  <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                    期限切れ
+                  </span>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleRevoke(inv.id)}
+                  disabled={revoke.isPending && revoke.variables === inv.id}
+                >
+                  取消
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
+++ b/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
@@ -1,0 +1,32 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+
+export type PendingInvitation = {
+  id: string;
+  email: string;
+  role: "admin" | "member";
+  status: "pending";
+  expiresAt: string;
+  createdAt: string;
+  expired: boolean;
+  inviter: { id: string; name: string; displayName: string; email: string };
+};
+
+// 組織の pending 招待一覧を取得するクエリ。
+// owner/admin のみ呼び出せる前提で、UI 側で表示の出し分けを行う。
+export function usePendingInvitations(orgId: string, enabled = true) {
+  return useQuery<PendingInvitation[]>({
+    queryKey: ["organizations", orgId, "invitations"],
+    enabled,
+    queryFn: async () => {
+      const res = await api.organizations[":id"].invitations.$get(
+        { param: { id: orgId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch invitations: ${res.status}`);
+      }
+      return (await res.json()) as PendingInvitation[];
+    },
+  });
+}

--- a/apps/web/src/features/organizations/hooks/useRevokeInvitation.ts
+++ b/apps/web/src/features/organizations/hooks/useRevokeInvitation.ts
@@ -1,0 +1,24 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+// DELETE /organizations/:id/invitations/:invitationId の薄いラッパー。
+// 成功時に該当組織の招待一覧を invalidate して UI を即時更新する。
+export function useRevokeInvitation(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (invitationId: string) => {
+      const res = await api.organizations[":id"].invitations[
+        ":invitationId"
+      ].$delete({ param: { id: orgId, invitationId } }, authHeaders());
+      if (!res.ok) {
+        throw new Error(`Failed to revoke invitation: ${res.status}`);
+      }
+      return invitationId;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", orgId, "invitations"],
+      });
+    },
+  });
+}

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -2,6 +2,7 @@ import { DeleteMemberDialog } from "@/features/organizations/components/DeleteMe
 import { DeleteOrganizationDialog } from "@/features/organizations/components/DeleteOrganizationDialog";
 import { EditOrganizationDialog } from "@/features/organizations/components/EditOrganizationDialog";
 import { InviteMemberDialog } from "@/features/organizations/components/InviteMemberDialog";
+import { PendingInvitationsList } from "@/features/organizations/components/PendingInvitationsList";
 import { RoleBadge } from "@/features/organizations/components/RoleBadge";
 import type {
   Member,
@@ -148,6 +149,10 @@ export function OrganizationDetailView({
           </ul>
         )}
       </section>
+
+      {(org.role === "owner" || org.role === "admin") && (
+        <PendingInvitationsList orgId={id} />
+      )}
 
       <section aria-label="定例" className="space-y-3">
         <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/test/organizations.invitationsManagement.test.tsx
+++ b/apps/web/src/test/organizations.invitationsManagement.test.tsx
@@ -1,0 +1,283 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockJson,
+  ownerOrgDetail,
+  renderDetail,
+  sampleMembers,
+} from "./helpers/organizationDetail";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    organizations: {
+      ":id": {
+        $get: vi.fn(),
+        $patch: vi.fn(),
+        $delete: vi.fn(),
+        invite: { $post: vi.fn() },
+        invitations: {
+          $get: vi.fn(),
+          ":invitationId": {
+            $delete: vi.fn(),
+          },
+        },
+        members: {
+          $get: vi.fn(),
+          ":userId": { $delete: vi.fn() },
+        },
+        meetings: { $post: vi.fn() },
+      },
+    },
+    "recurring-meetings": {
+      ":id": {
+        $patch: vi.fn(),
+        $delete: vi.fn(),
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  type MockLinkProps = {
+    to: string;
+    params?: Record<string, string>;
+    children?: React.ReactNode;
+    className?: string;
+  };
+  return {
+    ...actual,
+    Link: ({ to, params, children, className }: MockLinkProps) => {
+      const href =
+        typeof to === "string"
+          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+          : String(to);
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      );
+    },
+  };
+});
+
+import { api } from "@/lib/api";
+
+type Invitation = {
+  id: string;
+  email: string;
+  role: "admin" | "member";
+  status: "pending";
+  expiresAt: string;
+  createdAt: string;
+  expired: boolean;
+  inviter: { id: string; name: string; displayName: string; email: string };
+};
+
+const sampleInvitations: Invitation[] = [
+  {
+    id: "inv-1",
+    email: "bob@example.com",
+    role: "member",
+    status: "pending",
+    expiresAt: "2099-12-31T00:00:00.000Z",
+    createdAt: "2026-05-10T00:00:00.000Z",
+    expired: false,
+    inviter: {
+      id: "user-1",
+      name: "alice",
+      displayName: "Alice A.",
+      email: "alice@example.com",
+    },
+  },
+  {
+    id: "inv-2",
+    email: "dave@example.com",
+    role: "admin",
+    status: "pending",
+    expiresAt: "2026-05-10T00:00:00.000Z",
+    createdAt: "2026-05-05T00:00:00.000Z",
+    expired: true,
+    inviter: {
+      id: "user-1",
+      name: "alice",
+      displayName: "Alice A.",
+      email: "alice@example.com",
+    },
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("組織詳細ページ - 招待管理セクション", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("owner には招待管理セクションが表示され、pending 招待が一覧される", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "owner" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+    renderDetail();
+
+    const section = await screen.findByRole("region", { name: "招待管理" });
+    // 招待リスト (aria-label="招待一覧") がレンダリングされるまで待つ
+    const list = await within(section).findByRole("list", {
+      name: "招待一覧",
+    });
+    // member 一覧にも bob@example.com が出る (helper の sampleMembers 由来) ため、
+    // 招待一覧の範囲内で検証する。
+    expect(within(list).getByText("bob@example.com")).toBeInTheDocument();
+    expect(within(list).getByText("dave@example.com")).toBeInTheDocument();
+  });
+
+  it("admin にも招待管理セクションが表示される", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "admin" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+    renderDetail();
+
+    expect(
+      await screen.findByRole("region", { name: "招待管理" }),
+    ).toBeInTheDocument();
+  });
+
+  it("member には招待管理セクションが表示されない", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "member" }),
+    );
+    renderDetail();
+    await screen.findByText("ACME 株式会社");
+    expect(
+      screen.queryByRole("region", { name: "招待管理" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("pending 招待が無いときは空状態メッセージが表示される", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "owner" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderDetail();
+
+    const section = await screen.findByRole("region", { name: "招待管理" });
+    expect(
+      await within(section).findByText("ペンディング中の招待はありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("期限切れ招待にはバッジが表示される", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "owner" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+    renderDetail();
+
+    const section = await screen.findByRole("region", { name: "招待管理" });
+    const list = await within(section).findByRole("list", {
+      name: "招待一覧",
+    });
+    // dave@example.com の行に「期限切れ」ラベルがある
+    const daveRow = within(list).getByText("dave@example.com").closest("li");
+    if (!daveRow) return;
+    expect(
+      within(daveRow as HTMLElement).getByText("期限切れ"),
+    ).toBeInTheDocument();
+    // bob の行は期限切れではない
+    const bobRow = within(list).getByText("bob@example.com").closest("li");
+    if (!bobRow) return;
+    expect(
+      within(bobRow as HTMLElement).queryByText("期限切れ"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("取消ボタンを押すと DELETE が呼ばれ一覧から消える", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "owner" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get)
+      .mockResolvedValueOnce(mockJson(sampleInvitations))
+      .mockResolvedValueOnce(mockJson([sampleInvitations[1]]));
+    vi.mocked(
+      api.organizations[":id"].invitations[":invitationId"].$delete,
+    ).mockResolvedValue(mockJson(null, 204));
+
+    renderDetail();
+
+    const section = await screen.findByRole("region", { name: "招待管理" });
+    const list = await within(section).findByRole("list", {
+      name: "招待一覧",
+    });
+    const bobRow = within(list).getByText("bob@example.com").closest("li");
+    if (!bobRow) return;
+    await user.click(
+      within(bobRow as HTMLElement).getByRole("button", { name: "取消" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        api.organizations[":id"].invitations[":invitationId"].$delete,
+      ).toHaveBeenCalledWith(
+        { param: { id: "org-1", invitationId: "inv-1" } },
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+
+    // 一覧が再取得され、取消した招待が招待一覧から消える
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("bob@example.com"),
+      ).not.toBeInTheDocument();
+    });
+    expect(within(list).getByText("dave@example.com")).toBeInTheDocument();
+  });
+
+  it("取消失敗時にはエラー表示が出て一覧は維持される", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "owner" }),
+    );
+    vi.mocked(api.organizations[":id"].invitations.$get).mockResolvedValue(
+      mockJson(sampleInvitations),
+    );
+    vi.mocked(
+      api.organizations[":id"].invitations[":invitationId"].$delete,
+    ).mockResolvedValue(mockJson({ error: "bad" }, 500));
+
+    renderDetail();
+
+    const section = await screen.findByRole("region", { name: "招待管理" });
+    const list = await within(section).findByRole("list", {
+      name: "招待一覧",
+    });
+    const bobRow = within(list).getByText("bob@example.com").closest("li");
+    if (!bobRow) return;
+    await user.click(
+      within(bobRow as HTMLElement).getByRole("button", { name: "取消" }),
+    );
+
+    expect(
+      await within(section).findByText("取消に失敗しました"),
+    ).toBeInTheDocument();
+    expect(within(list).getByText("bob@example.com")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #123

## 概要・目的
* 組織の owner / admin が出した招待を、組織詳細ページから一覧・取消できる動線を追加する。
* 招待ミスや期限切れ前の取消ニーズに対応する。

## 背景
* PR #95 で組織招待 API は実装したが、出した側からは pending 招待を確認・取消する手段が無かった。
* PR #225 で受け取り側 (\`/invitations\`) は整備済み。本 PR で送り出した側の管理 UI を追加する。

## 変更内容
### Backend
* \`apps/api/prisma/schema.prisma\`: \`InvitationStatus\` enum に \`revoked\` を追加（migration 同梱）
* \`apps/api/src/routes/organizations.ts\`:
  * \`GET /organizations/:id/invitations\` (owner/admin) — status=pending の招待を createdAt 降順で返す。期限切れは status を変えず \`expired: true\` フラグで明示。inviter 情報を include。
  * \`DELETE /organizations/:id/invitations/:invitationId\` (owner/admin) — pending を revoked に遷移。横断アクセス防止のため organizationId 不一致は 404、accepted は 409、既に revoked は 冪等 204。
* \`apps/api/test/organizations.test.ts\`: 13 件のテストを追加

### Frontend
* \`apps/web/src/features/organizations/hooks/usePendingInvitations.ts\` (新規): 招待一覧クエリフック
* \`apps/web/src/features/organizations/hooks/useRevokeInvitation.ts\` (新規): 取消 mutation フック
* \`apps/web/src/features/organizations/components/PendingInvitationsList.tsx\` (新規): 招待管理セクション
* \`apps/web/src/routes/organizations.\$id.tsx\`: owner/admin 時のみ PendingInvitationsList を表示
* \`apps/web/src/test/organizations.invitationsManagement.test.tsx\` (新規): 7 件のテスト

## 動作確認手順
1. \`make dev\` で local 環境を起動
2. fake-auth で組織 owner としてログインし、組織詳細を開く
3. 「メンバー招待」から有効な email 宛に招待を発行
4. 「招待管理」セクションに pending 招待が表示されることを確認
5. 「取消」ボタンを押下 → 一覧から消えることを確認
6. 同じ email で再度招待を発行 → 取消後でも pending として作成できることを確認 (revoked 状態が unique key の差別化に効く)
7. \`member\` ロールで開いた場合に「招待管理」セクションが表示されないことを確認

## スクリーンショット
<img width="1037" height="695" alt="image" src="https://github.com/user-attachments/assets/309380ce-b37f-4b4a-9341-d87834a27843" />


## チェックリスト
- [x] 全テスト GREEN (api 88 件 / web 356 件)
- [x] lint / typecheck パス
- [x] Prisma migration 同梱 (revoked status 追加)
- [x] schema.dbml 再生成済み