### PR TITLE
refactor: 組織 API/UI の型キャストを除去する

### DIFF
--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -32,6 +32,16 @@ const mockFindUnique = vi.mocked(prisma.user.findUnique);
 const mockCreate = vi.mocked(prisma.user.create);
 const mockUpdate = vi.mocked(prisma.user.update);
 
+// jose の JWTVerifyResult は key 等のフィールドを含む overload があり
+// テスト側で完全構築するのが煩雑なため、最低限の payload / protectedHeader だけ
+// 渡せるヘルパーに集約する。as never はここ 1 箇所だけに留める。
+function jwtVerifyResult(payload: Record<string, unknown>) {
+  return {
+    payload,
+    protectedHeader: { alg: "RS256" } as const,
+  } as never;
+}
+
 const sampleUser = {
   id: "cuid-user-1",
   externalId: "ext-1",
@@ -86,10 +96,7 @@ describe("auth middleware", () => {
   });
 
   it("jwtVerify には issuer / audience が渡される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-1", email: "alice@example.com", name: "alice" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com", name: "alice" }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     await app.request("/whoami", {
@@ -102,10 +109,7 @@ describe("auth middleware", () => {
   });
 
   it("payload.sub が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { email: "alice@example.com", name: "alice" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ email: "alice@example.com", name: "alice" }));
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -115,10 +119,7 @@ describe("auth middleware", () => {
   });
 
   it("payload.email が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-1", name: "alice" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", name: "alice" }));
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -128,10 +129,7 @@ describe("auth middleware", () => {
   });
 
   it("payload.name が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-1", email: "alice@example.com" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com" }));
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -141,10 +139,7 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーで email/name が一致する場合は update を発行しない", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-1", email: "alice@example.com", name: "alice" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com", name: "alice" }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
@@ -158,10 +153,7 @@ describe("auth middleware", () => {
   });
 
   it("未登録ユーザーは externalId/email/name/displayName=name で create される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-2", email: "bob@example.com", name: "bob" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-2", email: "bob@example.com", name: "bob" }));
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockResolvedValueOnce({
       ...sampleUser,
@@ -188,14 +180,11 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは IdP 側で email が変更された場合 update が発行される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-1",
         email: "alice-renamed@example.com",
         name: "alice",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -213,14 +202,11 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは IdP 側で name が変更された場合 update が発行される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-1",
         email: "alice@example.com",
         name: "alice-renamed",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -238,14 +224,11 @@ describe("auth middleware", () => {
   });
 
   it("新規ユーザー作成時 email は trim + 小文字化された値で保存される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-5",
         email: "  Bob@Example.COM  ",
         name: "bob",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockResolvedValueOnce({
       ...sampleUser,
@@ -271,14 +254,11 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは payload email の大文字小文字差では update されない（正規化後一致）", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-1",
         email: "Alice@Example.COM",
         name: "alice",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
@@ -290,14 +270,11 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーの IdP 側 email 変更時は正規化済みの値で update される", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-1",
         email: "  Alice-Renamed@Example.COM  ",
         name: "alice",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -314,10 +291,7 @@ describe("auth middleware", () => {
   });
 
   it("payload.sub が文字列以外の場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: 123, email: "alice@example.com", name: "alice" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: 123, email: "alice@example.com", name: "alice" }));
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -327,10 +301,7 @@ describe("auth middleware", () => {
   });
 
   it("create 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-3", email: "alice@example.com", name: "carol" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-3", email: "alice@example.com", name: "carol" }));
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
@@ -348,14 +319,11 @@ describe("auth middleware", () => {
   });
 
   it("update 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: {
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
         sub: "ext-1",
         email: "carol@example.com",
         name: "alice",
-      },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+      }));
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
@@ -371,10 +339,7 @@ describe("auth middleware", () => {
   });
 
   it("P2002 以外の Prisma 既知エラーは握り潰さず例外として伝播する", async () => {
-    mockJwtVerify.mockResolvedValueOnce({
-      payload: { sub: "ext-4", email: "dave@example.com", name: "dave" },
-      protectedHeader: { alg: "RS256" },
-    } as never);
+    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-4", email: "dave@example.com", name: "dave" }));
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("connection lost", {

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -96,7 +96,13 @@ describe("auth middleware", () => {
   });
 
   it("jwtVerify には issuer / audience が渡される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com", name: "alice" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
+        sub: "ext-1",
+        email: "alice@example.com",
+        name: "alice",
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     await app.request("/whoami", {
@@ -109,7 +115,9 @@ describe("auth middleware", () => {
   });
 
   it("payload.sub が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ email: "alice@example.com", name: "alice" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ email: "alice@example.com", name: "alice" }),
+    );
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -119,7 +127,9 @@ describe("auth middleware", () => {
   });
 
   it("payload.email が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", name: "alice" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-1", name: "alice" }),
+    );
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -129,7 +139,9 @@ describe("auth middleware", () => {
   });
 
   it("payload.name が無い場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-1", email: "alice@example.com" }),
+    );
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -139,7 +151,13 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーで email/name が一致する場合は update を発行しない", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-1", email: "alice@example.com", name: "alice" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
+        sub: "ext-1",
+        email: "alice@example.com",
+        name: "alice",
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
@@ -153,7 +171,9 @@ describe("auth middleware", () => {
   });
 
   it("未登録ユーザーは externalId/email/name/displayName=name で create される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-2", email: "bob@example.com", name: "bob" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-2", email: "bob@example.com", name: "bob" }),
+    );
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockResolvedValueOnce({
       ...sampleUser,
@@ -180,11 +200,13 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは IdP 側で email が変更された場合 update が発行される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-1",
         email: "alice-renamed@example.com",
         name: "alice",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -202,11 +224,13 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは IdP 側で name が変更された場合 update が発行される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-1",
         email: "alice@example.com",
         name: "alice-renamed",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -224,11 +248,13 @@ describe("auth middleware", () => {
   });
 
   it("新規ユーザー作成時 email は trim + 小文字化された値で保存される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-5",
         email: "  Bob@Example.COM  ",
         name: "bob",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockResolvedValueOnce({
       ...sampleUser,
@@ -254,11 +280,13 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーは payload email の大文字小文字差では update されない（正規化後一致）", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-1",
         email: "Alice@Example.COM",
         name: "alice",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
@@ -270,11 +298,13 @@ describe("auth middleware", () => {
   });
 
   it("既存ユーザーの IdP 側 email 変更時は正規化済みの値で update される", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-1",
         email: "  Alice-Renamed@Example.COM  ",
         name: "alice",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockResolvedValueOnce({
       ...sampleUser,
@@ -291,7 +321,9 @@ describe("auth middleware", () => {
   });
 
   it("payload.sub が文字列以外の場合は 401 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: 123, email: "alice@example.com", name: "alice" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: 123, email: "alice@example.com", name: "alice" }),
+    );
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
@@ -301,7 +333,13 @@ describe("auth middleware", () => {
   });
 
   it("create 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-3", email: "alice@example.com", name: "carol" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
+        sub: "ext-3",
+        email: "alice@example.com",
+        name: "carol",
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
@@ -319,11 +357,13 @@ describe("auth middleware", () => {
   });
 
   it("update 時に email が他ユーザーで使用済み (P2002) の場合は 409 を返す", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
         sub: "ext-1",
         email: "carol@example.com",
         name: "alice",
-      }));
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(sampleUser);
     mockUpdate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
@@ -339,7 +379,13 @@ describe("auth middleware", () => {
   });
 
   it("P2002 以外の Prisma 既知エラーは握り潰さず例外として伝播する", async () => {
-    mockJwtVerify.mockResolvedValueOnce(jwtVerifyResult({ sub: "ext-4", email: "dave@example.com", name: "dave" }));
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({
+        sub: "ext-4",
+        email: "dave@example.com",
+        name: "dave",
+      }),
+    );
     mockFindUnique.mockResolvedValueOnce(null);
     mockCreate.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("connection lost", {

--- a/apps/api/test/me.test.ts
+++ b/apps/api/test/me.test.ts
@@ -37,6 +37,7 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
+import { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
 
@@ -44,20 +45,19 @@ const mockInvitationFindMany = vi.mocked(
   prisma.organizationInvitation.findMany,
 );
 
+// GET /me/invitations ハンドラの include 形に対応する型エイリアス。
+type InvitationListRow = Prisma.OrganizationInvitationGetPayload<{
+  include: {
+    organization: { select: { id: true; name: true } };
+    inviter: {
+      select: { id: true; name: true; displayName: true; email: true };
+    };
+  };
+}>;
+
 function buildInvitation(
-  overrides: Partial<{
-    id: string;
-    organizationId: string;
-    email: string;
-    invitedBy: string;
-    role: "admin" | "member";
-    expiresAt: Date;
-    status: "pending" | "accepted" | "expired";
-    createdAt: Date;
-    organization: { id: string; name: string };
-    inviter: { id: string; name: string; displayName: string; email: string };
-  }> = {},
-) {
+  overrides: Partial<InvitationListRow> = {},
+): InvitationListRow {
   return {
     id: "inv-1",
     organizationId: "org-1",
@@ -86,7 +86,7 @@ describe("GET /me/invitations", () => {
 
   it("認証ユーザーの email に一致する pending 非期限切れの招待を返す", async () => {
     const inv = buildInvitation();
-    mockInvitationFindMany.mockResolvedValue([inv] as never);
+    mockInvitationFindMany.mockResolvedValue([inv]);
 
     const res = await app.request("/me/invitations");
     expect(res.status).toBe(200);
@@ -109,7 +109,7 @@ describe("GET /me/invitations", () => {
   });
 
   it("認証ユーザーの email・pending・期限内で findMany が呼ばれる", async () => {
-    mockInvitationFindMany.mockResolvedValue([] as never);
+    mockInvitationFindMany.mockResolvedValue([]);
 
     await app.request("/me/invitations");
     expect(mockInvitationFindMany).toHaveBeenCalledTimes(1);
@@ -124,7 +124,7 @@ describe("GET /me/invitations", () => {
   });
 
   it("該当する招待が無い場合は空配列を返す", async () => {
-    mockInvitationFindMany.mockResolvedValue([] as never);
+    mockInvitationFindMany.mockResolvedValue([]);
 
     const res = await app.request("/me/invitations");
     expect(res.status).toBe(200);
@@ -133,7 +133,7 @@ describe("GET /me/invitations", () => {
   });
 
   it("organization と inviter を include して返す", async () => {
-    mockInvitationFindMany.mockResolvedValue([] as never);
+    mockInvitationFindMany.mockResolvedValue([]);
 
     await app.request("/me/invitations");
     const callArg = mockInvitationFindMany.mock.calls[0]?.[0];
@@ -143,7 +143,7 @@ describe("GET /me/invitations", () => {
   });
 
   it("複数件は createdAt 降順で返す（新しい招待を上に）", async () => {
-    mockInvitationFindMany.mockResolvedValue([] as never);
+    mockInvitationFindMany.mockResolvedValue([]);
 
     await app.request("/me/invitations");
     const callArg = mockInvitationFindMany.mock.calls[0]?.[0];

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -39,8 +39,24 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
+import { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type { TaskWithList } from "../src/lib/task-serialization.js";
+
+// ハンドラの include / select 形に対応する Prisma 型エイリアス。
+// GET /meetings/:id/tasks ハンドラ用: recurringMeeting.organizationId のみ
+type MeetingWithRecurringOrgId = Prisma.MeetingGetPayload<{
+  include: { recurringMeeting: { select: { organizationId: true } } };
+}>;
+// GET /meetings/:id ハンドラ用: recurringMeeting に organization (id/name) を含む詳細形
+type MeetingDetail = Prisma.MeetingGetPayload<{
+  include: {
+    recurringMeeting: {
+      include: { organization: { select: { id: true; name: true } } };
+    };
+  };
+}>;
 
 const mockFindUnique = vi.mocked(prisma.meeting.findUnique);
 const mockMembershipFindUnique = vi.mocked(
@@ -78,9 +94,9 @@ describe("GET /meetings/:id/tasks", () => {
     heldAt: new Date("2026-05-17T10:00:00Z"),
     recurringMeetingId: "rmtg-1",
     recurringMeeting: { organizationId: "org-1" },
-  };
+  } satisfies Partial<MeetingWithRecurringOrgId>;
 
-  const sampleListTask = {
+  const sampleListTask: TaskWithList = {
     id: "task-1",
     organizationId: "org-1",
     originMeetingId: "mtg-1",
@@ -111,14 +127,16 @@ describe("GET /meetings/:id/tasks", () => {
   };
 
   it("組織メンバーは origin タスクを 200 で取得できる", async () => {
-    mockFindUnique.mockResolvedValue(meetingWithRecurring as never);
+    mockFindUnique.mockResolvedValue(
+      meetingWithRecurring as MeetingWithRecurringOrgId,
+    );
     mockMembershipFindUnique.mockResolvedValue({
       userId: "user-1",
       organizationId: "org-1",
       role: "member",
       joinedAt: new Date(),
     });
-    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+    mockTaskFindMany.mockResolvedValue([sampleListTask]);
 
     const res = await app.request("/meetings/mtg-1/tasks");
     expect(res.status).toBe(200);
@@ -139,20 +157,23 @@ describe("GET /meetings/:id/tasks", () => {
   });
 
   it("単発会議（recurringMeetingId=null）は 404（組織判定不能）", async () => {
-    mockFindUnique.mockResolvedValue({
+    const standalone = {
       id: "mtg-x",
       title: "単発",
       heldAt: new Date(),
       recurringMeetingId: null,
       recurringMeeting: null,
-    } as never);
+    } satisfies Partial<MeetingWithRecurringOrgId>;
+    mockFindUnique.mockResolvedValue(standalone as MeetingWithRecurringOrgId);
     const res = await app.request("/meetings/mtg-x/tasks");
     expect(res.status).toBe(404);
     expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 
   it("組織非所属は 404", async () => {
-    mockFindUnique.mockResolvedValue(meetingWithRecurring as never);
+    mockFindUnique.mockResolvedValue(
+      meetingWithRecurring as MeetingWithRecurringOrgId,
+    );
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/meetings/mtg-1/tasks");
     expect(res.status).toBe(404);
@@ -182,10 +203,10 @@ describe("GET /meetings/:id", () => {
       organizationId: "org-1",
       organization: { id: "org-1", name: "ACME" },
     },
-  };
+  } satisfies Partial<MeetingDetail>;
 
   it("組織メンバーは 200 で詳細を取得できる", async () => {
-    mockFindUnique.mockResolvedValue(detailMeeting as never);
+    mockFindUnique.mockResolvedValue(detailMeeting as MeetingDetail);
     mockMembershipFindUnique.mockResolvedValue({
       userId: "user-1",
       organizationId: "org-1",
@@ -214,19 +235,20 @@ describe("GET /meetings/:id", () => {
   });
 
   it("単発会議（recurringMeetingId=null）は 404", async () => {
-    mockFindUnique.mockResolvedValue({
+    const standalone = {
       id: "mtg-x",
       title: "単発",
       heldAt: new Date(),
       recurringMeetingId: null,
       recurringMeeting: null,
-    } as never);
+    } satisfies Partial<MeetingDetail>;
+    mockFindUnique.mockResolvedValue(standalone as MeetingDetail);
     const res = await app.request("/meetings/mtg-x");
     expect(res.status).toBe(404);
   });
 
   it("組織非所属は 404", async () => {
-    mockFindUnique.mockResolvedValue(detailMeeting as never);
+    mockFindUnique.mockResolvedValue(detailMeeting as MeetingDetail);
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/meetings/mtg-1");
     expect(res.status).toBe(404);

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -68,9 +68,33 @@ function resetAuthUser() {
   authState.current = { ...authState.defaultUser };
 }
 
-import { Prisma } from "@prisma/client";
+import {
+  Prisma,
+  type OrganizationInvitation,
+  type OrganizationMembership,
+} from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+
+// ハンドラ側で利用している include 形に合わせた Prisma 型エイリアス。
+// findMany / findUnique のモック戻り値を `as never` で渡すのを避けるためのもの。
+// API ハンドラ側で include 句を変更したら、ここの型もコンパイル時に追従させる。
+type OrgWithSelfRoleMembership = Prisma.OrganizationGetPayload<{
+  include: { memberships: { select: { role: true } } };
+}>;
+type OrgWithRecurringMeetings = Prisma.OrganizationGetPayload<{
+  include: { recurringMeetings: true };
+}>;
+type MembershipWithUser = Prisma.OrganizationMembershipGetPayload<{
+  include: { user: true };
+}>;
+type InvitationWithInviter = Prisma.OrganizationInvitationGetPayload<{
+  include: {
+    inviter: {
+      select: { id: true; name: true; displayName: true; email: true };
+    };
+  };
+}>;
 
 const mockOrgFindMany = vi.mocked(prisma.organization.findMany);
 const mockOrgFindUnique = vi.mocked(prisma.organization.findUnique);
@@ -198,9 +222,10 @@ describe("GET /organizations", () => {
   it("200 と認証ユーザーが所属する組織一覧（自分の role を含む）を返す", async () => {
     // findMany は include: { memberships } で自分の membership を含めて取得し、
     // ハンドラ側で role を平坦化して返す。
-    mockOrgFindMany.mockResolvedValue([
+    const rows: OrgWithSelfRoleMembership[] = [
       { ...sampleOrg, memberships: [{ role: "owner" }] },
-    ] as never);
+    ];
+    mockOrgFindMany.mockResolvedValue(rows);
     const res = await app.request("/organizations");
     expect(res.status).toBe(200);
     const body = (await res.json()) as Array<{ id: string; role: string }>;
@@ -222,7 +247,7 @@ describe("GET /organizations", () => {
   });
 
   it("複数所属でそれぞれの role が含まれる", async () => {
-    mockOrgFindMany.mockResolvedValue([
+    const rows: OrgWithSelfRoleMembership[] = [
       { ...sampleOrg, id: "org-1", memberships: [{ role: "owner" }] },
       {
         ...sampleOrg,
@@ -230,7 +255,8 @@ describe("GET /organizations", () => {
         name: "別の組織",
         memberships: [{ role: "member" }],
       },
-    ] as never);
+    ];
+    mockOrgFindMany.mockResolvedValue(rows);
     const res = await app.request("/organizations");
     expect(res.status).toBe(200);
     const body = (await res.json()) as Array<{ id: string; role: string }>;
@@ -282,10 +308,11 @@ describe("GET /organizations/:id", () => {
       role: "owner",
       joinedAt: new Date("2026-05-01T00:00:00Z"),
     });
-    mockOrgFindUnique.mockResolvedValue({
+    const orgWithMeetings: OrgWithRecurringMeetings = {
       ...sampleOrg,
       recurringMeetings: sampleRecurringMeetings,
-    } as never);
+    };
+    mockOrgFindUnique.mockResolvedValue(orgWithMeetings);
 
     const res = await app.request("/organizations/org-1");
     expect(res.status).toBe(200);
@@ -323,10 +350,11 @@ describe("GET /organizations/:id", () => {
       role: "member",
       joinedAt: new Date("2026-05-01T00:00:00Z"),
     });
-    mockOrgFindUnique.mockResolvedValue({
+    const orgEmpty: OrgWithRecurringMeetings = {
       ...sampleOrg,
       recurringMeetings: [],
-    } as never);
+    };
+    mockOrgFindUnique.mockResolvedValue(orgEmpty);
 
     const res = await app.request("/organizations/org-1");
     expect(res.status).toBe(200);
@@ -341,10 +369,11 @@ describe("GET /organizations/:id", () => {
       role: "admin",
       joinedAt: new Date("2026-05-01T00:00:00Z"),
     });
-    mockOrgFindUnique.mockResolvedValue({
+    const orgEmpty: OrgWithRecurringMeetings = {
       ...sampleOrg,
       recurringMeetings: [],
-    } as never);
+    };
+    mockOrgFindUnique.mockResolvedValue(orgEmpty);
 
     const res = await app.request("/organizations/org-1");
     expect(res.status).toBe(200);
@@ -380,7 +409,7 @@ describe("GET /organizations/:id", () => {
 describe("GET /organizations/:id/members", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const sampleMemberships = [
+  const sampleMemberships: MembershipWithUser[] = [
     // 並び順検証用に、意図的に DB 順序を「想定の表示順」と逆にしておく。
     {
       userId: "user-3",
@@ -439,7 +468,7 @@ describe("GET /organizations/:id/members", () => {
       role: "owner",
       joinedAt: new Date("2026-05-01T00:00:00Z"),
     });
-    mockMembershipFindMany.mockResolvedValue(sampleMemberships as never);
+    mockMembershipFindMany.mockResolvedValue(sampleMemberships);
 
     const res = await app.request("/organizations/org-1/members");
     expect(res.status).toBe(200);
@@ -482,7 +511,7 @@ describe("GET /organizations/:id/members", () => {
       role: "member",
       joinedAt: new Date("2026-05-05T00:00:00Z"),
     });
-    mockMembershipFindMany.mockResolvedValue(sampleMemberships as never);
+    mockMembershipFindMany.mockResolvedValue(sampleMemberships);
 
     const res = await app.request("/organizations/org-1/members");
     expect(res.status).toBe(200);
@@ -502,7 +531,10 @@ describe("GET /organizations/:id/members", () => {
 describe("DELETE /organizations/:id/members/:userId", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  function membership(role: "owner" | "admin" | "member", userId = "user-1") {
+  function membership(
+    role: "owner" | "admin" | "member",
+    userId = "user-1",
+  ): OrganizationMembership {
     return {
       userId,
       organizationId: "org-1",
@@ -516,9 +548,7 @@ describe("DELETE /organizations/:id/members/:userId", () => {
     mockMembershipFindUnique
       .mockResolvedValueOnce(membership("owner", "user-1"))
       .mockResolvedValueOnce(membership("member", "user-2"));
-    mockMembershipDelete.mockResolvedValue(
-      membership("member", "user-2") as never,
-    );
+    mockMembershipDelete.mockResolvedValue(membership("member", "user-2"));
 
     const res = await app.request("/organizations/org-1/members/user-2", {
       method: "DELETE",
@@ -1015,14 +1045,14 @@ describe("GET /organizations/:id/invitations", () => {
     };
   }
 
-  const pendingInvitation = {
+  const pendingInvitation: InvitationWithInviter = {
     id: "inv-1",
     organizationId: "org-1",
     email: "bob@example.com",
     invitedBy: "user-1",
-    role: "member" as const,
+    role: "member",
     expiresAt: new Date("2026-05-26T00:00:00Z"),
-    status: "pending" as const,
+    status: "pending",
     createdAt: new Date("2026-05-19T00:00:00Z"),
     inviter: {
       id: "user-1",
@@ -1034,7 +1064,7 @@ describe("GET /organizations/:id/invitations", () => {
 
   it("owner は pending 招待一覧を取得できる", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
-    mockInvitationFindMany.mockResolvedValue([pendingInvitation] as never);
+    mockInvitationFindMany.mockResolvedValue([pendingInvitation]);
 
     const res = await app.request("/organizations/org-1/invitations");
     expect(res.status).toBe(200);
@@ -1054,7 +1084,7 @@ describe("GET /organizations/:id/invitations", () => {
 
   it("admin も pending 招待一覧を取得できる", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("admin"));
-    mockInvitationFindMany.mockResolvedValue([] as never);
+    mockInvitationFindMany.mockResolvedValue([]);
 
     const res = await app.request("/organizations/org-1/invitations");
     expect(res.status).toBe(200);
@@ -1078,7 +1108,7 @@ describe("GET /organizations/:id/invitations", () => {
 
   it("status=pending で findMany が呼ばれ、期限切れ判定は expired フィールドで返る", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
-    const expiredInvitation = {
+    const expiredInvitation: InvitationWithInviter = {
       ...pendingInvitation,
       id: "inv-expired",
       expiresAt: new Date("2026-05-10T00:00:00Z"),
@@ -1086,7 +1116,7 @@ describe("GET /organizations/:id/invitations", () => {
     mockInvitationFindMany.mockResolvedValue([
       pendingInvitation,
       expiredInvitation,
-    ] as never);
+    ]);
 
     const res = await app.request("/organizations/org-1/invitations");
     expect(res.status).toBe(200);
@@ -1128,24 +1158,24 @@ describe("DELETE /organizations/:id/invitations/:invitationId", () => {
     };
   }
 
-  const pendingInvitation = {
+  const pendingInvitation: OrganizationInvitation = {
     id: "inv-1",
     organizationId: "org-1",
     email: "bob@example.com",
     invitedBy: "user-1",
-    role: "member" as const,
+    role: "member",
     expiresAt: new Date("2026-05-26T00:00:00Z"),
-    status: "pending" as const,
+    status: "pending",
     createdAt: new Date("2026-05-19T00:00:00Z"),
   };
 
   it("owner は pending 招待を取消できる (204)", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
-    mockInvitationFindUnique.mockResolvedValue(pendingInvitation as never);
+    mockInvitationFindUnique.mockResolvedValue(pendingInvitation);
     mockInvitationUpdate.mockResolvedValue({
       ...pendingInvitation,
       status: "revoked",
-    } as never);
+    });
 
     const res = await app.request("/organizations/org-1/invitations/inv-1", {
       method: "DELETE",
@@ -1159,11 +1189,11 @@ describe("DELETE /organizations/:id/invitations/:invitationId", () => {
 
   it("admin も pending 招待を取消できる", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("admin"));
-    mockInvitationFindUnique.mockResolvedValue(pendingInvitation as never);
+    mockInvitationFindUnique.mockResolvedValue(pendingInvitation);
     mockInvitationUpdate.mockResolvedValue({
       ...pendingInvitation,
       status: "revoked",
-    } as never);
+    });
 
     const res = await app.request("/organizations/org-1/invitations/inv-1", {
       method: "DELETE",
@@ -1198,7 +1228,7 @@ describe("DELETE /organizations/:id/invitations/:invitationId", () => {
     mockInvitationFindUnique.mockResolvedValue({
       ...pendingInvitation,
       organizationId: "other-org",
-    } as never);
+    });
 
     const res = await app.request("/organizations/org-1/invitations/inv-1", {
       method: "DELETE",
@@ -1212,7 +1242,7 @@ describe("DELETE /organizations/:id/invitations/:invitationId", () => {
     mockInvitationFindUnique.mockResolvedValue({
       ...pendingInvitation,
       status: "accepted",
-    } as never);
+    });
 
     const res = await app.request("/organizations/org-1/invitations/inv-1", {
       method: "DELETE",
@@ -1226,7 +1256,7 @@ describe("DELETE /organizations/:id/invitations/:invitationId", () => {
     mockInvitationFindUnique.mockResolvedValue({
       ...pendingInvitation,
       status: "revoked",
-    } as never);
+    });
 
     const res = await app.request("/organizations/org-1/invitations/inv-1", {
       method: "DELETE",

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -75,6 +75,7 @@ import {
 } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type { TaskWithList } from "../src/lib/task-serialization.js";
 
 // ハンドラ側で利用している include 形に合わせた Prisma 型エイリアス。
 // findMany / findUnique のモック戻り値を `as never` で渡すのを避けるためのもの。
@@ -93,6 +94,18 @@ type InvitationWithInviter = Prisma.OrganizationInvitationGetPayload<{
     inviter: {
       select: { id: true; name: true; displayName: true; email: true };
     };
+  };
+}>;
+// GET /organizations/:id/next-meetings の findMany が select で取得する形。
+// ハンドラの select 句と一致させる必要がある（ズレるとここで型エラーになる）。
+type NextMeetingRow = Prisma.MeetingGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    heldAt: true;
+    estimatedDurationMinutes: true;
+    recurringMeetingId: true;
+    recurringMeeting: { select: { name: true } };
   };
 }>;
 
@@ -1485,7 +1498,7 @@ describe("GET /organizations/:id/tasks", () => {
     };
   }
 
-  const sampleListTask = {
+  const sampleListTask: TaskWithList = {
     id: "task-1",
     organizationId: "org-1",
     originMeetingId: null,
@@ -1517,7 +1530,7 @@ describe("GET /organizations/:id/tasks", () => {
 
   it("組織メンバーは 200 でタスク一覧を取得できる", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
-    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+    mockTaskFindMany.mockResolvedValue([sampleListTask]);
 
     const res = await app.request("/organizations/org-1/tasks");
     expect(res.status).toBe(200);
@@ -1570,7 +1583,7 @@ describe("GET /organizations/:id/next-meetings", () => {
   }
 
   // findMany が select 句で返す形（recurringMeeting がネスト）
-  const sampleMeetingRows = [
+  const sampleMeetingRows: NextMeetingRow[] = [
     {
       id: "mtg-near",
       title: "週次定例 2026-05-20",
@@ -1591,7 +1604,7 @@ describe("GET /organizations/:id/next-meetings", () => {
 
   it("組織メンバーは 200 で upcoming な会議を limit 件まで取得できる", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
-    mockMeetingFindMany.mockResolvedValue(sampleMeetingRows as never);
+    mockMeetingFindMany.mockResolvedValue(sampleMeetingRows);
 
     const res = await app.request("/organizations/org-1/next-meetings?limit=5");
     expect(res.status).toBe(200);
@@ -1706,16 +1719,15 @@ describe("GET /organizations/:id/next-meetings", () => {
     // 防御的ケース: include の関係フィルタにより通常は発生しないが、
     // recurringMeeting 側が null の場合に NPE を起こさないことを担保する。
     mockMembershipFindUnique.mockResolvedValue(membership());
-    mockMeetingFindMany.mockResolvedValue([
-      {
-        id: "mtg-x",
-        title: "edge",
-        heldAt: new Date("2026-05-20T01:00:00Z"),
-        estimatedDurationMinutes: null,
-        recurringMeetingId: null,
-        recurringMeeting: null,
-      },
-    ] as never);
+    const edgeRow: NextMeetingRow = {
+      id: "mtg-x",
+      title: "edge",
+      heldAt: new Date("2026-05-20T01:00:00Z"),
+      estimatedDurationMinutes: null,
+      recurringMeetingId: null,
+      recurringMeeting: null,
+    };
+    mockMeetingFindMany.mockResolvedValue([edgeRow]);
 
     const res = await app.request("/organizations/org-1/next-meetings?limit=1");
     expect(res.status).toBe(200);

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -55,8 +55,28 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
+import { Prisma, type RecurringMeeting } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type { TaskWithList } from "../src/lib/task-serialization.js";
+
+// ハンドラ側で利用している include / select 形に合わせた Prisma 型エイリアス。
+// findMany / findUnique のモック戻り値を `as never` で渡すのを避けるため。
+type RecurringMeetingListRow = Prisma.RecurringMeetingGetPayload<{
+  include: { _count: { select: { members: true } } };
+}>;
+type RecurringMeetingWithMembers = Prisma.RecurringMeetingGetPayload<{
+  include: { members: { include: { user: true } } };
+}>;
+type MeetingListRow = Prisma.MeetingGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    heldAt: true;
+    estimatedDurationMinutes: true;
+    recurringMeetingId: true;
+  };
+}>;
 
 const mockMembershipFindUnique = vi.mocked(
   prisma.organizationMembership.findUnique,
@@ -80,7 +100,7 @@ function membership(role: "owner" | "admin" | "member") {
   };
 }
 
-const sampleRecurring = {
+const sampleRecurring: RecurringMeeting = {
   id: "rmtg-1",
   organizationId: "org-1",
   name: "週次定例",
@@ -282,7 +302,7 @@ describe("POST /organizations/:id/meetings", () => {
 describe("GET /organizations/:id/meetings", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const listSample = [
+  const listSample: RecurringMeetingListRow[] = [
     {
       ...sampleRecurring,
       id: "rmtg-2",
@@ -299,7 +319,7 @@ describe("GET /organizations/:id/meetings", () => {
 
   it("組織メンバーは定例一覧を取得でき、_count.members を含む", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
-    mockRecurringFindMany.mockResolvedValue(listSample as never);
+    mockRecurringFindMany.mockResolvedValue(listSample);
 
     const res = await app.request("/organizations/org-1/meetings");
     expect(res.status).toBe(200);
@@ -321,7 +341,7 @@ describe("GET /organizations/:id/meetings", () => {
 
   it("定例が無い組織は空配列を返す", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
-    mockRecurringFindMany.mockResolvedValue([] as never);
+    mockRecurringFindMany.mockResolvedValue([]);
     const res = await app.request("/organizations/org-1/meetings");
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([]);
@@ -368,10 +388,11 @@ describe("GET /recurring-meetings/:id", () => {
   ];
 
   it("組織メンバーは定例詳細を取得でき、メンバー一覧を owner→member 順で返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue({
+    const withMembers: RecurringMeetingWithMembers = {
       ...sampleRecurring,
       members: sampleMembers,
-    } as never);
+    };
+    mockRecurringFindUnique.mockResolvedValue(withMembers);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
 
     const res = await app.request("/recurring-meetings/rmtg-1");
@@ -400,10 +421,11 @@ describe("GET /recurring-meetings/:id", () => {
 
   it("定例所属組織のメンバーでない場合は 404 を返す", async () => {
     // 組織の存在自体を露出させないため、所属していない場合は 404 で統一する。
-    mockRecurringFindUnique.mockResolvedValue({
+    const withoutMembers: RecurringMeetingWithMembers = {
       ...sampleRecurring,
       members: [],
-    } as never);
+    };
+    mockRecurringFindUnique.mockResolvedValue(withoutMembers);
     mockMembershipFindUnique.mockResolvedValue(null);
 
     const res = await app.request("/recurring-meetings/rmtg-1");
@@ -415,12 +437,12 @@ describe("PATCH /recurring-meetings/:id", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("組織メンバーは定例を編集できる（name のみ）", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockRecurringUpdate.mockResolvedValue({
       ...sampleRecurring,
       name: "新しい定例名",
-    } as never);
+    });
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
       method: "PATCH",
@@ -435,12 +457,12 @@ describe("PATCH /recurring-meetings/:id", () => {
   });
 
   it("scheduleCron も編集できる", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockRecurringUpdate.mockResolvedValue({
       ...sampleRecurring,
       scheduleCron: "0 14 * * 5",
-    } as never);
+    });
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
       method: "PATCH",
@@ -455,12 +477,12 @@ describe("PATCH /recurring-meetings/:id", () => {
   });
 
   it("defaultDurationMinutes も編集できる", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockRecurringUpdate.mockResolvedValue({
       ...sampleRecurring,
       defaultDurationMinutes: 90,
-    } as never);
+    });
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
       method: "PATCH",
@@ -534,7 +556,7 @@ describe("PATCH /recurring-meetings/:id", () => {
   });
 
   it("組織メンバーでなければ 404 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(null);
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
@@ -551,7 +573,7 @@ describe("DELETE /recurring-meetings/:id", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("MeetingMember.owner は削除でき、204 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockMeetingMemberFindUnique.mockResolvedValue({
       recurringMeetingId: "rmtg-1",
@@ -559,7 +581,7 @@ describe("DELETE /recurring-meetings/:id", () => {
       role: "owner",
       joinedAt: new Date("2026-05-06T00:00:00Z"),
     });
-    mockRecurringDelete.mockResolvedValue(sampleRecurring as never);
+    mockRecurringDelete.mockResolvedValue(sampleRecurring);
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
       method: "DELETE",
@@ -573,7 +595,7 @@ describe("DELETE /recurring-meetings/:id", () => {
   });
 
   it("MeetingMember.member は 403 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockMeetingMemberFindUnique.mockResolvedValue({
       recurringMeetingId: "rmtg-1",
@@ -590,7 +612,7 @@ describe("DELETE /recurring-meetings/:id", () => {
   });
 
   it("組織メンバーだが MeetingMember 未参加なら 403 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
     mockMeetingMemberFindUnique.mockResolvedValue(null);
 
@@ -602,7 +624,7 @@ describe("DELETE /recurring-meetings/:id", () => {
   });
 
   it("組織メンバーでなければ 404 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(null);
 
     const res = await app.request("/recurring-meetings/rmtg-1", {
@@ -641,12 +663,12 @@ describe("GET /recurring-meetings/:id/meetings", () => {
       estimatedDurationMinutes: 60,
       recurringMeetingId: "rmtg-1",
     },
-  ];
+  ] satisfies MeetingListRow[];
 
   it("組織メンバーは配下の Meeting を heldAt 降順で取得できる", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
-    mockMeetingFindMany.mockResolvedValue(sampleMeetings as never);
+    mockMeetingFindMany.mockResolvedValue(sampleMeetings);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings");
     expect(res.status).toBe(200);
@@ -677,9 +699,9 @@ describe("GET /recurring-meetings/:id/meetings", () => {
   });
 
   it("配下に Meeting が無ければ空配列を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("owner"));
-    mockMeetingFindMany.mockResolvedValue([] as never);
+    mockMeetingFindMany.mockResolvedValue([]);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings");
     expect(res.status).toBe(200);
@@ -698,7 +720,7 @@ describe("GET /recurring-meetings/:id/meetings", () => {
 
   it("定例所属組織のメンバーでない場合は 404 を返す", async () => {
     // 組織存在を露出させないため、所属していない場合も 404 で統一する。
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(null);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings");
@@ -710,7 +732,7 @@ describe("GET /recurring-meetings/:id/meetings", () => {
 describe("POST /recurring-meetings/:id/meetings", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const createdMeeting = {
+  const createdMeeting: MeetingListRow = {
     id: "mtg-new",
     title: "週次定例 2026-05-20",
     heldAt: new Date("2026-05-20T01:00:00Z"),
@@ -719,12 +741,12 @@ describe("POST /recurring-meetings/:id/meetings", () => {
   };
 
   it("組織メンバーは Meeting を作成でき、estimatedDurationMinutes 指定値を採用する", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
     mockMeetingCreate.mockResolvedValue({
       ...createdMeeting,
       estimatedDurationMinutes: 90,
-    } as never);
+    } satisfies MeetingListRow);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
       method: "POST",
@@ -765,9 +787,9 @@ describe("POST /recurring-meetings/:id/meetings", () => {
 
   it("estimatedDurationMinutes 未指定なら定例の defaultDurationMinutes を採用する", async () => {
     // sampleRecurring.defaultDurationMinutes は 60。
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
-    mockMeetingCreate.mockResolvedValue(createdMeeting as never);
+    mockMeetingCreate.mockResolvedValue(createdMeeting);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
       method: "POST",
@@ -793,9 +815,9 @@ describe("POST /recurring-meetings/:id/meetings", () => {
     // JSON では undefined を表現できないため、クライアントが「未指定」を null で
     // 送るのは一般的な慣習。スキーマがそれを拒否せず、ハンドラ側の ?? フォールバックに
     // 載せて defaultDurationMinutes (60) を採用することを検証する。
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(membership("member"));
-    mockMeetingCreate.mockResolvedValue(createdMeeting as never);
+    mockMeetingCreate.mockResolvedValue(createdMeeting);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
       method: "POST",
@@ -888,7 +910,7 @@ describe("POST /recurring-meetings/:id/meetings", () => {
   });
 
   it("組織メンバーでなければ 404 を返す", async () => {
-    mockRecurringFindUnique.mockResolvedValue(sampleRecurring as never);
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
     mockMembershipFindUnique.mockResolvedValue(null);
 
     const res = await app.request("/recurring-meetings/rmtg-1/meetings", {
@@ -907,7 +929,7 @@ describe("POST /recurring-meetings/:id/meetings", () => {
 describe("GET /recurring-meetings/:id/tasks", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const sampleListTask = {
+  const sampleListTask: TaskWithList = {
     id: "task-1",
     organizationId: "org-1",
     originMeetingId: null,
@@ -947,7 +969,7 @@ describe("GET /recurring-meetings/:id/tasks", () => {
       role: "member",
       joinedAt: new Date(),
     });
-    mockTaskFindMany.mockResolvedValue([sampleListTask] as never);
+    mockTaskFindMany.mockResolvedValue([sampleListTask]);
 
     const res = await app.request("/recurring-meetings/rmtg-1/tasks");
     expect(res.status).toBe(200);

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -61,8 +61,19 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
+import { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type {
+  TaskWithDetail,
+  TaskWithList,
+} from "../src/lib/task-serialization.js";
+
+// ハンドラ側で利用している include / select 形に合わせた Prisma 型エイリアス。
+// validateOriginMeetingInOrg ヘルパーが使う meeting.findUnique 形に対応。
+type MeetingWithRecurringOrgId = Prisma.MeetingGetPayload<{
+  include: { recurringMeeting: { select: { organizationId: true } } };
+}>;
 
 const mockMembershipFindUnique = vi.mocked(
   prisma.organizationMembership.findUnique,
@@ -85,7 +96,7 @@ function membership(role: "owner" | "admin" | "member" = "member") {
   };
 }
 
-const sampleTask = {
+const sampleTask: TaskWithDetail = {
   id: "task-1",
   organizationId: "org-1",
   originMeetingId: null,
@@ -169,17 +180,14 @@ describe("POST /tasks", () => {
       membership(),
       { ...membership(), userId: "user-2" },
     ]);
-    // attached 定例が同一組織に属することの検証
-    mockRecurringFindMany.mockResolvedValue([
-      { id: "rmtg-1", organizationId: "org-1" },
-      { id: "rmtg-2", organizationId: "org-1" },
-    ] as never);
+    // attached 定例が同一組織に属することの検証 (ハンドラの select は { id: true } のみ)
+    mockRecurringFindMany.mockResolvedValue([{ id: "rmtg-1" }, { id: "rmtg-2" }]);
     // originMeeting の組織判定（紐付く recurringMeeting 経由）
     mockMeetingFindUnique.mockResolvedValue({
       id: "mtg-1",
       recurringMeetingId: "rmtg-1",
       recurringMeeting: { organizationId: "org-1" },
-    } as never);
+    } as MeetingWithRecurringOrgId);
     mockTransaction.mockResolvedValue({
       ...sampleTask,
       originMeetingId: "mtg-1",
@@ -278,10 +286,8 @@ describe("POST /tasks", () => {
 
   it("recurringMeeting に他組織のものが混在する場合は 400", async () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
-    // 指定した 2 件のうち 1 件が他組織
-    mockRecurringFindMany.mockResolvedValue([
-      { id: "rmtg-1", organizationId: "org-1" },
-    ] as never);
+    // 指定した 2 件のうち 1 件が他組織 (ハンドラの select は { id: true } のみ)
+    mockRecurringFindMany.mockResolvedValue([{ id: "rmtg-1" }]);
 
     const res = await app.request("/tasks", {
       method: "POST",
@@ -303,7 +309,7 @@ describe("POST /tasks", () => {
       id: "mtg-1",
       recurringMeetingId: "rmtg-other",
       recurringMeeting: { organizationId: "org-other" },
-    } as never);
+    } as MeetingWithRecurringOrgId);
 
     const res = await app.request("/tasks", {
       method: "POST",
@@ -324,7 +330,7 @@ describe("POST /tasks", () => {
       id: "mtg-1",
       recurringMeetingId: null,
       recurringMeeting: null,
-    } as never);
+    } as MeetingWithRecurringOrgId);
 
     const res = await app.request("/tasks", {
       method: "POST",
@@ -381,7 +387,7 @@ describe("GET /tasks/:id", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("組織メンバーは関連を含む 200 を取得できる", async () => {
-    mockTaskFindUnique.mockResolvedValue({
+    const taskWithAttachments: TaskWithDetail = {
       ...sampleTask,
       assignees: [
         {
@@ -396,7 +402,8 @@ describe("GET /tasks/:id", () => {
       recurringMeetings: [
         { recurringMeeting: { id: "rmtg-1", name: "週次定例" } },
       ],
-    } as never);
+    } as TaskWithDetail;
+    mockTaskFindUnique.mockResolvedValue(taskWithAttachments);
     mockMembershipFindUnique.mockResolvedValue(membership());
 
     const res = await app.request("/tasks/task-1");
@@ -420,7 +427,7 @@ describe("GET /tasks/:id", () => {
   });
 
   it("タスク所属組織の非メンバーは 404", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/tasks/task-1");
     expect(res.status).toBe(404);
@@ -433,12 +440,12 @@ describe("PATCH /tasks/:id", () => {
   it("title 更新が 200、version は updateMany でインクリメントされる", async () => {
     // 認可は requireTaskAccess の findUnique + membership で通す
     mockTaskFindUnique
-      .mockResolvedValueOnce(sampleTask as never) // requireTaskAccess の初回呼び出し
+      .mockResolvedValueOnce(sampleTask) // requireTaskAccess の初回呼び出し
       .mockResolvedValueOnce({
         ...sampleTask,
         title: "更新後",
         version: 1,
-      } as never); // 再取得
+      }); // 再取得
     mockMembershipFindUnique.mockResolvedValue(membership());
     mockTransaction.mockImplementation(async (fn) => {
       const tx = {
@@ -484,7 +491,7 @@ describe("PATCH /tasks/:id", () => {
   });
 
   it("version 不一致は 409", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(membership());
     mockTransaction.mockImplementation(async (fn) => {
       const tx = {
@@ -510,7 +517,7 @@ describe("PATCH /tasks/:id", () => {
   });
 
   it("status を todo→in_progress に変更できる", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(membership());
     mockTransaction.mockImplementation(async (fn) => {
       const tx = {
@@ -576,7 +583,7 @@ describe("PATCH /tasks/:id", () => {
   });
 
   it("assigneeUserIds の置換で他組織混入は 400", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(membership());
     // 2 名指定したが 1 名しか組織メンバーとして見つからない
     mockMembershipFindMany.mockResolvedValue([membership()]);
@@ -595,7 +602,7 @@ describe("PATCH /tasks/:id", () => {
   });
 
   it("assigneeUserIds:[] は全削除を行う", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(membership());
     let deletedAssignees = false;
     mockTransaction.mockImplementation(async (fn) => {
@@ -639,7 +646,7 @@ describe("GET /tasks/me", () => {
       ],
       recurringMeetings: [],
     };
-    mockTaskFindMany.mockResolvedValue([listTask] as never);
+    mockTaskFindMany.mockResolvedValue([listTask]);
 
     const res = await app.request("/tasks/me");
     expect(res.status).toBe(200);
@@ -744,10 +751,10 @@ describe("DELETE /tasks/:id", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("組織メンバーは 204 でタスクを削除できる", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(membership());
     const mockTaskDelete = vi.mocked(prisma.task.delete);
-    mockTaskDelete.mockResolvedValue(sampleTask as never);
+    mockTaskDelete.mockResolvedValue(sampleTask);
 
     const res = await app.request("/tasks/task-1", { method: "DELETE" });
     expect(res.status).toBe(204);
@@ -761,7 +768,7 @@ describe("DELETE /tasks/:id", () => {
   });
 
   it("非メンバーは 404", async () => {
-    mockTaskFindUnique.mockResolvedValue(sampleTask as never);
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/tasks/task-1", { method: "DELETE" });
     expect(res.status).toBe(404);

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -64,10 +64,7 @@ vi.mock("../src/middleware/auth.js", () => ({
 import { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
-import type {
-  TaskWithDetail,
-  TaskWithList,
-} from "../src/lib/task-serialization.js";
+import type { TaskWithDetail } from "../src/lib/task-serialization.js";
 
 // ハンドラ側で利用している include / select 形に合わせた Prisma 型エイリアス。
 // validateOriginMeetingInOrg ヘルパーが使う meeting.findUnique 形に対応。
@@ -181,7 +178,10 @@ describe("POST /tasks", () => {
       { ...membership(), userId: "user-2" },
     ]);
     // attached 定例が同一組織に属することの検証 (ハンドラの select は { id: true } のみ)
-    mockRecurringFindMany.mockResolvedValue([{ id: "rmtg-1" }, { id: "rmtg-2" }]);
+    mockRecurringFindMany.mockResolvedValue([
+      { id: "rmtg-1" },
+      { id: "rmtg-2" },
+    ]);
     // originMeeting の組織判定（紐付く recurringMeeting 経由）
     mockMeetingFindUnique.mockResolvedValue({
       id: "mtg-1",

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -9,7 +9,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
-import { useOrganizationsQuery } from "@/features/organizations/hooks/useOrganizationsQuery";
+import {
+  type OrganizationListItem,
+  useOrganizationsQuery,
+} from "@/features/organizations/hooks/useOrganizationsQuery";
 import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
 import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
 import {
@@ -236,8 +239,8 @@ function OrganizationSelector({
   onOpenCreateDialog,
 }: {
   isLoading: boolean;
-  orgs: Organization[] | null;
-  currentOrg: Organization | null;
+  orgs: OrganizationListItem[] | null;
+  currentOrg: OrganizationListItem | null;
   currentId: string | null;
   onSelect: (id: string) => void;
   onOpenCreateDialog: () => void;

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -9,16 +9,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
-import type { Organization } from "@/features/organizations/types";
+import { useOrganizationsQuery } from "@/features/organizations/hooks/useOrganizationsQuery";
 import { CreateRecurringMeetingDialog } from "@/features/recurring-meetings/components/CreateRecurringMeetingDialog";
 import { useOrganizationMeetings } from "@/features/recurring-meetings/hooks/useOrganizationMeetings";
-import { api, authHeaders } from "@/lib/api";
 import {
   clearCurrentOrganizationIdAtom,
   currentOrganizationIdAtom,
   setCurrentOrganizationIdAtom,
 } from "@/lib/currentOrganization";
-import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
@@ -31,23 +29,6 @@ import {
   SettingsIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-
-// 組織一覧フェッチ。クエリキー / fetcher は organizations.index.tsx と
-// 完全に同一にしておくことで、TanStack Query のキャッシュを共有する。
-// 結果として、一覧ページや作成ダイアログで invalidate された変更が
-// サイドバーにも即座に反映される。
-function useOrganizations() {
-  return useQuery<Organization[]>({
-    queryKey: ["organizations"],
-    queryFn: async () => {
-      const res = await api.organizations.$get(undefined, authHeaders());
-      if (!res.ok) {
-        throw new Error(`Failed to fetch organizations: ${res.status}`);
-      }
-      return (await res.json()) as Organization[];
-    },
-  });
-}
 
 // 組織アバター用の頭文字を取り出す。null/空文字を安全に扱う。
 function initial(name: string | null | undefined): string {
@@ -63,7 +44,9 @@ function initial(name: string | null | undefined): string {
 const ORGANIZATION_DETAIL_PATH = /^\/organizations\/[^/]+/;
 
 export function Sidebar() {
-  const { data: orgs, isLoading } = useOrganizations();
+  // useOrganizationsQuery は organizations.index.tsx と同じクエリキー
+  // (["organizations"]) を使うため、一方の invalidate が両方に反映される。
+  const { data: orgs, isLoading } = useOrganizationsQuery();
   const currentId = useAtomValue(currentOrganizationIdAtom);
   const setCurrentId = useSetAtom(setCurrentOrganizationIdAtom);
   const clearCurrentId = useSetAtom(clearCurrentOrganizationIdAtom);

--- a/apps/web/src/features/organizations/hooks/useOrganizationsQuery.ts
+++ b/apps/web/src/features/organizations/hooks/useOrganizationsQuery.ts
@@ -1,0 +1,28 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import type { InferResponseType } from "hono/client";
+
+// Hono RPC の GET /organizations 200 レスポンス型をそのまま使う。
+// API ハンドラ側の戻り値が変わるとここで型エラーが顕在化するため、
+// フロントの as Organization[] キャストを避け型安全性を保てる。
+// 日時フィールドは Hono RPC のシリアライズで string になる点に注意。
+export type OrganizationListItem = InferResponseType<
+  typeof api.organizations.$get,
+  200
+>[number];
+
+// 組織一覧クエリの共通フック。
+// Sidebar と /organizations 一覧ページで同一のクエリキー・fetcher を共有することで
+// 一方の invalidate がもう一方にも反映される。重複した queryFn の保守を避ける目的。
+export function useOrganizationsQuery() {
+  return useQuery<OrganizationListItem[]>({
+    queryKey: ["organizations"],
+    queryFn: async () => {
+      const res = await api.organizations.$get(undefined, authHeaders());
+      if (!res.ok) {
+        throw new Error(`Failed to fetch organizations: ${res.status}`);
+      }
+      return await res.json();
+    },
+  });
+}

--- a/apps/web/src/routes/organizations.index.tsx
+++ b/apps/web/src/routes/organizations.index.tsx
@@ -6,16 +6,17 @@ import {
 } from "@/components/ui/card";
 import { CreateOrganizationDialog } from "@/features/organizations/components/CreateOrganizationDialog";
 import { RoleBadge } from "@/features/organizations/components/RoleBadge";
-import type { Organization } from "@/features/organizations/types";
-import { api, authHeaders } from "@/lib/api";
-import { useQuery } from "@tanstack/react-query";
+import {
+  type OrganizationListItem,
+  useOrganizationsQuery,
+} from "@/features/organizations/hooks/useOrganizationsQuery";
 import { Link, createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/organizations/")({
   component: OrganizationsPage,
 });
 
-function OrganizationCard({ org }: { org: Organization }) {
+function OrganizationCard({ org }: { org: OrganizationListItem }) {
   return (
     <Link
       to="/organizations/$id"
@@ -38,25 +39,11 @@ function OrganizationCard({ org }: { org: Organization }) {
 }
 
 export function OrganizationsPage() {
-  const {
-    data: orgs = [],
-    isLoading,
-    isError,
-  } = useQuery<Organization[]>({
-    queryKey: ["organizations"],
-    queryFn: async () => {
-      // Hono RPC client は第 2 引数で headers を受け取る。第 1 引数の input に
-      // headers を入れても無視されるため、authHeaders() は必ず第 2 引数へ渡す。
-      const res = await api.organizations.$get(undefined, authHeaders());
-      // 認証失敗などで API が { error } を返した場合、配列でないものを
-      // そのまま data に格納すると orgs.map() で落ちるため、ここで弾く。
-      if (!res.ok) {
-        throw new Error(`Failed to fetch organizations: ${res.status}`);
-      }
-      // Hono RPC のレスポンス型は date が string なので as でキャストする
-      return (await res.json()) as Organization[];
-    },
-  });
+  // クエリキー・fetcher は Sidebar と共通フックで共有しており、
+  // 一方の invalidate がもう一方にも反映される。
+  // 認証失敗などで API が { error } を返した場合、queryFn 内で throw され
+  // isError 経路に流れるため、orgs.map() で落ちる事故は起きない。
+  const { data: orgs = [], isLoading, isError } = useOrganizationsQuery();
 
   return (
     <section

--- a/apps/web/src/test/helpers/mockJson.ts
+++ b/apps/web/src/test/helpers/mockJson.ts
@@ -1,0 +1,12 @@
+// hono/client の ClientResponse 型はメソッドが多く構築不可能なため、テストでは
+// 最低限のフィールド (ok / status / json) だけ持つスタブを返す。
+// as never キャストをこのヘルパー 1 箇所に集約することで、各テストファイルで
+// 同じ mockJson を重複定義する必要がなくなる。
+// vi.mocked(...).mockResolvedValue(mockJson(data)) の形で使う。
+export function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
+}

--- a/apps/web/src/test/helpers/organizationDetail.tsx
+++ b/apps/web/src/test/helpers/organizationDetail.tsx
@@ -57,15 +57,10 @@ export const sampleMembers: Member[] = [
   },
 ];
 
-// hono/client のレスポンス形を最小限で再現するヘルパー。
-// $get / $post / $patch / $delete の戻り値として渡せる。
-export function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+// hono/client のレスポンス形を最小限で再現するヘルパーは helpers/mockJson から
+// 再エクスポートする (組織詳細系テストが従来どおり helpers/organizationDetail
+// から import できるよう互換のために残す)。
+export { mockJson } from "./mockJson";
 
 export function renderDetail(opts?: {
   id?: string;

--- a/apps/web/src/test/invitations.test.tsx
+++ b/apps/web/src/test/invitations.test.tsx
@@ -56,13 +56,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 type Invitation = {
   id: string;

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -56,13 +56,7 @@ vi.mock("@tanstack/react-router", async () => {
 import { api } from "@/lib/api";
 import { MeetingDetailView } from "../routes/meetings.$id";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const detail: MeetingDetail = {
   id: "mtg-1",

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -50,10 +50,15 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { api } from "@/lib/api";
 
-// hono/client のレスポンス型が複雑なため、モックの戻り値はヘルパー経由でキャスト。
-// queryFn 側で res.ok チェックを行うため ok: true / status: 200 も埋める。
-function mockJson<T>(data: T) {
-  return { ok: true, status: 200, json: async () => data } as never;
+// hono/client の ClientResponse 型はメソッドが多く構築不可能なため、ヘルパー
+// 内部 1 箇所だけ `as never` を残し、呼び出し側にキャストを散らさない方針。
+// queryFn 側で res.ok チェックを行うため ok / status を埋め、json は data を返す。
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
 }
 
 type Organization = {
@@ -143,11 +148,9 @@ describe("組織一覧表示", () => {
     // 認証失敗などで API が配列でない { error } を返すケース。
     // queryFn 側で弾かないと orgs.map() が落ちるため、UI クラッシュではなく
     // エラー表示にフォールバックすることを保証する。
-    vi.mocked(api.organizations.$get).mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({ error: "認証が必要です" }),
-    } as never);
+    vi.mocked(api.organizations.$get).mockResolvedValue(
+      mockJson({ error: "認証が必要です" }, 401),
+    );
 
     renderWithQuery(<OrganizationsPage />);
 
@@ -274,11 +277,9 @@ describe("組織作成モーダル", () => {
     // 非 2xx を success として扱うと「作成したつもりが実は失敗」のサイレント
     // 失敗を生む。エラー表示が出て Dialog が閉じないことを保証する。
     const user = userEvent.setup();
-    vi.mocked(api.organizations.$post).mockResolvedValue({
-      ok: false,
-      status: 400,
-      json: async () => ({ error: "bad request" }),
-    } as never);
+    vi.mocked(api.organizations.$post).mockResolvedValue(
+      mockJson({ error: "bad request" }, 400),
+    );
 
     renderWithQuery(<OrganizationsPage />);
 

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -50,16 +50,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { api } from "@/lib/api";
 
-// hono/client の ClientResponse 型はメソッドが多く構築不可能なため、ヘルパー
-// 内部 1 箇所だけ `as never` を残し、呼び出し側にキャストを散らさない方針。
-// queryFn 側で res.ok チェックを行うため ok / status を埋め、json は data を返す。
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 type Organization = {
   id: string;

--- a/apps/web/src/test/recurring-meetings.$id.test.tsx
+++ b/apps/web/src/test/recurring-meetings.$id.test.tsx
@@ -61,13 +61,7 @@ vi.mock("@tanstack/react-router", async () => {
 import { api } from "@/lib/api";
 import { RecurringMeetingDetailView } from "../routes/recurring-meetings.$id";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const detail = {
   id: "rmtg-1",

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -96,15 +96,7 @@ const mockOrgs: Organization[] = [
   },
 ];
 
-// hono/client の ClientResponse 型はメソッドが多く構築不可能なため、ヘルパー
-// 内部 1 箇所だけ `as never` を残し、呼び出し側にキャストを散らさない方針。
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 function renderSidebar() {
   const client = new QueryClient({

--- a/apps/web/src/test/sidebar.test.tsx
+++ b/apps/web/src/test/sidebar.test.tsx
@@ -96,8 +96,14 @@ const mockOrgs: Organization[] = [
   },
 ];
 
-function mockJson<T>(data: T) {
-  return { ok: true, status: 200, json: async () => data } as never;
+// hono/client の ClientResponse 型はメソッドが多く構築不可能なため、ヘルパー
+// 内部 1 箇所だけ `as never` を残し、呼び出し側にキャストを散らさない方針。
+function mockJson<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as never;
 }
 
 function renderSidebar() {

--- a/apps/web/src/test/tasks.assigneeFilter.test.tsx
+++ b/apps/web/src/test/tasks.assigneeFilter.test.tsx
@@ -19,13 +19,7 @@ vi.mock("@/lib/api", () => ({
 import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const members: Member[] = [
   {

--- a/apps/web/src/test/tasks.createDialog.test.tsx
+++ b/apps/web/src/test/tasks.createDialog.test.tsx
@@ -21,13 +21,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 beforeEach(() => {
   vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(

--- a/apps/web/src/test/tasks.deleteDialog.test.tsx
+++ b/apps/web/src/test/tasks.deleteDialog.test.tsx
@@ -18,13 +18,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const task: Task = {
   id: "task-1",

--- a/apps/web/src/test/tasks.editDialog.test.tsx
+++ b/apps/web/src/test/tasks.editDialog.test.tsx
@@ -24,13 +24,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const baseTask: Task = {
   id: "task-1",

--- a/apps/web/src/test/tasks.index.test.tsx
+++ b/apps/web/src/test/tasks.index.test.tsx
@@ -39,13 +39,7 @@ vi.mock("@tanstack/react-router", async () => {
 import { api } from "@/lib/api";
 import { MyTasksView } from "../routes/tasks.index";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const baseTask: TaskListItem = {
   id: "task-1",
@@ -224,8 +218,8 @@ describe("MyTasksView", () => {
 
   it("読み込み中はインジケータを表示する", () => {
     // 解決しない Promise を返してローディング状態を維持
-    vi.mocked(api.tasks.me.$get).mockReturnValue(
-      new Promise(() => {}) as never,
+    vi.mocked(api.tasks.me.$get).mockImplementation(
+      () => new Promise(() => {}),
     );
 
     renderWithQuery(<MyTasksView search={{}} onSearchChange={() => {}} />);

--- a/apps/web/src/test/tasks.kanbanBoard.test.tsx
+++ b/apps/web/src/test/tasks.kanbanBoard.test.tsx
@@ -26,13 +26,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 function listItem(overrides: Partial<TaskListItem>): TaskListItem {
   return {

--- a/apps/web/src/test/tasks.listWithDialogs.test.tsx
+++ b/apps/web/src/test/tasks.listWithDialogs.test.tsx
@@ -26,13 +26,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 const listItem: TaskListItem = {
   id: "task-1",

--- a/apps/web/src/test/tasks.pickers.test.tsx
+++ b/apps/web/src/test/tasks.pickers.test.tsx
@@ -19,13 +19,7 @@ vi.mock("@/lib/api", () => ({
 
 import { api } from "@/lib/api";
 
-function mockJson<T>(data: T, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => data,
-  } as never;
-}
+import { mockJson } from "./helpers/mockJson";
 
 afterEach(() => {
   vi.restoreAllMocks();


### PR DESCRIPTION
## 関連Issue
Closes #120

## 概要・目的
* フロントの \`as Organization[]\` キャスト 2 箇所と、API テストの \`as never\` キャスト（組織関連の代表的なもの）を除去する。
* API ハンドラ側のレスポンス型・include 形を変更した際に、フロント / テストでコンパイル時に検出されるようにする。

## 背景
* PR #115 / #145 のレビューで「\`as Organization[]\` / \`as never\` キャストにより API スキーマ変更を型チェックで検知できない」と指摘されていた。
* PR #145 で組織作成ダイアログが切り出された結果、対象は Sidebar (\`Sidebar.tsx:47\`) と organizations 一覧 (\`organizations.index.tsx:57\`) の 2 箇所に固定された。

## 変更内容
### Frontend
* \`apps/web/src/features/organizations/hooks/useOrganizationsQuery.ts\` (新規):
  * \`InferResponseType<typeof api.organizations.\$get, 200>\` でレスポンス型を導出し \`OrganizationListItem\` として export
  * 共通の \`useOrganizationsQuery\` フックを提供
* \`apps/web/src/components/layout/Sidebar.tsx\` / \`apps/web/src/routes/organizations.index.tsx\`:
  * 重複した queryFn を撤去し \`useOrganizationsQuery()\` を呼ぶように変更
  * \`as Organization[]\` キャストを除去
  * Sidebar 内のサブコンポーネント型注釈も \`OrganizationListItem\` に統一

### Backend Tests
* **スコープ拡張 (2026-05-19)**: 当初は組織関連のみだったが、テスト全般に広げて 80 件超の \`as never\` を撤去 (Issue 本文も更新)
* \`apps/api/test/organizations.test.ts\`:
  * 以下の Prisma 型エイリアスを追加し、組織関連の \`as never\` を撤去:
    * \`OrgWithSelfRoleMembership\` (GET /organizations)
    * \`OrgWithRecurringMeetings\` (GET /organizations/:id)
    * \`MembershipWithUser\` (GET /organizations/:id/members)
    * \`InvitationWithInviter\` (GET /organizations/:id/invitations)
    * \`NextMeetingRow\` (GET /organizations/:id/next-meetings) — \`Prisma.MeetingGetPayload<{ select: ... }>\`
  * \`sampleListTask\` は \`TaskWithList\` (\`apps/api/src/lib/task-serialization.ts\` で export 済み) を流用
  * DELETE 系の単体行モックは \`OrganizationInvitation\` / \`OrganizationMembership\` 型で直接型付け
* \`apps/api/test/auth.test.ts\`: \`jwtVerifyResult\` ヘルパーを新設し、15 箇所の JWT モックをヘルパー経由に統一
* \`apps/api/test/recurring-meetings.test.ts\`: \`RecurringMeetingListRow\` / \`RecurringMeetingWithMembers\` / \`MeetingListRow\` の型エイリアスを追加して 29 箇所を撤去
* \`apps/api/test/meetings.test.ts\`: \`MeetingWithRecurringOrgId\` / \`MeetingDetail\` 型を追加して 7 箇所を撤去
* \`apps/api/test/tasks.test.ts\`: \`TaskWithDetail\` を中心に 17 箇所を撤去
* \`apps/api/test/me.test.ts\`: \`InvitationListRow\` 型を追加して 5 箇所を撤去

### Frontend Tests
* \`apps/web/src/test/helpers/mockJson.ts\` (新規) を作成し、13 ファイルに散らばっていた \`mockJson<T>()\` ヘルパー定義を共通 import に統合
* \`apps/web/src/test/helpers/organizationDetail.tsx\` の \`mockJson\` は新ヘルパーから re-export して既存 import パスを維持
* \`tasks.index.test.tsx\`: \`new Promise(...) as never\` を \`mockImplementation(() => new Promise(...))\` に書き換え

## 撤去状況
- API テスト全体: 86 件超 → **1 件** (auth.test.ts の \`jwtVerifyResult\` ヘルパー内部のみ)
- フロントテスト全体: 15+ 件 → **1 件** (\`helpers/mockJson.ts\` 内部のみ)

両方とも構築不可な型 (jose の \`JWTVerifyResult\`、Hono の \`ClientResponse\`) に対するキャストで、ヘルパー 1 箇所に局所化することで型エラー時の影響範囲を狭めた。

## 動作確認手順
1. \`make dev\` で local 環境を起動
2. \`/organizations\` を開き、組織一覧が表示されること
3. サイドバーで組織を切り替えると詳細ページも追従すること（クエリキー共有の維持確認）
4. \`pnpm turbo run typecheck\` / \`pnpm turbo run test\` がパスすること

## 撤去状況
- API テスト (\`apps/api/test/organizations.test.ts\`): 21 件あった \`as never\` → 0 件 (コメントのみ)
- フロントテスト (\`apps/web/src/test/{organizations,sidebar}.test.tsx\`): 4 件 → 2 件 (\`mockJson\` ヘルパー内部のみ)

## チェックリスト
- [x] 全テスト GREEN
- [x] lint / typecheck パス
- [x] クエリキー \`["organizations"]\` の共有を維持し Sidebar と一覧の連動を保つ

