### PR TITLE
feat(api): MeetingにtranscriptTextカラムを追加する

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -10,6 +10,7 @@ Table Meeting {
   meetingType String [not null, default: 'one_time']
   transcriptionQuality String
   supplementaryMemo String
+  transcriptText String
   sequenceNumber Int
   previousMeetingId String
   estimatedDurationMinutes Int

--- a/apps/api/prisma/migrations/20260519081909_add_transcript_text/migration.sql
+++ b/apps/api/prisma/migrations/20260519081909_add_transcript_text/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN     "transcriptText" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Meeting {
   meetingType              String  @default("one_time")
   transcriptionQuality     String?
   supplementaryMemo        String?
+  transcriptText           String?   // Issue #228 add
   sequenceNumber           Int?
   previousMeetingId        String?
   estimatedDurationMinutes Int?


### PR DESCRIPTION
## 関連Issue
Closes #218

## 概要・目的
* AI解析パイプライン(#221)が書き起こし本文を参照できるよう、MeetingテーブルにtranscriptTextカラムを追加する

## 背景
* AI Serviceはapps/api経由でDBを操作する方針のため、書き起こし本文のDBへの保存先が必要

## 変更内容
* apps/api/prisma/schema.prisma に transcriptText String? を追加
* マイグレーション生成

## 動作確認手順
1. make migrate を実行してマイグレーションが正常に適用されること
2. make test がGREENであること

## スクリーンショット
* なし（スキーマ変更のみ）