### PR TITLE
deployワークフローにprisma generateを追加する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: 依存関係インストール
         run: pnpm install --frozen-lockfile
 
+      - name: Prisma クライアント生成        # issue 230 追加
+        run: pnpm --filter api exec prisma generate
+
       - name: ビルド
         run: pnpm turbo run build
 


### PR DESCRIPTION
## 関連Issue
Closes #230

## 概要・目的
* #229のスキーマ変更マージ後、deploy.ymlにprisma generateが抜けていたためビルドエラーが発生した
* deploy.ymlのbuildジョブにprisma generateステップを追加して解消する

## 背景
* ci.ymlには既に含まれていたがdeploy.ymlにのみ抜けていた

## 変更内容
* .github/workflows/deploy.yml にprisma generateステップを追加

## 動作確認手順
1. mainへのpush後、deploy.ymlのbuildジョブがGREENになること

## スクリーンショット
* なし