### PR TITLE
test(web): Link モックをテスト共通ヘルパーに切り出す

### DIFF
--- a/apps/web/src/test/helpers/link-mock.test.tsx
+++ b/apps/web/src/test/helpers/link-mock.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MockLink } from "./link-mock";
+
+describe("MockLink (link-mock helper)", () => {
+  it("子要素を含む <a> 要素として描画する", () => {
+    render(<MockLink to="/organizations">org</MockLink>);
+    const anchor = screen.getByText("org");
+    expect(anchor.tagName).toBe("A");
+    expect(anchor.getAttribute("href")).toBe("/organizations");
+  });
+
+  it("to の $key を params の値で置換する", () => {
+    render(
+      <MockLink to="/organizations/$id" params={{ id: "abc-123" }}>
+        link
+      </MockLink>,
+    );
+    expect(screen.getByText("link").getAttribute("href")).toBe(
+      "/organizations/abc-123",
+    );
+  });
+
+  it("params 未指定時は $key を空文字に置換する", () => {
+    render(<MockLink to="/organizations/$id">link</MockLink>);
+    expect(screen.getByText("link").getAttribute("href")).toBe(
+      "/organizations/",
+    );
+  });
+
+  it("複数の $key を含むパスを順に置換する", () => {
+    render(
+      <MockLink
+        to="/orgs/$orgId/users/$userId"
+        params={{ orgId: "o1", userId: "u1" }}
+      >
+        link
+      </MockLink>,
+    );
+    expect(screen.getByText("link").getAttribute("href")).toBe(
+      "/orgs/o1/users/u1",
+    );
+  });
+
+  it("className を <a> 要素に伝播する", () => {
+    render(
+      <MockLink to="/" className="nav-link">
+        home
+      </MockLink>,
+    );
+    expect(screen.getByText("home")).toHaveClass("nav-link");
+  });
+});

--- a/apps/web/src/test/helpers/link-mock.tsx
+++ b/apps/web/src/test/helpers/link-mock.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+// TanStack Router の <Link> は RouterProvider が無いと内部で落ちるため、
+// テスト中は href を持つ通常の <a> として描画するモックに差し替える。
+// 子要素・className を保持し、属性ベースの assertion を可能にする。
+// `to` 内の `$key` は `params[key]` で置換する（未指定なら空文字）。
+export function MockLink({
+  to,
+  params,
+  children,
+  className,
+}: {
+  to: string;
+  params?: Record<string, string>;
+  children?: ReactNode;
+  className?: string;
+}) {
+  const href =
+    typeof to === "string"
+      ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
+      : String(to);
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  );
+}
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    Link: MockLink,
+  };
+});

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -37,34 +39,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-// 定例カードに /recurring-meetings/$id への Link が含まれるため router を mock し、
-// href の検証ができる形（素の <a>）で描画する。
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.deleteMemberDialog.test.tsx
+++ b/apps/web/src/test/organizations.deleteMemberDialog.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,32 +34,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.deleteOrganizationDialog.test.tsx
+++ b/apps/web/src/test/organizations.deleteOrganizationDialog.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,32 +34,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.editOrganizationDialog.test.tsx
+++ b/apps/web/src/test/organizations.editOrganizationDialog.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,32 +34,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.invitationsManagement.test.tsx
+++ b/apps/web/src/test/organizations.invitationsManagement.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -38,32 +40,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.inviteMemberDialog.test.tsx
+++ b/apps/web/src/test/organizations.inviteMemberDialog.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,32 +34,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  type MockLinkProps = {
-    to: string;
-    params?: Record<string, string>;
-    children?: React.ReactNode;
-    className?: string;
-  };
-  return {
-    ...actual,
-    Link: ({ to, params, children, className }: MockLinkProps) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 

--- a/apps/web/src/test/organizations.test.tsx
+++ b/apps/web/src/test/organizations.test.tsx
@@ -1,3 +1,5 @@
+import "./helpers/link-mock";
+
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,39 +16,6 @@ vi.mock("@/lib/api", () => ({
   },
   authHeaders: () => ({ headers: {} }),
 }));
-
-// TanStack Router の <Link> は RouterProvider が無いと内部で落ちるため、
-// テスト中は href を持つ通常の <a> として描画するモックに差し替える。
-// 子要素・className・role 属性は保持し、属性ベースの assertion を可能にする。
-vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
-  return {
-    ...actual,
-    Link: ({
-      to,
-      params,
-      children,
-      className,
-    }: {
-      to: string;
-      params?: Record<string, string>;
-      children?: React.ReactNode;
-      className?: string;
-    }) => {
-      const href =
-        typeof to === "string"
-          ? to.replace(/\$(\w+)/g, (_, k: string) => params?.[k] ?? "")
-          : String(to);
-      return (
-        <a href={href} className={className}>
-          {children}
-        </a>
-      );
-    },
-  };
-});
 
 import { api } from "@/lib/api";
 


### PR DESCRIPTION
## 関連Issue
Closes #136

## 概要・目的
* 各テストファイルで重複していた TanStack Router の `<Link>` モックを `apps/web/src/test/helpers/link-mock.tsx` に切り出し、組織ページ系 7 テストファイルから import するだけで適用される形に整理。

## 背景
* PR #132（#88 対応）のレビューで指摘された通り、`<Link>` を `<a>` に差し替える `vi.mock("@tanstack/react-router", ...)` が各テストファイルにコピペで複製されており、Link を使うテストが増えるたびに重複が増える状態。
* `to` の `$key` 置換ロジックを含む同一実装を単一のソースで管理する。

## 変更内容
* `apps/web/src/test/helpers/link-mock.tsx` を新設。`MockLink` 関数を export し、`vi.mock("@tanstack/react-router", ...)` 内で Link を MockLink に差し替え
* `apps/web/src/test/helpers/link-mock.test.tsx` を追加。`to` の `$key` を `params` で置換 / `params` 未指定時の空文字置換 / 複数 `$key` の置換 / `className` の伝播 を 5 件のテストでカバー
* 以下 7 ファイルでインライン `vi.mock("@tanstack/react-router", ...)` を削除し、`import "./helpers/link-mock"` に置き換え
  * `organizations.test.tsx`
  * `organizations.\$id.test.tsx`
  * `organizations.editOrganizationDialog.test.tsx`
  * `organizations.inviteMemberDialog.test.tsx`
  * `organizations.deleteOrganizationDialog.test.tsx`
  * `organizations.deleteMemberDialog.test.tsx`
  * `organizations.invitationsManagement.test.tsx`
* 差分: +105 / -191（ネット -86 行）

## 動作確認手順
1. このブランチを checkout
2. `cd apps/web`
3. `pnpm test` で全 45 ファイル / 361 テストが GREEN を確認
4. `pnpm lint` でエラーなしを確認
5. `pnpm typecheck` でエラーなしを確認

## スクリーンショット
* なし（テストコードのみの変更）

## Notes / フォローアップ
* Issue 本文では 13 ファイル全置換を想定していたが、Vitest の `vi.mock` は同一モジュールへの複数呼び出しが後勝ちで上書きされる仕様のため、Link モックと他の Router API モック（`useNavigate` / `useRouterState` / `createFileRoute`）を併用しているファイルは helper に置換できない
* 以下 5 ファイルは本 PR の対象外。別 Issue で `useNavigate` / `useRouterState` / `createFileRoute` 用ヘルパー設計を検討する必要がある
  * `topbar.test.tsx` — Link + \`useNavigate\`
  * `sidebar.test.tsx` — Link + \`useRouterState\` + \`useNavigate\`
  * `invitations.test.tsx` — Link + \`useNavigate\`
  * `meetings.\$id.test.tsx` — Link + \`createFileRoute\`
  * `recurring-meetings.\$id.test.tsx` — Link + \`createFileRoute\`
* `tasks.index.test.tsx` は Link を使わず \`createFileRoute\` のみモックしているため本 helper は不要