### PR TITLE
fix: /analysis-runs を /internal 配下に移動し共有シークレット認証を適用

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { analysisRunsRoute } from "./routes/analysis-runs.js";
 import { healthRoute } from "./routes/health.js";
 import { meRoute } from "./routes/me.js";
 import { meetingsRoute } from "./routes/meetings.js";
@@ -54,8 +53,7 @@ const routes = app
   .route("/organizations", organizationsRoute)
   .route("/recurring-meetings", recurringMeetingsRoute)
   .route("/tasks", tasksRoute)
-  .route("/internal", internalRoute)
-  .route("/analysis-runs", analysisRunsRoute);
+  .route("/internal", internalRoute);
 
 export { app };
 export type AppType = typeof routes;

--- a/apps/api/src/routes/analysis-runs.ts
+++ b/apps/api/src/routes/analysis-runs.ts
@@ -3,7 +3,6 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 
-// AI Service 専用の内部エンドポイント。Docker network 内の内部通信として信頼するため認証不要。
 export const analysisRunsRoute = new Hono()
   // GET /:id/input — AI Service が解析に必要な情報を全て取得する
   .get("/:id/input", async (c) => {

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
+import { analysisRunsRoute } from "./analysis-runs.js";
 
 const decisionItemSchema = z.object({
   title: z.string(),
@@ -41,6 +42,7 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
 };
 
 export const internalRoute = new Hono()
+  .route("/analysis-runs", analysisRunsRoute)
   .patch(
     "/analysis-runs/:id",
     zValidator("json", z.object({ status: z.enum(["analyzing", "failed"]) })),

--- a/apps/api/test/analysis-runs.test.ts
+++ b/apps/api/test/analysis-runs.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// DB をモックする（analysis-runs は認証不要なので auth モックは不要）
+// DB をモックする
 vi.mock("../src/lib/prisma.js", () => ({
   prisma: {
     meetingAnalysisRun: {
@@ -19,7 +19,10 @@ const mockRunFindUnique = vi.mocked(prisma.meetingAnalysisRun.findUnique);
 const mockRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
 const mockRunUpdate = vi.mocked(prisma.meetingAnalysisRun.update);
 
-// GET /analysis-runs/:id/input で返る include の型
+const SECRET = "test-secret";
+const AUTH_HEADER = { "x-internal-secret": SECRET };
+
+// GET /internal/analysis-runs/:id/input で返る include の型
 type RunWithMeeting = Prisma.MeetingAnalysisRunGetPayload<{
   include: { meeting: { include: { speakers: true } } };
 }>;
@@ -80,13 +83,18 @@ const baseRun = {
   meeting: baseMeeting,
 };
 
-describe("GET /analysis-runs/:id/input", () => {
-  beforeEach(() => vi.clearAllMocks());
+describe("GET /internal/analysis-runs/:id/input", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_API_SECRET = SECRET;
+  });
 
   it("存在する解析ランの入力情報を 200 で返す", async () => {
     mockRunFindUnique.mockResolvedValue(baseRun as RunWithMeeting);
 
-    const res = await app.request("/analysis-runs/run-1/input");
+    const res = await app.request("/internal/analysis-runs/run-1/input", {
+      headers: AUTH_HEADER,
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       analysis_run_id: string;
@@ -125,7 +133,9 @@ describe("GET /analysis-runs/:id/input", () => {
       reportJson: { summary: "前回サマリー" },
     } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>);
 
-    const res = await app.request("/analysis-runs/run-1/input");
+    const res = await app.request("/internal/analysis-runs/run-1/input", {
+      headers: AUTH_HEADER,
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       previous_meeting_id: string;
@@ -154,7 +164,9 @@ describe("GET /analysis-runs/:id/input", () => {
     } as RunWithMeeting);
     mockRunFindFirst.mockResolvedValue(null);
 
-    const res = await app.request("/analysis-runs/run-1/input");
+    const res = await app.request("/internal/analysis-runs/run-1/input", {
+      headers: AUTH_HEADER,
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { previous_report_json: null };
     expect(body.previous_report_json).toBeNull();
@@ -162,13 +174,23 @@ describe("GET /analysis-runs/:id/input", () => {
 
   it("存在しない解析ランは 404", async () => {
     mockRunFindUnique.mockResolvedValue(null);
-    const res = await app.request("/analysis-runs/missing/input");
+    const res = await app.request("/internal/analysis-runs/missing/input", {
+      headers: AUTH_HEADER,
+    });
     expect(res.status).toBe(404);
+  });
+
+  it("認証ヘッダなしは 401", async () => {
+    const res = await app.request("/internal/analysis-runs/run-1/input");
+    expect(res.status).toBe(401);
   });
 });
 
-describe("PATCH /analysis-runs/:id/result", () => {
-  beforeEach(() => vi.clearAllMocks());
+describe("PATCH /internal/analysis-runs/:id/result", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_API_SECRET = SECRET;
+  });
 
   const existingRun = {
     ...baseRun,
@@ -183,9 +205,9 @@ describe("PATCH /analysis-runs/:id/result", () => {
       alertLevel: "low",
     } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>);
 
-    const res = await app.request("/analysis-runs/run-1/result", {
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
       body: JSON.stringify({
         status: "completed",
         summary: "解析サマリー",
@@ -217,9 +239,9 @@ describe("PATCH /analysis-runs/:id/result", () => {
       errorMessage: "解析エラー",
     } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>);
 
-    const res = await app.request("/analysis-runs/run-1/result", {
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
       body: JSON.stringify({
         status: "failed",
         error_message: "解析エラー",
@@ -241,9 +263,9 @@ describe("PATCH /analysis-runs/:id/result", () => {
   });
 
   it("不正な status は 400", async () => {
-    const res = await app.request("/analysis-runs/run-1/result", {
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
       body: JSON.stringify({ status: "queued" }),
     });
     expect(res.status).toBe(400);
@@ -252,12 +274,22 @@ describe("PATCH /analysis-runs/:id/result", () => {
 
   it("存在しない解析ランは 404", async () => {
     mockRunFindUnique.mockResolvedValue(null);
-    const res = await app.request("/analysis-runs/missing/result", {
+    const res = await app.request("/internal/analysis-runs/missing/result", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+      body: JSON.stringify({ status: "completed" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockRunUpdate).not.toHaveBeenCalled();
+  });
+
+  it("認証ヘッダなしは 401", async () => {
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status: "completed" }),
     });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(401);
     expect(mockRunUpdate).not.toHaveBeenCalled();
   });
 });

--- a/services/ai/integrations/app_api_client.py
+++ b/services/ai/integrations/app_api_client.py
@@ -20,7 +20,7 @@ class AppApiClient:
         """GET /analysis-runs/:id/input"""
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                f"{self.base_url}/analysis-runs/{analysis_run_id}/input",
+                f"{self.base_url}/internal/analysis-runs/{analysis_run_id}/input",
                 headers=self._headers,
                 timeout=30.0,
             )
@@ -33,7 +33,7 @@ class AppApiClient:
         """PATCH /analysis-runs/:id/result"""
         async with httpx.AsyncClient() as client:
             response = await client.patch(
-                f"{self.base_url}/analysis-runs/{analysis_run_id}/result",
+                f"{self.base_url}/internal/analysis-runs/{analysis_run_id}/result",
                 json=result,
                 headers=self._headers,
                 timeout=30.0,

--- a/services/ai/integrations/app_api_client.py
+++ b/services/ai/integrations/app_api_client.py
@@ -17,7 +17,7 @@ class AppApiClient:
         return {"x-internal-secret": self._secret}
 
     async def get_analysis_run_input(self, analysis_run_id: str) -> dict:
-        """GET /analysis-runs/:id/input"""
+        """GET /internal/analysis-runs/:id/input"""
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self.base_url}/internal/analysis-runs/{analysis_run_id}/input",
@@ -30,7 +30,7 @@ class AppApiClient:
     async def update_analysis_run_result(
         self, analysis_run_id: str, result: dict
     ) -> None:
-        """PATCH /analysis-runs/:id/result"""
+        """PATCH /internal/analysis-runs/:id/result"""
         async with httpx.AsyncClient() as client:
             response = await client.patch(
                 f"{self.base_url}/internal/analysis-runs/{analysis_run_id}/result",

--- a/services/ai/routers/analysis.py
+++ b/services/ai/routers/analysis.py
@@ -1,4 +1,5 @@
 """開発・検証用解析エンドポイント。Service Busを経由せずに解析を実行できる。"""
+
 import logging
 
 from fastapi import APIRouter
@@ -21,7 +22,7 @@ async def analyze(job: AnalysisJobInput) -> AnalysisRunResult:
     - 結果JSONだけをレスポンスで返す
 
     analysis_run_idがある場合:
-    - 解析完了後にapps/apiのPATCH /analysis-runs/:id/resultを呼ぶ
+    - 解析完了後にapps/apiのPATCH /internal/analysis-runs/:id/resultを呼ぶ
     """
     llm_client = AzureOpenAIClient()
     result = await analyze_meeting(job, llm_client)
@@ -34,8 +35,6 @@ async def analyze(job: AnalysisJobInput) -> AnalysisRunResult:
                 result.model_dump(exclude_none=True),
             )
         except Exception:
-            logger.exception(
-                "結果保存失敗 analysis_run_id=%s", job.analysis_run_id
-            )
+            logger.exception("結果保存失敗 analysis_run_id=%s", job.analysis_run_id)
 
     return result


### PR DESCRIPTION
## 関連Issue
Closes #241

## 概要・目的
- `/analysis-runs` がトップレベルにマウントされており、認証なしで第三者からアクセスできる状態だった
- `/internal` 配下に移動し、既存の `internalAuth`（共有シークレット）ミドルウェアを適用することで保護する
- AIサービス側のリクエスト先URLも合わせて更新する

## 背景
- `apps/api` の `/internal/*` には `x-internal-secret` ヘッダによる認証ミドルウェアが適用済み
- `analysis-runs.ts` の機能（解析入力取得・結果保存）はAIサービス専用の内部エンドポイントであり、外部公開は不要

## 変更内容
- `apps/api/src/app.ts`：`/analysis-runs` のトップレベルマウントおよびimportを削除
- `apps/api/src/routes/internal.ts`：`analysisRunsRoute` を `/internal/analysis-runs` としてマウント
- `services/ai/integrations/app_api_client.py`：リクエスト先URLを `/internal/analysis-runs` に変更
- `apps/api/test/analysis-runs.test.ts`：パスを `/internal/analysis-runs` に更新し、認証ヘッダの付与・認証なし 401 のテストを追加

## 動作確認手順

1. `apps/api` でテストを実行し全件パスすることを確認する
    ```bash
    cd apps/api && npm test
2. 認証ヘッダなしで GET /analysis-runs/:id/input にリクエストし、404（ルート未定義）が返ることを確認する
3. 認証ヘッダ付きで GET /internal/analysis-runs/:id/input にリクエストし、正常レスポンスが返ることを確認する

 ## スクリーンショット
・APIエンドポイントの変更のみのためなし