### PR TITLE
fix: fake-auth の /authorize HTML テンプレートに HTML エスケープを適用する

### DIFF
--- a/services/fake-auth/src/index.ts
+++ b/services/fake-auth/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
+import { html } from "hono/html";
 import {
   exportJWK,
   importJWK,
@@ -81,6 +82,8 @@ app.get("/.well-known/jwks.json", async (c) => {
 });
 
 // Authorize - GET (login form)
+// クエリ・ユーザー情報を直接埋め込むため、hono/html の `html` タグ関数で
+// 自動 HTML エスケープを適用し XSS を防ぐ。
 app.get("/authorize", (c) => {
   const redirectUri = c.req.query("redirect_uri");
   const state = c.req.query("state") ?? "";
@@ -90,14 +93,12 @@ app.get("/authorize", (c) => {
     return c.text("redirect_uri is required", 400);
   }
 
-  const usersList = getAllUsers()
-    .map(
-      ([key, user]) =>
-        `<option value="${key}">${user.displayName} (${user.email})</option>`,
-    )
-    .join("");
+  const userOptions = getAllUsers().map(
+    ([key, user]) =>
+      html`<option value="${key}">${user.displayName} (${user.email})</option>`,
+  );
 
-  const html = `<!DOCTYPE html>
+  const page = html`<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -138,14 +139,14 @@ app.get("/authorize", (c) => {
     <input type="hidden" name="nonce" value="${nonce}">
     <select name="user" required>
       <option value="">-- ユーザーを選択 --</option>
-      ${usersList}
+      ${userOptions}
     </select>
     <button type="submit">ログイン</button>
   </form>
 </body>
 </html>`;
 
-  return c.html(html);
+  return c.html(page);
 });
 
 // Authorize - POST (generate ID token and redirect)


### PR DESCRIPTION
## 関連Issue
Closes #244

## 概要・目的
* fake-auth の `/authorize` ログインフォーム HTML で、外部入力を直接文字列補間していたため XSS の余地があった
* hono/html の `html` タグ関数で自動エスケープを適用する

## 背景
* `services/fake-auth/src/index.ts` の `/authorize` GET ハンドラは、ログインフォーム HTML を生成して返す
* HTML 内に埋め込んでいた `redirect_uri` / `state` / `nonce`（クエリ起源）と `displayName` / `email` / `key`（ユーザー情報起源）が無加工で展開されており、`redirect_uri="><script>alert(1)</script>` のような URL を踏むと任意 JavaScript が実行される状態だった
* fake-auth はローカル開発専用とはいえ、社内チャットで URL を踏ませる pretext が成立しうるため、被害最小化として対応する

## 変更内容
* `services/fake-auth/src/index.ts`
  * `hono/html` の `html` タグ関数を import
  * `/authorize` GET の HTML 生成を `html` タグ関数で書き直し、すべての外部入力埋め込み箇所で自動エスケープが効くようにする
  * ユーザーリストも `html` テンプレートの配列として渡し、各要素のエスケープを保証

## 動作確認手順
1. `make dev` で開発環境を起動する
2. ブラウザで `http://localhost:3007/authorize?redirect_uri=%22%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E&state=foo&nonce=bar` を開く
3. アラートが出ず、ページソースに `&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;` の形でエスケープされていることを確認する
4. 通常の URL `http://localhost:3007/authorize?redirect_uri=http://localhost:5173/login` で従来通りログインできることを確認する

## スクリーンショット
* HTML の自動エスケープ適用のみで UI 表示に変更なし