### PR TITLE
fix: sendToServiceBus の引数仕様を整理し env 内部取得に統一する

### DIFF
--- a/apps/api/src/lib/service-bus.ts
+++ b/apps/api/src/lib/service-bus.ts
@@ -1,13 +1,24 @@
 import { ServiceBusClient, type ServiceBusSender } from "@azure/service-bus";
+import { requireEnv } from "./env.js";
 
 let client: ServiceBusClient | undefined;
 let sender: ServiceBusSender | undefined;
 
-function getOrCreateSender(
-  connectionString: string,
-  queueName: string,
-): ServiceBusSender {
+// 初回呼び出し時に env から接続情報を取得して client / sender を生成する。
+// 接続情報は起動中固定とする（実行時に切り替える要件は無いため）。
+function getOrCreateSender(): ServiceBusSender {
   if (!sender) {
+    const connectionString = requireEnv(
+      "AZURE_SERVICE_BUS_CONNECTION_STRING",
+      "",
+    );
+    if (!connectionString) {
+      throw new Error("AZURE_SERVICE_BUS_CONNECTION_STRING が未設定です");
+    }
+    const queueName = requireEnv(
+      "AZURE_SERVICE_BUS_QUEUE_NAME",
+      "decision-loop",
+    );
     client = new ServiceBusClient(connectionString);
     sender = client.createSender(queueName);
   }
@@ -20,11 +31,9 @@ function getOrCreateSender(
  * フィールドを変更する場合は必ず両方を同時に更新してください。
  */
 export async function sendToServiceBus(
-  connectionString: string,
-  queueName: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const s = getOrCreateSender(connectionString, queueName);
+  const s = getOrCreateSender();
   await s.sendMessages({
     body: JSON.stringify(payload),
     contentType: "application/json",

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -232,13 +232,10 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       },
     });
 
-    // AI Service に解析を依頼するメッセージを Service Bus に送信する
-    const connectionString =
-      process.env.AZURE_SERVICE_BUS_CONNECTION_STRING ?? "";
-    const queueName =
-      process.env.AZURE_SERVICE_BUS_QUEUE_NAME ?? "decision-loop";
+    // AI Service に解析を依頼するメッセージを Service Bus に送信する。
+    // 接続情報は service-bus モジュール内部で env から取得する。
     try {
-      await sendToServiceBus(connectionString, queueName, {
+      await sendToServiceBus({
         analysis_run_id: run.id,
         meeting_id: id,
         trigger_type: "transcript_submitted",

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -476,8 +476,6 @@ describe("POST /meetings/:id/analyze", () => {
       }),
     );
     expect(mockSendToServiceBus).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
       expect.objectContaining({
         analysis_run_id: "run-1",
         meeting_id: "mtg-1",

--- a/apps/api/test/service-bus.test.ts
+++ b/apps/api/test/service-bus.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   MockServiceBusClient,
@@ -34,13 +34,19 @@ vi.mock("@azure/service-bus", () => ({
 import { closeServiceBus, sendToServiceBus } from "../src/lib/service-bus.js";
 
 describe("service-bus", () => {
+  beforeEach(() => {
+    vi.stubEnv("AZURE_SERVICE_BUS_CONNECTION_STRING", "conn-string");
+    vi.stubEnv("AZURE_SERVICE_BUS_QUEUE_NAME", "test-queue");
+  });
+
   afterEach(async () => {
     await closeServiceBus();
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
-  it("(a) 初回呼び出しで ServiceBusClient と sender が新規作成される", async () => {
-    await sendToServiceBus("conn-string", "test-queue", { key: "value" });
+  it("(a) 初回呼び出しで env から接続情報を読んで ServiceBusClient と sender を生成する", async () => {
+    await sendToServiceBus({ key: "value" });
 
     expect(MockServiceBusClient).toHaveBeenCalledOnce();
     expect(MockServiceBusClient).toHaveBeenCalledWith("conn-string");
@@ -49,17 +55,17 @@ describe("service-bus", () => {
     expect(mockSendMessages).toHaveBeenCalledOnce();
   });
 
-  it("(b) 2回目以降は既存の sender が再利用され、ServiceBusClient が新規作成されない", async () => {
-    await sendToServiceBus("conn-string", "test-queue", { key: "first" });
-    await sendToServiceBus("conn-string", "test-queue", { key: "second" });
+  it("(b) 2回目以降は既存の client / sender を再利用する", async () => {
+    await sendToServiceBus({ key: "first" });
+    await sendToServiceBus({ key: "second" });
 
     expect(MockServiceBusClient).toHaveBeenCalledOnce();
     expect(mockCreateSender).toHaveBeenCalledOnce();
     expect(mockSendMessages).toHaveBeenCalledTimes(2);
   });
 
-  it("(c) closeServiceBus() 呼び出し後に sender と client の close が呼ばれる", async () => {
-    await sendToServiceBus("conn-string", "test-queue", { key: "value" });
+  it("(c) closeServiceBus() で sender と client の close が呼ばれる", async () => {
+    await sendToServiceBus({ key: "value" });
     vi.clearAllMocks();
 
     await closeServiceBus();
@@ -69,21 +75,31 @@ describe("service-bus", () => {
   });
 
   it("(d) closeServiceBus() 後に再送信すると新しい client と sender が作成される", async () => {
-    await sendToServiceBus("conn-string", "test-queue", { key: "before" });
+    await sendToServiceBus({ key: "before" });
     await closeServiceBus();
     vi.clearAllMocks();
 
-    await sendToServiceBus("conn-string", "test-queue", { key: "after" });
+    await sendToServiceBus({ key: "after" });
 
     expect(MockServiceBusClient).toHaveBeenCalledOnce();
     expect(mockCreateSender).toHaveBeenCalledOnce();
     expect(mockSendMessages).toHaveBeenCalledOnce();
   });
 
-  it("(e) afterEach で closeServiceBus() を呼ぶことで各テストは独立した状態から始まる", async () => {
-    await sendToServiceBus("conn-string", "test-queue", { key: "value" });
+  it("(e) AZURE_SERVICE_BUS_CONNECTION_STRING 未設定なら明示的に throw する", async () => {
+    vi.stubEnv("AZURE_SERVICE_BUS_CONNECTION_STRING", "");
 
-    expect(MockServiceBusClient).toHaveBeenCalledOnce();
-    expect(mockCreateSender).toHaveBeenCalledOnce();
+    await expect(sendToServiceBus({ key: "value" })).rejects.toThrowError(
+      /AZURE_SERVICE_BUS_CONNECTION_STRING/,
+    );
+    expect(MockServiceBusClient).not.toHaveBeenCalled();
+  });
+
+  it("(f) AZURE_SERVICE_BUS_QUEUE_NAME 未設定なら decision-loop にフォールバックする", async () => {
+    vi.stubEnv("AZURE_SERVICE_BUS_QUEUE_NAME", "");
+
+    await sendToServiceBus({ key: "value" });
+
+    expect(mockCreateSender).toHaveBeenCalledWith("decision-loop");
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #246

## 概要・目的
* `sendToServiceBus(connectionString, queueName, payload)` は引数を取れる API シグネチャでありながら、内部では初回呼び出し勝ちで sender を固定する実装になっていた
* 引数を `payload` のみに絞り、接続情報は `service-bus` モジュール内部で env から取得する形に統一する

## 背景
* `apps/api/src/lib/service-bus.ts:6-15` の `getOrCreateSender` がモジュール変数 `sender` を初回引数で固定する実装で、2 回目以降は引数を無視する
* 呼び出し側 `apps/api/src/routes/meetings.ts:236-239` では `process.env.AZURE_SERVICE_BUS_CONNECTION_STRING ?? ""` の素通しがあり、env 未設定時に空文字列でクライアント生成を試みる経路もあった
* 接続情報を実行時に切り替える要件は無いため、引数撤去 + env 内部参照に整理する

## 変更内容
* `apps/api/src/lib/service-bus.ts`
  * `sendToServiceBus(payload)` に signature 変更
  * `getOrCreateSender()` 内で `requireEnv` を使い、`AZURE_SERVICE_BUS_CONNECTION_STRING` 未設定時は明示的に throw する
  * `AZURE_SERVICE_BUS_QUEUE_NAME` 未設定時は `decision-loop` にフォールバック
* `apps/api/src/routes/meetings.ts:236-261`
  * env を route 側で読む実装を撤去し、`sendToServiceBus({...})` 呼び出しに簡略化
* `apps/api/test/service-bus.test.ts`
  * 新シグネチャに合わせて全テストを書き直し
  * 接続文字列未設定時に throw されること、QUEUE_NAME 未設定時に `decision-loop` にフォールバックすることのテストを追加
* `apps/api/test/meetings.test.ts`
  * `mockSendToServiceBus` の呼び出し assertion を新シグネチャに合わせて修正

## 動作確認手順
1. `pnpm --filter api test` を実行し、`service-bus.test.ts` (6 ケース) と `meetings.test.ts` がすべて通ることを確認する
2. `pnpm --filter api typecheck` と `pnpm --filter api lint` がエラーなく完了することを確認する
3. `make dev` で開発環境を起動し、会議解析 (`POST /meetings/:id/analyze`) が引き続き 202 で解析ジョブを投入することを確認する

## スクリーンショット
* API シグネチャの整理のみのためなし