### PR TITLE
fix(ai): Service Bus consumer のハンドラ失敗時に abandon_message を呼ぶ

### DIFF
--- a/services/ai/consumers/service_bus.py
+++ b/services/ai/consumers/service_bus.py
@@ -25,7 +25,15 @@ class ServiceBusConsumer:
                         await handler(message)
                         await receiver.complete_message(message)
                     except Exception:
-                        # 1件の処理失敗でループを止めない
+                        # 1件の処理失敗でループを止めない。
+                        # ロック保持のままにすると Service Bus のロック期限切れまで
+                        # 再配送されないため、明示的に abandon してロックを解放する。
                         logger.exception(
                             "メッセージ処理中にエラーが発生しました: %s", message
                         )
+                        try:
+                            await receiver.abandon_message(message)
+                        except Exception:
+                            logger.exception(
+                                "abandon_message にも失敗しました: %s", message
+                            )

--- a/services/ai/tests/test_service_bus.py
+++ b/services/ai/tests/test_service_bus.py
@@ -72,6 +72,99 @@ async def test_consumer_start_continues_on_handler_error():
         def __init__(self):
             self._items = ["bad", "good"]
             self.complete_message = AsyncMock()
+            self.abandon_message = AsyncMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._items:
+                return self._items.pop(0)
+            raise StopAsyncIteration
+
+    mock_receiver = _MockReceiver()
+    mock_client = MagicMock()
+
+    @asynccontextmanager
+    async def receiver_ctx(*_args, **_kwargs):
+        yield mock_receiver
+
+    mock_client.get_queue_receiver = receiver_ctx
+
+    @asynccontextmanager
+    async def client_factory(_conn_str):
+        yield mock_client
+
+    consumer._client_factory = client_factory
+    await consumer.start(handler)
+
+    assert processed == ["good"]
+
+
+async def test_consumer_calls_abandon_on_handler_error():
+    """ハンドラーが例外を投げた場合に abandon_message が呼ばれることを確認"""
+    consumer = ServiceBusConsumer(
+        connection_string="Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
+        queue_name="test-queue",
+    )
+
+    async def handler(_msg):
+        raise ValueError("意図的なエラー")
+
+    class _MockReceiver:
+        def __init__(self):
+            self._items = ["bad"]
+            self.complete_message = AsyncMock()
+            self.abandon_message = AsyncMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._items:
+                return self._items.pop(0)
+            raise StopAsyncIteration
+
+    mock_receiver = _MockReceiver()
+    mock_client = MagicMock()
+
+    @asynccontextmanager
+    async def receiver_ctx(*_args, **_kwargs):
+        yield mock_receiver
+
+    mock_client.get_queue_receiver = receiver_ctx
+
+    @asynccontextmanager
+    async def client_factory(_conn_str):
+        yield mock_client
+
+    consumer._client_factory = client_factory
+    await consumer.start(handler)
+
+    # ハンドラ失敗時は complete_message は呼ばれず、abandon_message が呼ばれる
+    mock_receiver.complete_message.assert_not_called()
+    mock_receiver.abandon_message.assert_called_once_with("bad")
+
+
+async def test_consumer_loop_continues_when_abandon_fails():
+    """abandon_message 自体が失敗してもループは継続することを確認"""
+    consumer = ServiceBusConsumer(
+        connection_string="Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
+        queue_name="test-queue",
+    )
+
+    processed = []
+
+    async def handler(msg):
+        if msg == "bad":
+            raise ValueError("意図的なエラー")
+        processed.append(msg)
+
+    class _MockReceiver:
+        def __init__(self):
+            self._items = ["bad", "good"]
+            self.complete_message = AsyncMock()
+            self.abandon_message = AsyncMock(side_effect=RuntimeError("abandon失敗"))
 
         def __aiter__(self):
             return self


### PR DESCRIPTION
## 関連Issue
Closes #247

## 概要・目的
* AI Service の Service Bus consumer がハンドラ例外を握り潰すだけで `abandon_message` を呼んでいないため、ロック期限切れまで他コンシューマーで再処理できない状態だった
* 明示的に `abandon_message` を呼んでロックを解放し、コメントが示す「再配送」セマンティクスを実装側でも満たす

## 背景
* `services/ai/consumers/service_bus.py:24-31` で `except Exception` で握り潰してループ継続する実装
* `services/ai/main.py:90` のコメントには「`raise` で Consumer に失敗を伝えて再配送させる」と書かれていたが、上位の `_handle_message` の `raise` は consumer の except に飲み込まれていた
* Service Bus のロック期限はデフォルト数十秒〜分単位で、その間メッセージは他コンシューマーで処理できなくなる

## 変更内容
* `services/ai/consumers/service_bus.py`
  * ハンドラ例外時に `receiver.abandon_message(message)` を明示呼び出し
  * `abandon_message` 自体が失敗した場合は `logger.exception` でログのみ残してループは継続
* `services/ai/tests/test_service_bus.py`
  * 既存テストの `_MockReceiver` に `abandon_message = AsyncMock()` を追加
  * 新規テスト 2 件: 「ハンドラ失敗時に abandon_message が呼ばれる」「abandon_message 失敗時もループ継続」

## 動作確認手順
1. `cd services/ai && uv run pytest tests/test_service_bus.py -v` を実行し 4 ケース全て通ることを確認する
2. `make dev` で開発環境を起動し、AI Service のログでメッセージ処理が継続することを確認する
3. （任意）解析失敗を意図的に起こすメッセージを投入し、ロックが即解放されることを Service Bus エミュレータで確認する

## スクリーンショット
* 内部処理の修正のためなし