### PR TITLE
fix(ai): call1 の keywords パースが dict 形式の戻り値を拾えるようにする

### DIFF
--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -49,6 +49,26 @@ def _load_prompts() -> dict:
         return tomllib.load(f)
 
 
+def _extract_keywords(parsed: dict | list) -> list[str]:
+    """call1 の戻り値からキーワードリストを抽出する。
+
+    プロンプトは list を期待しているが、LLM が `{"keywords": [...]}` のような
+    dict を返すケースに備えて代表的なキー名と「最初の list 値」をフォールバック
+    として拾う。どちらにも該当しなければ空 list を返す。
+    """
+    if isinstance(parsed, list):
+        return [str(k) for k in parsed]
+    if isinstance(parsed, dict):
+        for key in ("keywords", "items", "data"):
+            value = parsed.get(key)
+            if isinstance(value, list):
+                return [str(k) for k in value]
+        for value in parsed.values():
+            if isinstance(value, list):
+                return [str(k) for k in value]
+    return []
+
+
 def _calc_input_hash(job: AnalysisJobInput) -> str:
     """入力の再現性確認用ハッシュを計算する。"""
     payload = {
@@ -145,7 +165,11 @@ async def analyze_meeting(
         raw_outputs["call1"] = raw1
         if isinstance(parsed1, dict) and "_parse_error" in parsed1:
             return _failed("call1", parsed1, raw_outputs, input_hash)
-        keywords: list[str] = parsed1 if isinstance(parsed1, list) else []
+        keywords: list[str] = _extract_keywords(parsed1)
+        if not keywords and not isinstance(parsed1, list):
+            logger.warning(
+                "[call1] キーワード抽出失敗: 受け取った形式=%s", type(parsed1).__name__
+            )
         logger.info("[call1] キーワード抽出完了: %d件", len(keywords))
 
         # ── RAG検索① ──────────────────────────────────────────

--- a/services/ai/tests/test_analyze_pipeline.py
+++ b/services/ai/tests/test_analyze_pipeline.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 from llm.client import FakeLLMClient
-from pipeline.analyze_meeting import analyze_meeting
+from pipeline.analyze_meeting import _extract_keywords, analyze_meeting
 from pipeline.continuity import (
     prepare_change_summary_for_call6,
     prepare_prev_open_issues_for_call2,
@@ -317,3 +317,34 @@ def test_prepare_change_summary_for_call6():
     summary = prepare_change_summary_for_call6(prev_json)
     assert "完了タスク" in summary
     assert "継続中" in summary  # high_recurrence_issues に含まれる
+
+
+# ──────────────────────── _extract_keywords ──────────────────────────
+
+
+def test_extract_keywords_from_list():
+    assert _extract_keywords(["a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_extract_keywords_from_keywords_key():
+    assert _extract_keywords({"keywords": ["x", "y"]}) == ["x", "y"]
+
+
+def test_extract_keywords_from_items_key():
+    assert _extract_keywords({"items": ["foo"]}) == ["foo"]
+
+
+def test_extract_keywords_falls_back_to_first_list_value():
+    assert _extract_keywords({"other": ["alpha"]}) == ["alpha"]
+
+
+def test_extract_keywords_returns_empty_when_no_list_found():
+    assert _extract_keywords({"summary": "string only"}) == []
+
+
+def test_extract_keywords_returns_empty_for_unsupported_type():
+    assert _extract_keywords("not a dict or list") == []  # type: ignore[arg-type]
+
+
+def test_extract_keywords_coerces_to_str():
+    assert _extract_keywords([1, 2, 3]) == ["1", "2", "3"]


### PR DESCRIPTION
## 関連Issue
Closes #248

## 概要・目的
* call1 はキーワード list を返すプロンプトだが、LLM の出力揺れで `{"keywords": [...]}` のような dict が返るケースに対応していなかった
* `_extract_keywords` ヘルパーを追加し、list / 代表 dict キー / 最初の list 値の順でフォールバック取得する

## 背景
* `services/ai/pipeline/analyze_meeting.py:148` で `keywords = parsed1 if isinstance(parsed1, list) else []` の単純判定
* LLM が dict 形式で返した場合、空 list 扱いされて RAG 検索や call2 のキーワード文脈が空になっていた
* プロンプトを完全にコントロールできない以上、入口側で形式揺れを吸収するのが妥当

## 変更内容
* `services/ai/pipeline/analyze_meeting.py`
  * `_extract_keywords(parsed: dict | list) -> list[str]` を追加
    * list → そのまま str 化
    * dict → `keywords` / `items` / `data` キーを優先、無ければ最初の list 値を fallback
    * どちらでもなければ空 list
  * call1 結果取得を `keywords = _extract_keywords(parsed1)` に差し替え
  * dict 経由で keywords が取れなかった場合は warning ログを残す
* `services/ai/tests/test_analyze_pipeline.py`
  * `_extract_keywords` の単体テストを 7 ケース追加
    * list / keywords key / items key / 最初の list 値 / 文字列のみ dict / 非対応型 / 数値要素の str 化

## 動作確認手順
1. `cd services/ai && uv run pytest tests/test_analyze_pipeline.py -v` を実行し、既存パイプラインテストおよび `_extract_keywords` テストが全て通ることを確認する
2. `cd services/ai && uv run ruff check .` で lint が通ることを確認する
3. （任意）`make dev` 環境で実 LLM が dict 形式を返した場合に warning ログが出ることを確認する

## スクリーンショット
* 内部処理の修正のためなし