### PR TITLE
fix(ai): LLM クライアントを非同期化し event loop ブロックを解消する

### DIFF
--- a/services/ai/llm/client.py
+++ b/services/ai/llm/client.py
@@ -4,26 +4,29 @@ from abc import ABC, abstractmethod
 
 class LLMClient(ABC):
     @abstractmethod
-    def call(self, prompt: str, temperature: float = 0.1) -> str:
+    async def call(self, prompt: str, temperature: float = 0.1) -> str:
         """プロンプトを送信してraw textを返す。"""
         ...
 
 
 class AzureOpenAIClient(LLMClient):
-    """本番用。環境変数からAzure OpenAI設定を読む。"""
+    """本番用。環境変数からAzure OpenAI設定を読む。
+
+    AsyncAzureOpenAI を使い、event loop をブロックせずに LLM 呼び出しを行う。
+    """
 
     def __init__(self) -> None:
-        from openai import AzureOpenAI
+        from openai import AsyncAzureOpenAI
 
-        self.client = AzureOpenAI(
+        self.client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             api_version=os.environ["AZURE_OPENAI_API_VERSION"],
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         )
         self.deployment = os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"]
 
-    def call(self, prompt: str, temperature: float = 0.1) -> str:
-        response = self.client.chat.completions.create(
+    async def call(self, prompt: str, temperature: float = 0.1) -> str:
+        response = await self.client.chat.completions.create(
             model=self.deployment,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
@@ -39,7 +42,7 @@ class FakeLLMClient(LLMClient):
         self.responses = responses
         self._call_counter: dict[str, int] = {}
 
-    def call(self, prompt: str, temperature: float = 0.1) -> str:
+    async def call(self, prompt: str, temperature: float = 0.1) -> str:
         # promptの内容からCallを識別して対応するレスポンスを返す
         for key, response in self.responses.items():
             if key in prompt:

--- a/services/ai/llm/json_runner.py
+++ b/services/ai/llm/json_runner.py
@@ -17,15 +17,15 @@ def parse_json_output(raw: str) -> dict | list:
     return cast(dict[Any, Any] | list[Any], json.loads(cleaned))
 
 
-def run_llm_call(
+async def run_llm_call(
     client: LLMClient, call_name: str, prompt: str
 ) -> tuple[str, dict | list]:
     """
-    LLMを呼び出し、raw textとパース済みdictを返す。
+    LLMを非同期で呼び出し、raw textとパース済みdictを返す。
     パース失敗時はraw textとエラー情報をdictで返す（例外は送出しない）。
     """
     logger.info("[%s] 実行中...", call_name)
-    raw = client.call(prompt)
+    raw = await client.call(prompt)
     logger.debug("[%s] OUTPUT: %.200s", call_name, raw)
 
     try:

--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -141,7 +141,7 @@ async def analyze_meeting(
             prompts["call1_keywords"]["template"],
             transcript=job.transcript,
         )
-        raw1, parsed1 = run_llm_call(llm_client, "call1", prompt1)
+        raw1, parsed1 = await run_llm_call(llm_client, "call1", prompt1)
         raw_outputs["call1"] = raw1
         if isinstance(parsed1, dict) and "_parse_error" in parsed1:
             return _failed("call1", parsed1, raw_outputs, input_hash)
@@ -168,7 +168,7 @@ async def analyze_meeting(
             rag_context=rag_context,
             prev_open_issues=prev_open_issues,
         )
-        raw2, parsed2 = run_llm_call(llm_client, "call2", prompt2)
+        raw2, parsed2 = await run_llm_call(llm_client, "call2", prompt2)
         raw_outputs["call2"] = raw2
         if isinstance(parsed2, dict) and "_parse_error" in parsed2:
             return _failed("call2", parsed2, raw_outputs, input_hash)
@@ -203,7 +203,7 @@ async def analyze_meeting(
             rag_context=rag_context,
             prev_tasks=prev_tasks,
         )
-        raw3, parsed3 = run_llm_call(llm_client, "call3", prompt3)
+        raw3, parsed3 = await run_llm_call(llm_client, "call3", prompt3)
         raw_outputs["call3"] = raw3
         if isinstance(parsed3, dict) and "_parse_error" in parsed3:
             return _failed("call3", parsed3, raw_outputs, input_hash)
@@ -231,7 +231,7 @@ async def analyze_meeting(
             transcription_quality=job.transcription_quality,
             context_summary=context_summary,
         )
-        raw4a, parsed4a = run_llm_call(llm_client, "call4a", prompt4a)
+        raw4a, parsed4a = await run_llm_call(llm_client, "call4a", prompt4a)
         raw_outputs["call4a"] = raw4a
         ambiguities_quality: list[dict] = (
             parsed4a.get("ambiguities_quality", [])
@@ -244,7 +244,7 @@ async def analyze_meeting(
             prompts["call4b_content_ambiguities"]["template"],
             context_summary=context_summary,
         )
-        raw4b, parsed4b = run_llm_call(llm_client, "call4b", prompt4b)
+        raw4b, parsed4b = await run_llm_call(llm_client, "call4b", prompt4b)
         raw_outputs["call4b"] = raw4b
         ambiguities_content: list[dict] = (
             parsed4b.get("ambiguities_content", [])
@@ -265,7 +265,7 @@ async def analyze_meeting(
                 meeting_date=job.meeting_date,
                 due_date_raws=due_date_raws,
             )
-            raw5, parsed5 = run_llm_call(llm_client, "call5", prompt5)
+            raw5, parsed5 = await run_llm_call(llm_client, "call5", prompt5)
             raw_outputs["call5"] = raw5
             if isinstance(parsed5, dict) and "_parse_error" not in parsed5:
                 conversions = parsed5.get("conversions", [])
@@ -308,7 +308,7 @@ async def analyze_meeting(
             suggested_participants=suggested_participants,
             change_summary=change_summary,
         )
-        raw6, parsed6 = run_llm_call(llm_client, "call6", prompt6)
+        raw6, parsed6 = await run_llm_call(llm_client, "call6", prompt6)
         raw_outputs["call6"] = raw6
         summary = ""
         recommended_agenda: list[dict] = []


### PR DESCRIPTION
## 関連Issue
Closes #249

## 概要・目的
* `AzureOpenAIClient.call` が同期実装で、async な `analyze_meeting` の中で 6 回の LLM 呼び出しごとに event loop をブロックしていた
* `AsyncAzureOpenAI` ベースに置き換え、Service Bus consumer の `async for` が解析中も止まらないようにする

## 背景
* `services/ai/llm/client.py:25-31` が `self.client.chat.completions.create(...)` を同期呼び出し
* `analyze_meeting` は async だが、内部の `run_llm_call` 経由で同期呼び出しがそのまま走り、event loop を call1〜call6 で連続ブロック
* 結果として Service Bus consumer の `async for message in receiver` が止まり、ヘルスチェック応答も遅延する

## 変更内容
* `services/ai/llm/client.py`
  * `LLMClient` ABC を `async def call(...)` に変更
  * `AzureOpenAIClient` を `openai.AsyncAzureOpenAI` ベースに置き換え、`call` を async + await に
  * `FakeLLMClient.call` も `async def` に統一
* `services/ai/llm/json_runner.py`
  * `run_llm_call` を `async def` + `await client.call(prompt)` に変更
* `services/ai/pipeline/analyze_meeting.py`
  * call1〜call6 の `run_llm_call` 呼び出し 6 箇所すべてに `await` を付与

挙動上はシリアル実行のまま（call1 → call2 → ... → call6）です。LLM 呼び出し中に他コルーチンが進行可能になる点が主目的。

## 動作確認手順
1. `cd services/ai && uv run pytest -v` を実行し、全 36 テストが通ることを確認する
2. `cd services/ai && uv run ruff check .` で lint が通ることを確認する
3. `make dev` で開発環境を起動し、`POST /meetings/:id/analyze` 実行中も `GET /health` が即座に 200 を返すことを確認する

## スクリーンショット
* 内部処理の修正のためなし