### PR TITLE
fix(ai): /analyze で結果保存失敗を握り潰さず 502 を返す

### DIFF
--- a/services/ai/routers/analysis.py
+++ b/services/ai/routers/analysis.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from integrations.app_api_client import AppApiClient
 from llm.client import AzureOpenAIClient
@@ -23,6 +23,7 @@ async def analyze(job: AnalysisJobInput) -> AnalysisRunResult:
 
     analysis_run_idがある場合:
     - 解析完了後にapps/apiのPATCH /internal/analysis-runs/:id/resultを呼ぶ
+    - PATCH失敗時は 502 を返し、呼び出し側に保存失敗を明示する
     """
     llm_client = AzureOpenAIClient()
     result = await analyze_meeting(job, llm_client)
@@ -34,7 +35,19 @@ async def analyze(job: AnalysisJobInput) -> AnalysisRunResult:
                 job.analysis_run_id,
                 result.model_dump(exclude_none=True),
             )
-        except Exception:
+        except Exception as e:
             logger.exception("結果保存失敗 analysis_run_id=%s", job.analysis_run_id)
+            # PATCH 失敗を握り潰さず、呼び出し側に通知する。
+            # 解析自体は完了しているので、再投入判断に使えるよう
+            # result も detail に含める。
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "結果保存に失敗しました",
+                    "analysis_run_id": job.analysis_run_id,
+                    "underlying_error": str(e),
+                    "result": result.model_dump(exclude_none=True),
+                },
+            ) from e
 
     return result

--- a/services/ai/tests/test_analysis_router.py
+++ b/services/ai/tests/test_analysis_router.py
@@ -1,0 +1,89 @@
+"""routers/analysis.py の挙動検証テスト。"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from routers.analysis import analyze
+from schemas.analysis import AnalysisJobInput, AnalysisRunResult
+
+
+def _make_job(run_id: str | None) -> AnalysisJobInput:
+    return AnalysisJobInput(
+        analysis_run_id=run_id,
+        meeting_id="mtg-1",
+        meeting_type="recurring_meeting",
+        transcription_quality="full",
+        transcript="本日の議題は...",
+        meeting_date="2026-05-21",
+        speakers=[],
+        previous_report_json=None,
+    )
+
+
+def _make_completed_result() -> AnalysisRunResult:
+    return AnalysisRunResult(status="completed", summary="ダミーサマリー")
+
+
+@pytest.mark.asyncio
+async def test_analyze_dry_run_skips_api_client():
+    """analysis_run_id 省略時は AppApiClient を呼び出さない。"""
+    job = _make_job(run_id=None)
+    expected_result = _make_completed_result()
+
+    with patch("routers.analysis.AzureOpenAIClient") as _mock_llm, patch(
+        "routers.analysis.analyze_meeting",
+        new=AsyncMock(return_value=expected_result),
+    ), patch("routers.analysis.AppApiClient") as mock_client_cls:
+        result = await analyze(job)
+
+    assert result == expected_result
+    mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_analyze_with_run_id_calls_patch():
+    """analysis_run_id 指定時は AppApiClient.update_analysis_run_result を呼ぶ。"""
+    job = _make_job(run_id="run-1")
+    expected_result = _make_completed_result()
+
+    with patch("routers.analysis.AzureOpenAIClient") as _mock_llm, patch(
+        "routers.analysis.analyze_meeting",
+        new=AsyncMock(return_value=expected_result),
+    ), patch("routers.analysis.AppApiClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.update_analysis_run_result = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await analyze(job)
+
+        assert result == expected_result
+        mock_client.update_analysis_run_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_analyze_raises_502_when_patch_fails():
+    """PATCH 失敗時は HTTPException(502) を投げ、detail に result を含める。"""
+    job = _make_job(run_id="run-1")
+    expected_result = _make_completed_result()
+
+    with patch("routers.analysis.AzureOpenAIClient") as _mock_llm, patch(
+        "routers.analysis.analyze_meeting",
+        new=AsyncMock(return_value=expected_result),
+    ), patch("routers.analysis.AppApiClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.update_analysis_run_result = AsyncMock(
+            side_effect=RuntimeError("PATCH failed")
+        )
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(HTTPException) as exc_info:
+            await analyze(job)
+
+    assert exc_info.value.status_code == 502
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["analysis_run_id"] == "run-1"
+    assert "PATCH failed" in detail["underlying_error"]
+    # 解析結果が再投入できるよう含まれていること
+    assert detail["result"]["status"] == "completed"


### PR DESCRIPTION
## 関連Issue
Closes #250

## 概要・目的
* `POST /analyze` で apps/api への PATCH /internal/analysis-runs/:id/result に失敗した場合、ログだけ残して HTTP 200 + completed 結果を返していた
* クライアントは「完了」を信じる一方で apps/api 側 DB は queued/analyzing のまま放置される状態不整合を解消する

## 背景
* `services/ai/routers/analysis.py:36-39` で `logger.exception` のみ
* /analyze は dev/検証用エンドポイントだが、失敗の事実を隠す設計は再現確認の難易度を上げるため修正する
* 解析自体は完了しているので、再投入判断に使えるよう result を detail に含める

## 変更内容
* `services/ai/routers/analysis.py`
  * PATCH 失敗時に `HTTPException(status_code=502, detail={...})` を raise する
  * detail に `analysis_run_id` / `underlying_error` / `result`（completed の AnalysisRunResult）を含める
  * `raise ... from e` で原例外も保持
* `services/ai/tests/test_analysis_router.py`（新規）
  * ドライランで AppApiClient を呼ばないこと
  * PATCH 成功時に通常レスポンスが返ること
  * PATCH 失敗時に 502 + detail に result が含まれること

## 動作確認手順
1. `cd services/ai && uv run pytest tests/test_analysis_router.py -v` で 3 ケース全て通ることを確認する
2. `cd services/ai && uv run ruff check .` で lint が通ることを確認する
3. （任意）apps/api を止めた状態で `POST /analyze` を `analysis_run_id` 付きで叩き、502 と detail.result が返ることを確認する

## スクリーンショット
* APIレスポンスの変更：失敗時 502 + 下記 detail を返す
  ```json
  {
    "detail": {
      "error": "結果保存に失敗しました",
      "analysis_run_id": "run-xxx",
      "underlying_error": "...",
      "result": { "status": "completed", "summary": "...", ... }
    }
  }
  ```