### PR TITLE
fix(ai): report_json に estimation / estimation_note を含める

### DIFF
--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -118,6 +118,11 @@ def _assemble(
         },
         "summary": summary,
         "alert_level": alert_level,
+        # estimation / estimation_note は AnalysisRunResult のトップレベルでは
+        # 保持しないため、apps/api 側で UI 表示や MeetingEstimationBreakdown 反映に
+        # 使えるよう report_json にも含める（issue #251）。
+        "estimation": estimation,
+        "estimation_note": estimation_note,
         "validation_warnings": validation_warnings,
         "rag_retrieval": rag_retrieval,
         "decisions": decisions,

--- a/services/ai/tests/test_analyze_pipeline.py
+++ b/services/ai/tests/test_analyze_pipeline.py
@@ -177,6 +177,13 @@ async def test_analyze_meeting_completed():
     # handoverが存在すること
     assert "handover" in report
 
+    # estimation / estimation_note が report_json に含まれていること（#251）
+    assert "estimation" in report
+    assert "breakdown" in report["estimation"]
+    assert "total_minutes" in report["estimation"]
+    assert isinstance(report.get("estimation_note"), str)
+    assert "想定所要時間" in report["estimation_note"]
+
 
 @pytest.mark.asyncio
 async def test_analyze_meeting_parse_error_returns_failed():


### PR DESCRIPTION
## 関連Issue
Closes #251

## 概要・目的
* `_assemble` が `estimation` と `estimation_note` を引数で受け取っているのに戻り値 (report_json) に含めず破棄していた
* apps/api 側でも `MeetingEstimationBreakdown` への書き込みコードは存在しないため、AI Service 側で報告漏れになっていた
* report_json に追加し、apps/api の UI 表示や DB 反映の入口を確保する

## 背景
* `services/ai/pipeline/analyze_meeting.py:84-113` の `_assemble` が `estimation_note` / `estimation` を引数だけで受けて return には含めない実装になっていた
* `alert_level = calc_alert_level(estimation)` のみが間接的に使われ、内訳と note 文字列は呼び出し元で破棄されていた
* apps/api 側 (`prisma/schema.prisma:301-315` の `MeetingEstimationBreakdown` テーブル / `apps/api/src/routes/internal.ts`) を grep しても書き込み経路が無く、AI 側の出力漏れが原因と判断

## 変更内容
* `services/ai/pipeline/analyze_meeting.py`
  * `_assemble` の戻り値に `estimation` と `estimation_note` を追加
  * 意図を明記するコメントを併記
* `services/ai/tests/test_analyze_pipeline.py`
  * 既存縦断テスト `test_analyze_meeting_completed` に `estimation` / `estimation_note` のアサーションを追加

## 動作確認手順
1. `cd services/ai && uv run pytest tests/test_analyze_pipeline.py -v` を実行し既存パイプラインテストが通ることを確認する
2. `cd services/ai && uv run ruff check .` で lint が通ることを確認する
3. （任意）`POST /analyze` の dry-run を叩き、レスポンスの `report_json` に `estimation.breakdown` / `estimation.total_minutes` / `estimation_note` が含まれていることを確認する

## スクリーンショット
* レスポンス JSON に下記が追加される
  ```json
  {
    "report_json": {
      "estimation": { "breakdown": {...}, "total_minutes": 35 },
      "estimation_note": "次回会議の想定所要時間: 約35分\n  - 必須タスク確認: 3件 × 2分 = 6分\n  - ..."
    }
  }
  ```