### PR TITLE
fix(ai): _fmt_estimation_note で count==0 のとき ZeroDivisionError を防ぐ

### DIFF
--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -434,10 +434,14 @@ def _fmt_estimation_note(estimation: dict) -> str:
     }
     for key, val in breakdown.items():
         label = label_map.get(key, key)
-        per = val["minutes"] // val["count"]
-        lines.append(
-            f"  - {label}: {val['count']}件 × {per}分 = {val['minutes']}分"
-        )
+        count = val.get("count", 0)
+        minutes = val.get("minutes", 0)
+        if count <= 0:
+            # 件数 0 のカテゴリは「N分」のみ表示し、ZeroDivisionError を回避する。
+            lines.append(f"  - {label}: 0件 = {minutes}分")
+            continue
+        per = minutes // count
+        lines.append(f"  - {label}: {count}件 × {per}分 = {minutes}分")
     return "\n".join(lines)
 
 

--- a/services/ai/tests/test_analyze_pipeline.py
+++ b/services/ai/tests/test_analyze_pipeline.py
@@ -4,7 +4,11 @@ import json
 import pytest
 
 from llm.client import FakeLLMClient
-from pipeline.analyze_meeting import _extract_keywords, analyze_meeting
+from pipeline.analyze_meeting import (
+    _extract_keywords,
+    _fmt_estimation_note,
+    analyze_meeting,
+)
 from pipeline.continuity import (
     prepare_change_summary_for_call6,
     prepare_prev_open_issues_for_call2,
@@ -348,3 +352,39 @@ def test_extract_keywords_returns_empty_for_unsupported_type():
 
 def test_extract_keywords_coerces_to_str():
     assert _extract_keywords([1, 2, 3]) == ["1", "2", "3"]
+
+
+# ──────────────────────── _fmt_estimation_note ────────────────────────
+
+
+def test_fmt_estimation_note_with_normal_breakdown():
+    estimation = {
+        "total_minutes": 25,
+        "breakdown": {
+            "required_task_check": {"count": 3, "minutes": 6},
+            "buffer": {"count": 1, "minutes": 10},
+        },
+    }
+    note = _fmt_estimation_note(estimation)
+    assert "想定所要時間: 約25分" in note
+    assert "必須タスク確認: 3件 × 2分 = 6分" in note
+    assert "バッファ: 1件 × 10分 = 10分" in note
+
+
+def test_fmt_estimation_note_handles_zero_count_without_zero_division():
+    """count==0 のカテゴリでも ZeroDivisionError を起こさない。"""
+    estimation = {
+        "total_minutes": 10,
+        "breakdown": {
+            "buffer": {"count": 0, "minutes": 10},
+        },
+    }
+    note = _fmt_estimation_note(estimation)
+    # 0件のカテゴリは「N分」のみ表示する
+    assert "0件" in note
+    assert "10分" in note
+
+
+def test_fmt_estimation_note_with_empty_breakdown():
+    note = _fmt_estimation_note({"total_minutes": 0, "breakdown": {}})
+    assert "想定所要時間: 約0分" in note


### PR DESCRIPTION
## 関連Issue
Closes #252

## 概要・目的
* `_fmt_estimation_note` の `per = val["minutes"] // val["count"]` が、将来 count==0 のカテゴリを入れた瞬間に ZeroDivisionError で落ちる構造だった
* count==0 の場合は「N分」のみ表示する分岐を追加して防御する

## 背景
* `services/ai/pipeline/analyze_meeting.py:413` で `val["minutes"] // val["count"]` の単純除算
* 現状の `calc_estimation` は `count > 0` のときのみ breakdown を入れるため本番経路では発生しないが、`buffer` 等で `count: 0` を許す変更が入ると即座に落ちる
* 入力に対する防御的実装を入れて、estimation カテゴリ追加時の地雷を取り除く

## 変更内容
* `services/ai/pipeline/analyze_meeting.py`
  * `count <= 0` のとき「{label}: 0件 = {minutes}分」を出力する分岐を追加
  * `count` / `minutes` 取得を `val.get(..., 0)` に変更し欠落キーにも耐える
* `services/ai/tests/test_analyze_pipeline.py`
  * `_fmt_estimation_note` の単体テスト 3 ケース追加（通常 / count==0 / 空 breakdown）

## 動作確認手順
1. `cd services/ai && uv run pytest tests/test_analyze_pipeline.py -v -k "fmt_estimation_note"` を実行し 3 ケース全て通ることを確認する
2. `cd services/ai && uv run pytest` で 49 件全て通ることを確認する
3. `cd services/ai && uv run ruff check .` で lint が通ることを確認する

## スクリーンショット
* 内部処理の修正のためなし