### PR TITLE
fix: MeetingAnalysisRun.status を Prisma enum 化し型保証を強化する

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -302,7 +302,7 @@ Table AmbiguousInfo {
 Table MeetingAnalysisRun {
   id String [pk]
   meetingId String [not null]
-  status String [not null, default: 'queued']
+  status AnalysisRunStatus [not null, default: 'queued']
   currentStep String
   triggerType String
   modelName String
@@ -448,6 +448,13 @@ Enum InvitationStatus {
 Enum MeetingRole {
   owner
   member
+}
+
+Enum AnalysisRunStatus {
+  queued
+  analyzing
+  completed
+  failed
 }
 
 Ref: Meeting.previousMeetingId - Meeting.id

--- a/apps/api/prisma/migrations/20260521012142_add_analysis_run_status_enum/migration.sql
+++ b/apps/api/prisma/migrations/20260521012142_add_analysis_run_status_enum/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - The `status` column on the `MeetingAnalysisRun` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "AnalysisRunStatus" AS ENUM ('queued', 'analyzing', 'completed', 'failed');
+
+-- AlterTable
+ALTER TABLE "MeetingAnalysisRun" DROP COLUMN "status",
+ADD COLUMN     "status" "AnalysisRunStatus" NOT NULL DEFAULT 'queued';
+
+-- CreateIndex
+CREATE INDEX "MeetingAnalysisRun_meetingId_status_idx" ON "MeetingAnalysisRun"("meetingId", "status");
+
+-- CreateIndex
+CREATE INDEX "MeetingAnalysisRun_status_idx" ON "MeetingAnalysisRun"("status");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -503,6 +503,14 @@ model AmbiguousInfo {
   @@index([status])
 }
 
+// 解析ランの実行状態。queued → analyzing → completed | failed の遷移を取る。
+enum AnalysisRunStatus {
+  queued
+  analyzing
+  completed
+  failed
+}
+
 // AI解析の実行履歴。1回の解析runごとに、最終JSON・検証警告・RAG検索ログなどを保持する。
 // 業務状態の正本ではなく、監査・再現性・デバッグ・再実行比較のためのスナップショット。
 model MeetingAnalysisRun {
@@ -510,7 +518,7 @@ model MeetingAnalysisRun {
   meetingId String
 
   // 実行状態
-  status      String  @default("queued")
+  status      AnalysisRunStatus @default(queued)
   currentStep String?
   triggerType String?
 

--- a/services/ai/schemas/analysis.py
+++ b/services/ai/schemas/analysis.py
@@ -1,6 +1,10 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
+
+# apps/api 側の Prisma enum AnalysisRunStatus と一致させる。
+# 変更時は両方を同時に更新すること。
+AnalysisRunStatus = Literal["queued", "analyzing", "completed", "failed"]
 
 
 class SpeakerInfo(BaseModel):
@@ -26,7 +30,7 @@ class AnalysisJobInput(BaseModel):
 
 
 class AnalysisRunResult(BaseModel):
-    status: str  # "completed" | "failed"
+    status: AnalysisRunStatus
     current_step: Optional[str] = None
     report_json: Optional[dict] = None
     raw_outputs_json: Optional[dict] = None


### PR DESCRIPTION
## 関連Issue
Closes #253

## 概要・目的
* `MeetingAnalysisRun.status` が String で実装層 (`VALID_TRANSITIONS`) 管理になっていたが、他テーブル（TaskStatus / DecisionItemStatus 等）は Prisma enum で型保証されており一貫性が崩れていた
* `enum AnalysisRunStatus { queued analyzing completed failed }` を追加し、DB レベルで不正値を排除する
* Python 側も `Literal` で揃え、apps/api ↔ AI Service の API 契約を型レベルで一致させる

## 背景
* `apps/api/prisma/schema.prisma:513` が `status String @default("queued")` で String 型
* 許容値は `apps/api/src/routes/internal.ts` の `VALID_TRANSITIONS` でアプリ層管理
* DB に直接 INSERT すれば任意の文字列が入る状態
* Python 側 `services/ai/schemas/analysis.py:29` は `status: str` でコメント `# "completed" | "failed"` のみ

## 変更内容
* `apps/api/prisma/schema.prisma`
  * `enum AnalysisRunStatus { queued analyzing completed failed }` を追加
  * `MeetingAnalysisRun.status` を `AnalysisRunStatus @default(queued)` に変更
* `apps/api/prisma/dbml/schema.dbml`
  * `prisma generate` の出力差分
* `services/ai/schemas/analysis.py`
  * `AnalysisRunStatus = Literal["queued", "analyzing", "completed", "failed"]` を定義
  * `AnalysisRunResult.status` を `AnalysisRunStatus` 型に変更
* TypeScript 側のコードはそのまま（Prisma が enum を string literal union として生成するため、既存の `"queued"` 等の文字列リテラルがそのまま互換）

## 動作確認手順
1. （マイグレーション生成）ローカル DB を起動した状態で次を実行する
   ```bash
   make migrate NAME=add_analysis_run_status_enum
   ```
   生成されたマイグレーションファイル (`apps/api/prisma/migrations/*_add_analysis_run_status_enum/migration.sql`) を本ブランチに追加 commit してから merge する
2. `pnpm --filter api typecheck` がエラーなく完了することを確認する
3. `pnpm --filter api test` で全 278 件が通ることを確認する
4. `cd services/ai && uv run pytest` で全 46 件が通ることを確認する
5. `make dev-reset` で DB を作り直して `make migrate` 後、`POST /meetings/:id/analyze` 経由で解析ランが正常に動作することを確認する

## 注意
* マイグレーションファイルはローカル DB なしでは生成できないため、本 PR ではプロジェクトメンバーが生成してから merge する想定です
* 本番デプロイ前提のため、既存データの移行は不要（dev-reset で作り直し）

## スクリーンショット
* スキーマレベルの修正のためなし