### PR TITLE
refactor: 会議アクセス検証を requireMeetingAccess に集約する

### DIFF
--- a/apps/api/src/middleware/meeting-access.ts
+++ b/apps/api/src/middleware/meeting-access.ts
@@ -1,0 +1,75 @@
+import type { Prisma } from "@prisma/client";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import type { AuthVariables } from "./auth.js";
+
+// 認可検証で取得する meeting 情報。組織判定に必要な最小限の include に揃える。
+const meetingAccessInclude = {
+  recurringMeeting: { select: { organizationId: true } },
+} satisfies Prisma.MeetingInclude;
+
+type MeetingForAccess = Prisma.MeetingGetPayload<{
+  include: typeof meetingAccessInclude;
+}>;
+
+// 認可検証通過時に呼び出し側へ渡る meeting。recurringMeeting が null でないことを保証する。
+type AccessibleMeeting = MeetingForAccess & {
+  recurringMeeting: NonNullable<MeetingForAccess["recurringMeeting"]>;
+};
+
+export type MeetingAccessResult =
+  | {
+      ok: true;
+      meeting: AccessibleMeeting;
+      membership: Prisma.OrganizationMembershipGetPayload<true>;
+    }
+  | { ok: false; response: Response };
+
+/**
+ * /meetings/:id 配下の認可検証を共通化したヘルパー。
+ *
+ * - meeting を recurringMeeting.organizationId 付きで取得する
+ * - 単発会議（recurringMeetingId=null）は組織判定不能のため 404 で拒否する
+ * - 認証ユーザーが当該組織のメンバーでなければ 404 で拒否する
+ *   （attackable surface を増やさないため 403 ではなく 404 で揃える）
+ *
+ * 呼び出し側は GET /:id のような追加情報が必要なケースでは、本ヘルパーで認可を
+ * 確定したあとに必要な include 付きで再フェッチする想定。
+ */
+export async function requireMeetingAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  meetingId: string,
+): Promise<MeetingAccessResult> {
+  const meeting = await prisma.meeting.findUnique({
+    where: { id: meetingId },
+    include: meetingAccessInclude,
+  });
+  if (!meeting?.recurringMeeting) {
+    return {
+      ok: false,
+      response: c.json({ error: "会議が見つかりません" }, 404),
+    };
+  }
+
+  const user = c.var.user;
+  const membership = await prisma.organizationMembership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId: user.id,
+        organizationId: meeting.recurringMeeting.organizationId,
+      },
+    },
+  });
+  if (!membership) {
+    return {
+      ok: false,
+      response: c.json({ error: "会議が見つかりません" }, 404),
+    };
+  }
+
+  return {
+    ok: true,
+    meeting: meeting as AccessibleMeeting,
+    membership,
+  };
+}

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -13,6 +13,7 @@ import {
   taskListOrderBy,
 } from "../lib/task-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireMeetingAccess } from "../middleware/meeting-access.js";
 
 // 会議メタ情報の更新スキーマ。transcriptText を中心に議事録関連フィールドを受け付ける。
 // 全フィールド optional だが、いずれか 1 つ以上の指定を必須とする。
@@ -38,9 +39,12 @@ const meetingUpdateSchema = z
 export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   .get("/:id", auth, async (c) => {
     const id = c.req.param("id");
-    // 会議 + 紐付く定例 + 組織 + 最新解析ランを一度に取得する。
-    // 単発会議（recurringMeetingId=null）は組織判定不能のため 404 で拒否する。
-    const meeting = await prisma.meeting.findUnique({
+    // 認可検証は共通ヘルパーで実施。GET /:id は追加情報が必要なため、
+    // 認可確定後に detail include 付きで再フェッチする。
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
+
+    const detail = await prisma.meeting.findUnique({
       where: { id },
       include: {
         recurringMeeting: {
@@ -55,24 +59,12 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         },
       },
     });
-    if (!meeting?.recurringMeeting) {
+    // requireMeetingAccess 通過直後なので存在は保証されるが、型ナローイングのため再判定
+    if (!detail?.recurringMeeting) {
       return c.json({ error: "会議が見つかりません" }, 404);
     }
 
-    const user = c.var.user;
-    const membership = await prisma.organizationMembership.findUnique({
-      where: {
-        userId_organizationId: {
-          userId: user.id,
-          organizationId: meeting.recurringMeeting.organizationId,
-        },
-      },
-    });
-    if (!membership) {
-      return c.json({ error: "会議が見つかりません" }, 404);
-    }
-
-    const { recurringMeeting, analysisRuns, ...rest } = meeting;
+    const { recurringMeeting, analysisRuns, ...rest } = detail;
     const latestRun = analysisRuns[0] ?? null;
 
     return c.json({
@@ -104,28 +96,8 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       const id = c.req.param("id");
       const filters = c.req.valid("query");
 
-      // 会議存在 + 紐付く定例経由で組織判定。単発会議（recurringMeetingId=null）は
-      // 組織判定不能のため 404 で拒否する（MVP スコープ）。
-      const meeting = await prisma.meeting.findUnique({
-        where: { id },
-        include: { recurringMeeting: { select: { organizationId: true } } },
-      });
-      if (!meeting?.recurringMeeting) {
-        return c.json({ error: "会議が見つかりません" }, 404);
-      }
-
-      const user = c.var.user;
-      const membership = await prisma.organizationMembership.findUnique({
-        where: {
-          userId_organizationId: {
-            userId: user.id,
-            organizationId: meeting.recurringMeeting.organizationId,
-          },
-        },
-      });
-      if (!membership) {
-        return c.json({ error: "会議が見つかりません" }, 404);
-      }
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
 
       // 当該会議を発生源とするタスクのみ。
       const tasks = await prisma.task.findMany({
@@ -143,27 +115,8 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
     const id = c.req.param("id");
     const data = c.req.valid("json");
 
-    // 会議 + 紐付く定例経由で組織判定する
-    const meeting = await prisma.meeting.findUnique({
-      where: { id },
-      include: { recurringMeeting: { select: { organizationId: true } } },
-    });
-    if (!meeting?.recurringMeeting) {
-      return c.json({ error: "会議が見つかりません" }, 404);
-    }
-
-    const user = c.var.user;
-    const membership = await prisma.organizationMembership.findUnique({
-      where: {
-        userId_organizationId: {
-          userId: user.id,
-          organizationId: meeting.recurringMeeting.organizationId,
-        },
-      },
-    });
-    if (!membership) {
-      return c.json({ error: "会議が見つかりません" }, 404);
-    }
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
 
     // undefined フィールドを除外して更新データを構築する
     const updateData: Record<string, unknown> = {};
@@ -185,30 +138,11 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   .post("/:id/analyze", auth, async (c) => {
     const id = c.req.param("id");
 
-    // 会議存在確認 + 組織判定
-    const meeting = await prisma.meeting.findUnique({
-      where: { id },
-      include: { recurringMeeting: { select: { organizationId: true } } },
-    });
-    if (!meeting?.recurringMeeting) {
-      return c.json({ error: "会議が見つかりません" }, 404);
-    }
-
-    const user = c.var.user;
-    const membership = await prisma.organizationMembership.findUnique({
-      where: {
-        userId_organizationId: {
-          userId: user.id,
-          organizationId: meeting.recurringMeeting.organizationId,
-        },
-      },
-    });
-    if (!membership) {
-      return c.json({ error: "会議が見つかりません" }, 404);
-    }
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
 
     // 文字起こしテキスト未設定は解析不可
-    if (!meeting.transcriptText) {
+    if (!access.meeting.transcriptText) {
       return c.json({ error: "文字起こしテキストが設定されていません" }, 400);
     }
 


### PR DESCRIPTION
## 関連Issue
Closes #254

## 概要・目的
* `routes/meetings.ts` の GET / PATCH / POST 各エンドポイント 4 箇所で `meeting.findUnique` + `organizationMembership.findUnique` の認可検証ブロックが重複していた
* 共通ヘルパー `requireMeetingAccess` に集約し、認可ロジック変更時に取りこぼしが起きないようにする

## 背景
* `apps/api/src/routes/meetings.ts` の GET /:id, GET /:id/tasks, PATCH /:id, POST /:id/analyze で同じパターンが 4 回繰り返し
* `recurring-meetings.ts` 側は `authz.findOrgMembership` を使うなど、組織所属判定のスタイルがファイル間で不揃いだった

## 変更内容
* `apps/api/src/middleware/meeting-access.ts`（新規）
  * `requireMeetingAccess(c, meetingId)` を実装
  * `MeetingAccessResult` 型で成功/失敗を表現（成功時は `meeting` と `membership`、失敗時は `Response`）
  * 単発会議（recurringMeetingId=null）と組織非所属はどちらも 404 で統一（attackable surface を増やさない）
* `apps/api/src/routes/meetings.ts`
  * 4 エンドポイントから重複する findUnique × 2 のブロックを撤去し、`requireMeetingAccess` 呼び出しに置換
  * GET /:id は detail フェッチが必要なため、認可確定後に include 付きで再フェッチする（include 形状の差は本ヘルパーでは扱わない）

## 動作確認手順
1. `pnpm --filter api typecheck` がエラーなく完了することを確認する
2. `pnpm --filter api test` で全 278 件が通ることを確認する
3. `pnpm --filter api lint` で lint が通ることを確認する
4. （任意）`make dev` で開発環境を起動し、`GET /meetings/:id` `GET /meetings/:id/tasks` `PATCH /meetings/:id` `POST /meetings/:id/analyze` の 4 エンドポイントが従来通り動作することを確認する

## スクリーンショット
* 内部リファクタのためなし