### PR TITLE
refactor: 解析ランの状態遷移を analysis-run-state.ts に中央化する

### DIFF
--- a/apps/api/src/lib/analysis-run-state.ts
+++ b/apps/api/src/lib/analysis-run-state.ts
@@ -1,0 +1,115 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+// 解析ランの状態。schema.prisma の enum AnalysisRunStatus と一致させる。
+export type AnalysisRunStatus = "queued" | "analyzing" | "completed" | "failed";
+
+/**
+ * 状態遷移テーブル。 `from` に対して許容される `to` の集合を定義する。
+ * - queued → analyzing（AI Service が解析開始時）
+ * - analyzing → completed（解析成功）/ failed（解析失敗）
+ * - completed / failed は終端状態（再遷移不可）
+ *
+ * 「queued → failed」のような遷移は外部 API（PATCH /internal/analysis-runs/:id）
+ * では許可していないため、本テーブルにも含めない。Service Bus 送信失敗時等の
+ * 内部経路で queued レコードを失敗にする場合は、本関数を経由しない direct
+ * update を使う（meetings.ts:POST /:id/analyze）。
+ */
+export const VALID_TRANSITIONS: Record<
+  AnalysisRunStatus,
+  ReadonlyArray<AnalysisRunStatus>
+> = {
+  queued: ["analyzing"],
+  analyzing: ["completed", "failed"],
+  completed: [],
+  failed: [],
+};
+
+export class InvalidAnalysisRunTransitionError extends Error {
+  readonly from: AnalysisRunStatus;
+  readonly to: AnalysisRunStatus;
+  constructor(from: AnalysisRunStatus, to: AnalysisRunStatus) {
+    super(`不正な状態遷移: ${from} → ${to}`);
+    this.name = "InvalidAnalysisRunTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+export function canTransition(
+  from: AnalysisRunStatus,
+  to: AnalysisRunStatus,
+): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+// 遷移時に同時に書き込むカラム類。Prisma UpdateInput と互換に絞り込み。
+export type AnalysisRunUpdateExtras = Omit<
+  Prisma.MeetingAnalysisRunUpdateInput,
+  "status" | "startedAt" | "completedAt" | "failedAt"
+>;
+
+export type TransitionOutcome =
+  | { kind: "transitioned"; from: AnalysisRunStatus }
+  | { kind: "noop"; current: AnalysisRunStatus } // 既に target の状態だった
+  | { kind: "conflict"; current: AnalysisRunStatus } // CAS で取り逃した
+  | { kind: "not_found" };
+
+/**
+ * 解析ランの状態を遷移させる。
+ *
+ * Compare-and-swap で同時更新の競合を検出する。
+ * 遷移ターゲットに応じて startedAt / completedAt / failedAt を自動セットする。
+ *
+ * - 不正遷移は InvalidAnalysisRunTransitionError を投げる
+ * - すでに target の状態なら { kind: "noop" } を返す（冪等）
+ * - CAS で取り逃した場合は { kind: "conflict" } を返す（呼び出し側で 409）
+ * - レコード不在は { kind: "not_found" }
+ */
+export async function transitionAnalysisRunStatus(
+  client: PrismaClient | Prisma.TransactionClient,
+  id: string,
+  to: AnalysisRunStatus,
+  extras?: AnalysisRunUpdateExtras,
+): Promise<TransitionOutcome> {
+  const current = await client.meetingAnalysisRun.findUnique({
+    where: { id },
+    select: { status: true },
+  });
+  if (!current) {
+    return { kind: "not_found" };
+  }
+  const from = current.status as AnalysisRunStatus;
+  if (from === to) {
+    return { kind: "noop", current: from };
+  }
+  if (!canTransition(from, to)) {
+    throw new InvalidAnalysisRunTransitionError(from, to);
+  }
+
+  const data: Prisma.MeetingAnalysisRunUpdateInput = {
+    ...(extras ?? {}),
+    status: to,
+  };
+  // 状態固有のタイムスタンプを自動セットする。extras 側では startedAt /
+  // completedAt / failedAt は受け取らない（型で除外済み）。
+  if (to === "analyzing") data.startedAt = new Date();
+  if (to === "completed") data.completedAt = new Date();
+  if (to === "failed") data.failedAt = new Date();
+
+  // 取得時の status を条件に加えた CAS。並行更新が走っていた場合は 0 件になる。
+  const result = await client.meetingAnalysisRun.updateMany({
+    where: { id, status: from },
+    data,
+  });
+  if (result.count === 0) {
+    const latest = await client.meetingAnalysisRun.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+    return {
+      kind: "conflict",
+      current: (latest?.status ?? from) as AnalysisRunStatus,
+    };
+  }
+  return { kind: "transitioned", from };
+}

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -1,6 +1,11 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  type AnalysisRunStatus,
+  InvalidAnalysisRunTransitionError,
+  transitionAnalysisRunStatus,
+} from "../lib/analysis-run-state.js";
 import { prisma } from "../lib/prisma.js";
 import { analysisRunsRoute } from "./analysis-runs.js";
 
@@ -36,11 +41,6 @@ const ambiguousInfoSchema = z.object({
   severity: z.enum(["high", "medium", "low"]).optional(),
 });
 
-const VALID_TRANSITIONS: Record<string, string[]> = {
-  queued: ["analyzing"],
-  analyzing: ["failed"],
-};
-
 export const internalRoute = new Hono()
   .route("/analysis-runs", analysisRunsRoute)
   .patch(
@@ -50,37 +50,35 @@ export const internalRoute = new Hono()
       const id = c.req.param("id");
       const { status } = c.req.valid("json");
 
-      const run = await prisma.meetingAnalysisRun.findUnique({ where: { id } });
-      if (!run) {
-        return c.json({ error: "analysis run が見つかりません" }, 404);
-      }
-
-      const allowed = VALID_TRANSITIONS[run.status] ?? [];
-      if (!allowed.includes(status)) {
-        return c.json(
-          { error: `${run.status} -> ${status} への遷移は許可されていません` },
-          422,
+      try {
+        const outcome = await transitionAnalysisRunStatus(
+          prisma,
+          id,
+          status as AnalysisRunStatus,
         );
+        if (outcome.kind === "not_found") {
+          return c.json({ error: "analysis run が見つかりません" }, 404);
+        }
+        if (outcome.kind === "conflict") {
+          return c.json(
+            { error: "ステータスが競合しました。再試行してください。" },
+            409,
+          );
+        }
+        // transitioned / noop どちらも最新レコードを返す
+        const updated = await prisma.meetingAnalysisRun.findUnique({
+          where: { id },
+        });
+        return c.json(updated);
+      } catch (e) {
+        if (e instanceof InvalidAnalysisRunTransitionError) {
+          return c.json(
+            { error: `${e.from} -> ${e.to} への遷移は許可されていません` },
+            422,
+          );
+        }
+        throw e;
       }
-
-      const data: Record<string, unknown> = { status };
-      if (status === "analyzing") data.startedAt = new Date();
-      if (status === "failed") data.failedAt = new Date();
-
-      const result = await prisma.meetingAnalysisRun.updateMany({
-        where: { id, status: run.status },
-        data,
-      });
-      if (result.count === 0) {
-        return c.json(
-          { error: "ステータスが競合しました。再試行してください。" },
-          409,
-        );
-      }
-      const updated = await prisma.meetingAnalysisRun.findUnique({
-        where: { id },
-      });
-      return c.json(updated);
     },
   )
   .post(
@@ -114,26 +112,18 @@ export const internalRoute = new Hono()
         return c.json({ error: "組織情報が取得できません" }, 422);
       }
 
-      // analyzing -> completed へのアトミックな遷移と結果保存をひとつの transaction に収める。
+      // analyzing -> completed への遷移と結果保存をひとつの transaction に収める。
       try {
-        await prisma.$transaction(async (tx) => {
-          const claimed = await tx.meetingAnalysisRun.updateMany({
-            where: { id, status: "analyzing" },
-            data: { status: "completed", completedAt: new Date() },
-          });
-
-          if (claimed.count === 0) {
-            const current = await tx.meetingAnalysisRun.findUnique({
-              where: { id },
-            });
-            if (current?.status === "completed") {
-              return; // 完了済みは冪等に 200 を返す
-            }
-            throw Object.assign(new Error("INVALID_STATUS"), {
-              currentStatus: current?.status,
-            });
+        const completeOutcome = await prisma.$transaction(async (tx) => {
+          const outcome = await transitionAnalysisRunStatus(
+            tx,
+            id,
+            "completed",
+          );
+          if (outcome.kind !== "transitioned") {
+            // noop / conflict / not_found のときは create 系をスキップ
+            return outcome;
           }
-
           if (decisionItems.length > 0) {
             await tx.decisionItem.createMany({
               data: decisionItems.map((item) => ({
@@ -145,7 +135,6 @@ export const internalRoute = new Hono()
               })),
             });
           }
-
           if (tasks.length > 0) {
             await tx.task.createMany({
               data: tasks.map((task) => ({
@@ -159,7 +148,6 @@ export const internalRoute = new Hono()
               })),
             });
           }
-
           if (ambiguousInfos.length > 0) {
             await tx.ambiguousInfo.createMany({
               data: ambiguousInfos.map((info) => ({
@@ -172,13 +160,25 @@ export const internalRoute = new Hono()
               })),
             });
           }
+          return outcome;
         });
-      } catch (e) {
-        if (e instanceof Error && e.message === "INVALID_STATUS") {
+
+        if (completeOutcome.kind === "conflict") {
           return c.json(
             {
-              error: `analyzing 状態でないため complete できません: ${(e as { currentStatus?: string }).currentStatus}`,
+              error: `analyzing 状態でないため complete できません: ${completeOutcome.current}`,
             },
+            422,
+          );
+        }
+        if (completeOutcome.kind === "not_found") {
+          return c.json({ error: "analysis run が見つかりません" }, 404);
+        }
+        // noop / transitioned はいずれも { ok: true } で冪等に応答
+      } catch (e) {
+        if (e instanceof InvalidAnalysisRunTransitionError) {
+          return c.json(
+            { error: `${e.from} -> ${e.to} への遷移は許可されていません` },
             422,
           );
         }

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -243,6 +243,8 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
     } catch (sbErr) {
       console.error("[meetings] Service Bus 送信失敗 run=%s:", run.id, sbErr);
       try {
+        // queued -> failed は VALID_TRANSITIONS には含めず、内部経路として
+        // 直接更新する（外部 API では queued -> failed を許可しない）
         await prisma.meetingAnalysisRun.update({
           where: { id: run.id },
           data: {

--- a/apps/api/test/internal.test.ts
+++ b/apps/api/test/internal.test.ts
@@ -81,7 +81,9 @@ function makeTx() {
   return {
     meetingAnalysisRun: {
       updateMany: vi.fn(),
-      findUnique: vi.fn(),
+      // transitionAnalysisRunStatus が現状の status を取得するためのモック。
+      // デフォルトは analyzing から completed への遷移を想定。
+      findUnique: vi.fn().mockResolvedValue({ status: "analyzing" }),
     },
     decisionItem: { createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     task: { createMany: vi.fn().mockResolvedValue({ count: 0 }) },


### PR DESCRIPTION
## 関連Issue
Closes #255

## 概要・目的
* `routes/internal.ts` に散在していた `VALID_TRANSITIONS` テーブルと `PATCH /complete` の analyzing → completed 遷移を、共通ヘルパー `transitionAnalysisRunStatus` に集約する
* 状態遷移ロジックの追加・変更を 1 箇所にまとめ、不正遷移検知・タイムスタンプ自動セットを共通化する

## 背景
* 状態遷移ロジックが `routes/internal.ts` の `VALID_TRANSITIONS` + 個別 updateMany と、`routes/meetings.ts` の直接 update に分散していた
* `PATCH /complete` も独自の updateMany + status === "completed" の冪等判定で書かれており、他の遷移と書き味が違っていた
* 中央化で、遷移追加・タイムスタンプ規約の変更が 1 ファイル修正で済むようにする

## 変更内容
* `apps/api/src/lib/analysis-run-state.ts`（新規）
  * `AnalysisRunStatus` 型と `VALID_TRANSITIONS` テーブル
  * `canTransition` / `InvalidAnalysisRunTransitionError`
  * `transitionAnalysisRunStatus(client, id, to, extras?)`
    * Compare-and-swap で並行更新の競合を検出
    * 状態遷移ターゲットに応じて `startedAt` / `completedAt` / `failedAt` を自動セット
    * 戻り値 `TransitionOutcome`: `transitioned` / `noop` / `conflict` / `not_found`
* `apps/api/src/routes/internal.ts`
  * VALID_TRANSITIONS / 個別 updateMany 呼び出しを `transitionAnalysisRunStatus` 経由に置換
  * PATCH `/analysis-runs/:id` と POST `/analysis-runs/:id/complete` の状態遷移を一元化
  * 冪等性 (noop) / 競合 (conflict) / 不在 (not_found) を区別したエラーレスポンス
* `apps/api/src/routes/meetings.ts`
  * `queued → failed` の内部経路（Service Bus 送信失敗時）は VALID_TRANSITIONS に含めず direct update のままにする
  * 「外部 API では queued → failed を許可しない」意図をコメントで明記
* `apps/api/test/internal.test.ts`
  * `makeTx()` の `findUnique` のデフォルト戻り値を `{ status: "analyzing" }` に設定

## 動作確認手順
1. `pnpm --filter api typecheck` がエラーなく完了することを確認する
2. `pnpm --filter api test` で全 278 件が通ることを確認する
3. `pnpm --filter api lint` で lint が通ることを確認する
4. （任意）`make dev` で開発環境を起動し、解析ジョブ実行時の状態遷移 `queued → analyzing → completed` が従来通り動作することを確認する

## スクリーンショット
* 内部リファクタのためなし