### PR TITLE
refactor: Task ダイアログ state machine を useTaskDialogState に共通化する

### DIFF
--- a/apps/web/src/features/tasks/components/KanbanBoard.tsx
+++ b/apps/web/src/features/tasks/components/KanbanBoard.tsx
@@ -3,7 +3,7 @@ import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
 import { KanbanCard } from "@/features/tasks/components/KanbanCard";
 import { KanbanColumn } from "@/features/tasks/components/KanbanColumn";
 import { useKanbanStatusUpdate } from "@/features/tasks/hooks/useKanbanStatusUpdate";
-import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import { useTaskDialogState } from "@/features/tasks/hooks/useTaskDialogState";
 import { TaskVersionConflictError } from "@/features/tasks/hooks/useUpdateTask";
 import type { ManualTaskStatus, TaskListItem } from "@/features/tasks/types";
 import {
@@ -49,23 +49,22 @@ export function KanbanBoard({
 }) {
   const statusUpdate = useKanbanStatusUpdate(queryKey);
   const [dndError, setDndError] = useState<string | null>(null);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-
-  const detailQuery = useTaskDetail(selectedTaskId);
-  const task = detailQuery.data ?? null;
-  const isError = selectedTaskId !== null && detailQuery.isError;
+  const {
+    task,
+    isError,
+    deleteOpen,
+    detailQuery,
+    select,
+    openDelete,
+    setDeleteOpen,
+    closeAll,
+  } = useTaskDialogState();
 
   // PointerSensor の activationConstraint で短いクリックは drag を発火させない。
   // distance: 5 で十分（タスクカードのクリック=編集と区別）。
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
-
-  const closeAll = () => {
-    setDeleteOpen(false);
-    setSelectedTaskId(null);
-  };
 
   // 列ごとにタスクを振り分け。手動 4 status 以外は無視（AI 専用は将来別 UI）。
   const byStatus = new Map<ManualTaskStatus, TaskListItem[]>(
@@ -82,13 +81,13 @@ export function KanbanBoard({
     const dropStatus = String(over.id);
     if (!isManualStatus(dropStatus)) return;
 
-    const task = tasks.find((t) => t.id === taskId);
-    if (!task) return;
-    if (task.status === dropStatus) return; // 同じ列に戻したケースは no-op
+    const target = tasks.find((t) => t.id === taskId);
+    if (!target) return;
+    if (target.status === dropStatus) return; // 同じ列に戻したケースは no-op
 
     setDndError(null);
     statusUpdate.mutate(
-      { taskId, version: task.version, status: dropStatus },
+      { taskId, version: target.version, status: dropStatus },
       {
         onError: (err) => {
           // 409 とそれ以外でメッセージを区別する。useKanbanStatusUpdate 側で rollback 済み。
@@ -128,7 +127,7 @@ export function KanbanBoard({
                       key={t.id}
                       task={t}
                       now={now}
-                      onClick={() => setSelectedTaskId(t.id)}
+                      onClick={() => select(t.id)}
                     />
                   ))
                 )}
@@ -157,7 +156,7 @@ export function KanbanBoard({
       )}
 
       {/* TaskListWithDialogs と同じ詳細取得 → 編集ダイアログ → 削除ダイアログの動線。
-          重複は将来 useTaskDialogState 等で共通化する余地あり。 */}
+          state machine は useTaskDialogState で共通化済み。 */}
       {isError && (
         <div
           role="alert"
@@ -183,7 +182,7 @@ export function KanbanBoard({
           onOpenChange={(next) => {
             if (!next && !deleteOpen) closeAll();
           }}
-          onRequestDelete={() => setDeleteOpen(true)}
+          onRequestDelete={openDelete}
         />
       )}
 

--- a/apps/web/src/features/tasks/components/TaskListWithDialogs.tsx
+++ b/apps/web/src/features/tasks/components/TaskListWithDialogs.tsx
@@ -1,20 +1,12 @@
 import { DeleteTaskDialog } from "@/features/tasks/components/DeleteTaskDialog";
 import { EditTaskDialog } from "@/features/tasks/components/EditTaskDialog";
 import { TaskRow } from "@/features/tasks/components/TaskRow";
-import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import { useTaskDialogState } from "@/features/tasks/hooks/useTaskDialogState";
 import type { TaskListItem } from "@/features/tasks/types";
-import { useState } from "react";
 
 // タスク一覧の行クリック → 編集ダイアログ → 削除ダイアログまで一気通貫で扱う共通ラッパー。
 // 各ページ（My タスク・定例詳細・会議詳細）で重複する「行クリック state + useTaskDetail
-// + EditTaskDialog + DeleteTaskDialog の連動」をここに閉じ込める。
-//
-// 動作:
-//   1. 行クリック → selectedTaskId をセット
-//   2. useTaskDetail で詳細取得（取得中はダイアログ未表示）
-//   3. 取得成功で EditTaskDialog を開く
-//   4. 削除ボタン押下で DeleteTaskDialog を開く
-//   5. ダイアログ閉鎖時に selectedTaskId をクリア
+// + EditTaskDialog + DeleteTaskDialog の連動」を useTaskDialogState で共通化している。
 export function TaskListWithDialogs({
   tasks,
   ariaLabel,
@@ -24,30 +16,23 @@ export function TaskListWithDialogs({
   ariaLabel: string;
   now?: Date;
 }) {
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-
-  // taskId が null の時は useTaskDetail 側で enabled:false になり fetch されない。
-  const detailQuery = useTaskDetail(selectedTaskId);
-  const task = detailQuery.data ?? null;
-  const isLoading = selectedTaskId !== null && detailQuery.isLoading;
-  const isError = selectedTaskId !== null && detailQuery.isError;
-
-  const closeAll = () => {
-    setDeleteOpen(false);
-    setSelectedTaskId(null);
-  };
+  const {
+    task,
+    isLoading,
+    isError,
+    deleteOpen,
+    detailQuery,
+    select,
+    openDelete,
+    setDeleteOpen,
+    closeAll,
+  } = useTaskDialogState();
 
   return (
     <>
       <ul aria-label={ariaLabel} className="grid gap-2">
         {tasks.map((t) => (
-          <TaskRow
-            key={t.id}
-            task={t}
-            now={now}
-            onClick={() => setSelectedTaskId(t.id)}
-          />
+          <TaskRow key={t.id} task={t} now={now} onClick={() => select(t.id)} />
         ))}
       </ul>
 
@@ -70,8 +55,7 @@ export function TaskListWithDialogs({
         </div>
       )}
 
-      {/* 取得中はダイアログを開かず、UI を阻害しないよう軽い表示のみ。
-          長時間かかる場合はトーストやスケルトンへ拡張する余地を残す。 */}
+      {/* 取得中はダイアログを開かず、UI を阻害しないよう軽い表示のみ。 */}
       {isLoading && (
         <p className="text-xs text-muted-foreground" role="status">
           タスク詳細を読み込み中...
@@ -88,7 +72,7 @@ export function TaskListWithDialogs({
             // Edit が閉じられたら全状態をリセット（次の行クリックを受けられる状態に戻す）。
             if (!next && !deleteOpen) closeAll();
           }}
-          onRequestDelete={() => setDeleteOpen(true)}
+          onRequestDelete={openDelete}
         />
       )}
 

--- a/apps/web/src/features/tasks/hooks/useTaskDialogState.ts
+++ b/apps/web/src/features/tasks/hooks/useTaskDialogState.ts
@@ -1,0 +1,50 @@
+import { useTaskDetail } from "@/features/tasks/hooks/useTaskDetail";
+import { useState } from "react";
+
+/**
+ * 行クリック → 詳細取得 → 編集ダイアログ → 削除ダイアログまでの state machine を共通化する hook。
+ *
+ * TaskListWithDialogs と KanbanBoard で重複していたロジックを集約する。
+ *
+ * 戻り値:
+ * - selectedTaskId: 選択中のタスク ID（未選択時は null）
+ * - task: useTaskDetail で取得した詳細データ
+ * - isLoading: 詳細取得中フラグ（selectedTaskId 非 null かつ loading 時のみ true）
+ * - isError: 詳細取得失敗フラグ
+ * - deleteOpen: 削除ダイアログ表示中フラグ
+ * - detailQuery: 元の useTaskDetail の戻り値（refetch 用）
+ * - select: タスクを選択する（行クリックハンドラから呼ぶ）
+ * - openDelete: 削除ダイアログを開く
+ * - setDeleteOpen: 削除ダイアログの open 状態を更新する（onOpenChange 用）
+ * - closeAll: 全状態をリセット（選択解除＋削除ダイアログクローズ）
+ */
+export function useTaskDialogState() {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // taskId が null の時は useTaskDetail 側で enabled:false になり fetch されない。
+  const detailQuery = useTaskDetail(selectedTaskId);
+  const task = detailQuery.data ?? null;
+  const isLoading = selectedTaskId !== null && detailQuery.isLoading;
+  const isError = selectedTaskId !== null && detailQuery.isError;
+
+  const select = (taskId: string) => setSelectedTaskId(taskId);
+  const openDelete = () => setDeleteOpen(true);
+  const closeAll = () => {
+    setDeleteOpen(false);
+    setSelectedTaskId(null);
+  };
+
+  return {
+    selectedTaskId,
+    task,
+    isLoading,
+    isError,
+    deleteOpen,
+    detailQuery,
+    select,
+    openDelete,
+    setDeleteOpen,
+    closeAll,
+  };
+}


### PR DESCRIPTION
## 関連Issue
Closes #256

## 概要・目的
* `TaskListWithDialogs` と `KanbanBoard` で重複していた「行クリック state + useTaskDetail + EditTaskDialog + DeleteTaskDialog の連動」ロジックを共通 hook に集約する
* 今後タスクビューが増えても 1 行で再利用できる状態にする

## 背景
* `apps/web/src/features/tasks/components/TaskListWithDialogs.tsx` と `KanbanBoard.tsx` で同じ state machine がコピペ実装されていた
* `TaskListWithDialogs.tsx:159` 付近のコメントにも「将来 useTaskDialogState 等で共通化する余地あり」と記載済み

## 変更内容
* `apps/web/src/features/tasks/hooks/useTaskDialogState.ts`（新規）
  * `selectedTaskId` / `deleteOpen` の state
  * `useTaskDetail` と連動した `task` / `isLoading` / `isError` / `detailQuery`
  * `select` / `openDelete` / `setDeleteOpen` / `closeAll` の操作 API
* `apps/web/src/features/tasks/components/TaskListWithDialogs.tsx`
  * 自前 useState ペアを `useTaskDialogState()` に置換
* `apps/web/src/features/tasks/components/KanbanBoard.tsx`
  * 同じく useTaskDialogState 経由に書き換え
  * 「将来共通化の余地あり」コメントを「共通化済み」に更新

## 動作確認手順
1. `pnpm --filter web typecheck` がエラーなく完了することを確認する
2. `pnpm --filter web test` で全 368 件が通ることを確認する
3. `pnpm --filter web lint` で lint が通ることを確認する
4. （任意）`make dev` で開発環境を起動し、My タスク・カンバン・会議詳細各画面で行クリック → 詳細編集 → 削除の動線が従来通り動作することを確認する

## スクリーンショット
* UI 変更なし（内部リファクタのため）