### PR TITLE
refactor: email 正規化処理を lib/email.ts に集約する

### DIFF
--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,0 +1,16 @@
+/**
+ * email アドレスを比較・マッチング可能な正規化済み文字列に変換する。
+ *
+ * - 前後の空白を除去
+ * - 大文字を小文字に統一（local-part は大文字小文字を区別すべきと RFC 5321 にあるが、
+ *   実運用上ほぼすべての MTA が case-insensitive で扱うため統一する）
+ *
+ * 招待マッチングと OIDC 経由のユーザー紐付けの両方でこの関数を使うことで、
+ * 「招待時 abc@example.com、ログイン時 ABC@example.com」のような表記揺れを吸収する。
+ *
+ * 将来 Gmail の "+alias" や "." の取り扱い、Unicode 正規化（NFKC）等を追加する場合は
+ * 本関数を更新する。
+ */
+export function normalizeEmail(input: string): string {
+  return input.trim().toLowerCase();
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Prisma, type User } from "@prisma/client";
 import type { MiddlewareHandler } from "hono";
 import { jwtVerify } from "jose";
+import { normalizeEmail } from "../lib/email.js";
 import { getAudience, getIssuerUrl, getJwks } from "../lib/oidc.js";
 import { prisma } from "../lib/prisma.js";
 
@@ -47,9 +48,9 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
   }
 
   // IdP が返す email は大文字や前後空白を含み得るため、保存前に正規化する。
-  // 招待 (`OrganizationInvitation.email`) も小文字化済みで保存しているため、
+  // 招待 (`OrganizationInvitation.email`) も同じ normalizeEmail で保存しているため、
   // 比較経路全体で正規化を一貫させる必要がある。
-  const email = rawEmail.trim().toLowerCase();
+  const email = normalizeEmail(rawEmail);
 
   // まず findUnique で取得し、差分があるときのみ update / 不在なら create を発行する。
   // upsert を毎リクエスト走らせると、同一ユーザーに対する並列リクエストで

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { type OrgRole, Prisma } from "@prisma/client";
 import { Hono } from "hono";
 import { z } from "zod";
+import { normalizeEmail } from "../lib/email.js";
 import { prisma } from "../lib/prisma.js";
 import { recurringMeetingCreateSchema } from "../lib/schemas/recurring-meeting.js";
 import {
@@ -43,12 +44,13 @@ const nextMeetingsQuerySchema = z.object({
 });
 
 // owner ロールの招待は不可（owner は組織作成者のみ）。
-// expiresInDays は 1〜365 日。email はサーバ側で trim + 小文字化して保存・比較する。
+// expiresInDays は 1〜365 日。email は lib/email.ts の normalizeEmail で
+// 正規化（trim + 小文字化）した上で保存・比較する。
 // role / expiresInDays は省略・null のいずれも「未指定」として扱い、
 // ハンドラ側で role="member" / 7 日のデフォルトにフォールバックする。
 // JSON では undefined を表現できないため、クライアントが null で送る慣習に合わせる。
 const inviteSchema = z.object({
-  email: z.string().trim().toLowerCase().email(),
+  email: z.string().transform(normalizeEmail).pipe(z.string().email()),
   role: z.enum(["admin", "member"]).nullable().optional(),
   expiresInDays: z.number().int().positive().max(365).nullable().optional(),
 });


### PR DESCRIPTION
## 関連Issue
Closes #257

## 概要・目的
* `middleware/auth.ts` と `routes/organizations.ts` の双方で `.trim().toLowerCase()` が別実装になっていた email 正規化を、`normalizeEmail` ヘルパーに集約する
* 招待マッチングと OIDC 経由のユーザー紐付けで「片方だけ仕様変更してマッチング失敗」が起きないよう、単一の真実源を作る

## 背景
* `apps/api/src/middleware/auth.ts:52` で `rawEmail.trim().toLowerCase()`
* `apps/api/src/routes/organizations.ts:51` で `z.string().trim().toLowerCase().email()`
* 同じ意味のロジックが 2 箇所で独立して書かれており、Gmail "+alias" や Unicode 正規化を将来追加するときに乖離するリスクがあった

## 変更内容
* `apps/api/src/lib/email.ts`（新規）
  * `normalizeEmail(input: string): string` を実装
  * 現状は `trim + toLowerCase` の最小実装
  * Gmail エイリアス / NFKC 正規化等を将来追加する場合の入口を docstring に明記
* `apps/api/src/middleware/auth.ts`
  * `rawEmail.trim().toLowerCase()` を `normalizeEmail(rawEmail)` に置換
* `apps/api/src/routes/organizations.ts`
  * `inviteSchema.email` を `z.string().transform(normalizeEmail).pipe(z.string().email())` に変更
  * normalize → validate の順で適用するため、表記揺れ入力でも email バリデーションが正規化済み文字列で実行される

## 仕様メモ
* 招待マッチングは `trim` + `toLowerCase` を「双方で適用後の文字列が一致」で行う（現状仕様）
* Gmail の "+alias" や "." の吸収、NFKC 正規化は本 PR ではスコープ外。将来検討する場合は本ヘルパーに足す

## 動作確認手順
1. `pnpm --filter api typecheck` がエラーなく完了することを確認する
2. `pnpm --filter api test` で全 278 件が通ることを確認する
3. `pnpm --filter api lint` で lint が通ることを確認する
4. （任意）`POST /organizations/:id/invitations` に `"  USER@Example.COM  "` のような入力を送り、保存・比較が小文字化済みで動作することを確認する

## スクリーンショット
* 内部リファクタのためなし