### PR TITLE
feat(api): レビューアイテム API を実装

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { ambiguousInfosRoute } from "./routes/ambiguous-infos.js";
+import { decisionItemsRoute } from "./routes/decision-items.js";
 import { healthRoute } from "./routes/health.js";
 import { meRoute } from "./routes/me.js";
 import { meetingsRoute } from "./routes/meetings.js";
@@ -53,6 +55,8 @@ const routes = app
   .route("/organizations", organizationsRoute)
   .route("/recurring-meetings", recurringMeetingsRoute)
   .route("/tasks", tasksRoute)
+  .route("/decision-items", decisionItemsRoute)
+  .route("/ambiguous-infos", ambiguousInfosRoute)
   .route("/internal", internalRoute);
 
 export { app };

--- a/apps/api/src/lib/org-validation.ts
+++ b/apps/api/src/lib/org-validation.ts
@@ -1,0 +1,25 @@
+import { prisma } from "./prisma.js";
+
+export async function validateAssigneesInOrg(
+  organizationId: string,
+  userIds: string[],
+): Promise<boolean> {
+  if (userIds.length === 0) return true;
+  const members = await prisma.organizationMembership.findMany({
+    where: { organizationId, userId: { in: userIds } },
+    select: { userId: true },
+  });
+  return members.length === userIds.length;
+}
+
+export async function validateRecurringMeetingsInOrg(
+  organizationId: string,
+  recurringMeetingIds: string[],
+): Promise<boolean> {
+  if (recurringMeetingIds.length === 0) return true;
+  const rms = await prisma.recurringMeeting.findMany({
+    where: { id: { in: recurringMeetingIds }, organizationId },
+    select: { id: true },
+  });
+  return rms.length === recurringMeetingIds.length;
+}

--- a/apps/api/src/lib/review-item-serialization.ts
+++ b/apps/api/src/lib/review-item-serialization.ts
@@ -54,7 +54,7 @@ function serializeDecisionItem(item: DecisionItemWithReview) {
   };
 }
 
-// originMeetingId は review 用クエリで常に非 null（where 条件で保証）。
+// originMeetingId・originMeeting は review 用クエリの where 条件（originMeetingId: { not: null }）で非 null が保証される。
 function serializeTaskAsReviewItem(task: TaskWithReview) {
   return {
     id: task.id,
@@ -66,8 +66,10 @@ function serializeTaskAsReviewItem(task: TaskWithReview) {
     sourceQuote: task.sourceQuote,
     sourceContext: task.sourceContext,
     severity: null,
-    meetingId: task.originMeetingId as string,
-    recurringMeetingId: task.originMeeting?.recurringMeetingId ?? null,
+    // biome-ignore lint/style/noNonNullAssertion: where 条件で originMeetingId: { not: null } を保証済み
+    meetingId: task.originMeetingId!,
+    // biome-ignore lint/style/noNonNullAssertion: 同上
+    recurringMeetingId: task.originMeeting!.recurringMeetingId,
     assignees: task.assignees.map((a) => a.user),
     deadline: task.dueDate,
     version: task.version,

--- a/apps/api/src/lib/review-item-serialization.ts
+++ b/apps/api/src/lib/review-item-serialization.ts
@@ -1,0 +1,110 @@
+import type { Prisma } from "@prisma/client";
+
+const userSelect = {
+  id: true,
+  name: true,
+  displayName: true,
+  email: true,
+} as const;
+
+export const decisionItemReviewInclude = {
+  assignees: { include: { user: { select: userSelect } } },
+  meeting: { select: { recurringMeetingId: true } },
+} as const satisfies Prisma.DecisionItemInclude;
+
+export const taskReviewInclude = {
+  assignees: { include: { user: { select: userSelect } } },
+  originMeeting: { select: { recurringMeetingId: true } },
+} as const satisfies Prisma.TaskInclude;
+
+export const ambiguousInfoReviewInclude = {
+  meeting: { select: { recurringMeetingId: true } },
+} as const satisfies Prisma.AmbiguousInfoInclude;
+
+type DecisionItemWithReview = Prisma.DecisionItemGetPayload<{
+  include: typeof decisionItemReviewInclude;
+}>;
+type TaskWithReview = Prisma.TaskGetPayload<{
+  include: typeof taskReviewInclude;
+}>;
+type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
+  include: typeof ambiguousInfoReviewInclude;
+}>;
+
+function serializeDecisionItem(item: DecisionItemWithReview) {
+  const type =
+    item.decisionState === "confirmed" || item.decisionState === "tentative"
+      ? ("decision" as const)
+      : ("open_issue" as const);
+  return {
+    id: item.id,
+    sourceTable: "decision_item" as const,
+    type,
+    status: item.status,
+    title: item.title,
+    body: item.body,
+    sourceQuote: item.sourceQuote,
+    sourceContext: item.sourceContext,
+    severity: null,
+    meetingId: item.meetingId,
+    recurringMeetingId: item.meeting.recurringMeetingId,
+    assignees: item.assignees.map((a) => a.user),
+    deadline: item.decisionDeadline,
+    version: item.version,
+  };
+}
+
+// originMeetingId は review 用クエリで常に非 null（where 条件で保証）。
+function serializeTaskAsReviewItem(task: TaskWithReview) {
+  return {
+    id: task.id,
+    sourceTable: "task" as const,
+    type: "task_candidate" as const,
+    status: task.status,
+    title: task.title,
+    body: task.body,
+    sourceQuote: task.sourceQuote,
+    sourceContext: task.sourceContext,
+    severity: null,
+    meetingId: task.originMeetingId as string,
+    recurringMeetingId: task.originMeeting?.recurringMeetingId ?? null,
+    assignees: task.assignees.map((a) => a.user),
+    deadline: task.dueDate,
+    version: task.version,
+  };
+}
+
+function serializeAmbiguousInfo(item: AmbiguousInfoWithReview) {
+  return {
+    id: item.id,
+    sourceTable: "ambiguous_info" as const,
+    type: "ambiguity" as const,
+    status: item.status,
+    title: item.body,
+    body: null,
+    sourceQuote: item.sourceQuote,
+    sourceContext: item.sourceContext,
+    severity: item.severity,
+    meetingId: item.meetingId,
+    recurringMeetingId: item.meeting.recurringMeetingId,
+    assignees: [],
+    deadline: null,
+    version: item.version,
+  };
+}
+
+export function serializeReviewItems({
+  decisionItems,
+  tasks,
+  ambiguousInfos,
+}: {
+  decisionItems: DecisionItemWithReview[];
+  tasks: TaskWithReview[];
+  ambiguousInfos: AmbiguousInfoWithReview[];
+}) {
+  return [
+    ...decisionItems.map(serializeDecisionItem),
+    ...tasks.map(serializeTaskAsReviewItem),
+    ...ambiguousInfos.map(serializeAmbiguousInfo),
+  ];
+}

--- a/apps/api/src/lib/review-item-serialization.ts
+++ b/apps/api/src/lib/review-item-serialization.ts
@@ -31,7 +31,7 @@ type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
   include: typeof ambiguousInfoReviewInclude;
 }>;
 
-function serializeDecisionItem(item: DecisionItemWithReview) {
+export function serializeDecisionItem(item: DecisionItemWithReview) {
   const type =
     item.decisionState === "confirmed" || item.decisionState === "tentative"
       ? ("decision" as const)
@@ -76,7 +76,7 @@ function serializeTaskAsReviewItem(task: TaskWithReview) {
   };
 }
 
-function serializeAmbiguousInfo(item: AmbiguousInfoWithReview) {
+export function serializeAmbiguousInfo(item: AmbiguousInfoWithReview) {
   return {
     id: item.id,
     sourceTable: "ambiguous_info" as const,

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -26,9 +26,10 @@ export const reviewItemQuerySchema = z.object({
   type: commaSeparatedTypes.optional(),
 });
 
-export const recurringMeetingReviewItemQuerySchema = reviewItemQuerySchema.extend({
-  meetingId: z.string().min(1).optional(),
-});
+export const recurringMeetingReviewItemQuerySchema =
+  reviewItemQuerySchema.extend({
+    meetingId: z.string().min(1).optional(),
+  });
 
 export const decisionItemPatchSchema = z
   .object({
@@ -74,10 +75,9 @@ export const ambiguousInfoPatchSchema = z
       .optional(),
   })
   .strict()
-  .refine(
-    (d) => d.status !== undefined || d.resolutionType !== undefined,
-    { message: "status または resolutionType を指定してください" },
-  );
+  .refine((d) => d.status !== undefined || d.resolutionType !== undefined, {
+    message: "status または resolutionType を指定してください",
+  });
 
 // POST /meetings/:id/review-items（動作確認用・後で削除予定）
 export const reviewItemCreateSchema = z.object({
@@ -112,7 +112,9 @@ export function buildReviewItemTypeFilter(typeFilter: ReviewItemQuery["type"]) {
     const wantDecision = typeFilter.includes("decision");
     const wantOpenIssue = typeFilter.includes("open_issue");
     if (wantDecision && !wantOpenIssue) {
-      decisionItemTypeWhere = { decisionState: { in: ["confirmed", "tentative"] } };
+      decisionItemTypeWhere = {
+        decisionState: { in: ["confirmed", "tentative"] },
+      };
     } else if (!wantDecision && wantOpenIssue) {
       decisionItemTypeWhere = {
         OR: [{ decisionState: "open" }, { decisionState: null }],
@@ -120,5 +122,10 @@ export function buildReviewItemTypeFilter(typeFilter: ReviewItemQuery["type"]) {
     }
   }
 
-  return { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere };
+  return {
+    includeDecision,
+    includeTasks,
+    includeAmbiguousInfos,
+    decisionItemTypeWhere,
+  };
 }

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -84,7 +84,7 @@ export const ambiguousInfoPatchSchema = z
     message: "status または resolutionType を指定してください",
   });
 
-// POST /meetings/:id/review-items（動作確認用・後で削除予定）
+// TODO: POST /meetings/:id/review-items は動作確認用のため削除する
 // ambiguity は AmbiguousInfo.body に title を格納するため body フィールドを持たない。
 const baseCreateFields = {
   title: z.string().min(1),

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -52,8 +52,6 @@ export const decisionItemPatchSchema = z
     { message: "更新する項目を 1 つ以上指定してください" },
   );
 
-// resolutionType: "task" のとき newTask、"decision_item" のとき newDecisionItem を参照する。
-// タイトル未指定の場合は AmbiguousInfo.body をそのまま引き継ぐ。
 export const ambiguousInfoPatchSchema = z
   .object({
     version: z.number().int().nonnegative(),
@@ -97,7 +95,6 @@ export type DecisionItemPatchInput = z.infer<typeof decisionItemPatchSchema>;
 export type AmbiguousInfoPatchInput = z.infer<typeof ambiguousInfoPatchSchema>;
 export type ReviewItemCreateInput = z.infer<typeof reviewItemCreateSchema>;
 
-// decisionItemTypeWhere は DecisionItem の where に直接スプレッドして使う。
 export function buildReviewItemTypeFilter(typeFilter: ReviewItemQuery["type"]) {
   const includeDecision =
     !typeFilter ||

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -34,8 +34,13 @@ export const recurringMeetingReviewItemQuerySchema =
 export const decisionItemPatchSchema = z
   .object({
     version: z.number().int().nonnegative(),
-    status: z.enum(["decided", "cancelled"]).optional(),
-    decisionState: z.enum(["confirmed", "tentative", "open"]).optional(),
+    status: z
+      .enum(["draft", "reviewing", "open", "decided", "cancelled"])
+      .optional(),
+    decisionState: z
+      .enum(["confirmed", "tentative", "open"])
+      .nullable()
+      .optional(),
     title: z.string().min(1).optional(),
     body: z.string().nullable().optional(),
     assigneeUserIds: idArraySchema.optional(),

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -106,7 +106,7 @@ export const reviewItemCreateSchema = z.discriminatedUnion("type", [
     ...baseCreateFields,
     body: z.string().optional(),
   }),
-  z.object({ type: z.literal("ambiguity"), ...baseCreateFields }),
+  z.object({ type: z.literal("ambiguity"), ...baseCreateFields }).strict(),
 ]);
 
 export type ReviewItemQuery = z.infer<typeof reviewItemQuerySchema>;

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -85,12 +85,29 @@ export const ambiguousInfoPatchSchema = z
   });
 
 // POST /meetings/:id/review-items（動作確認用・後で削除予定）
-export const reviewItemCreateSchema = z.object({
-  type: z.enum(reviewItemTypeValues),
+// ambiguity は AmbiguousInfo.body に title を格納するため body フィールドを持たない。
+const baseCreateFields = {
   title: z.string().min(1),
-  body: z.string().optional(),
   sourceContext: z.string().optional(),
-});
+};
+export const reviewItemCreateSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("decision"),
+    ...baseCreateFields,
+    body: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("open_issue"),
+    ...baseCreateFields,
+    body: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("task_candidate"),
+    ...baseCreateFields,
+    body: z.string().optional(),
+  }),
+  z.object({ type: z.literal("ambiguity"), ...baseCreateFields }),
+]);
 
 export type ReviewItemQuery = z.infer<typeof reviewItemQuerySchema>;
 export type RecurringMeetingReviewItemQuery = z.infer<

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -1,0 +1,127 @@
+import type { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+const idArraySchema = z
+  .array(z.string().min(1))
+  .transform((arr) => [...new Set(arr)]);
+
+const reviewItemTypeValues = [
+  "decision",
+  "open_issue",
+  "task_candidate",
+  "ambiguity",
+] as const;
+
+const commaSeparatedTypes = z
+  .string()
+  .transform((s) =>
+    s
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean),
+  )
+  .pipe(z.array(z.enum(reviewItemTypeValues)));
+
+export const reviewItemQuerySchema = z.object({
+  type: commaSeparatedTypes.optional(),
+});
+
+export const recurringMeetingReviewItemQuerySchema = reviewItemQuerySchema.extend({
+  meetingId: z.string().min(1).optional(),
+});
+
+export const decisionItemPatchSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    status: z.enum(["decided", "cancelled"]).optional(),
+    decisionState: z.enum(["confirmed", "tentative", "open"]).optional(),
+    title: z.string().min(1).optional(),
+    body: z.string().nullable().optional(),
+    assigneeUserIds: idArraySchema.optional(),
+    decisionDeadline: z.string().datetime().nullable().optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.status !== undefined ||
+      d.decisionState !== undefined ||
+      d.title !== undefined ||
+      d.body !== undefined ||
+      d.assigneeUserIds !== undefined ||
+      d.decisionDeadline !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+// resolutionType: "task" のとき newTask、"decision_item" のとき newDecisionItem を参照する。
+// タイトル未指定の場合は AmbiguousInfo.body をそのまま引き継ぐ。
+export const ambiguousInfoPatchSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    status: z.enum(["rejected"]).optional(),
+    resolutionType: z.enum(["task", "decision_item", "discarded"]).optional(),
+    newTask: z
+      .object({
+        title: z.string().min(1).optional(),
+        body: z.string().optional(),
+        assigneeUserIds: idArraySchema.optional(),
+        recurringMeetingIds: idArraySchema.optional(),
+        dueDate: z.string().datetime().nullable().optional(),
+      })
+      .optional(),
+    newDecisionItem: z
+      .object({
+        title: z.string().min(1).optional(),
+        body: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict()
+  .refine(
+    (d) => d.status !== undefined || d.resolutionType !== undefined,
+    { message: "status または resolutionType を指定してください" },
+  );
+
+// POST /meetings/:id/review-items（動作確認用・後で削除予定）
+export const reviewItemCreateSchema = z.object({
+  type: z.enum(reviewItemTypeValues),
+  title: z.string().min(1),
+  body: z.string().optional(),
+  sourceContext: z.string().optional(),
+});
+
+export type ReviewItemQuery = z.infer<typeof reviewItemQuerySchema>;
+export type RecurringMeetingReviewItemQuery = z.infer<
+  typeof recurringMeetingReviewItemQuerySchema
+>;
+export type DecisionItemPatchInput = z.infer<typeof decisionItemPatchSchema>;
+export type AmbiguousInfoPatchInput = z.infer<typeof ambiguousInfoPatchSchema>;
+export type ReviewItemCreateInput = z.infer<typeof reviewItemCreateSchema>;
+
+// decisionItemTypeWhere は DecisionItem の where に直接スプレッドして使う。
+export function buildReviewItemTypeFilter(typeFilter: ReviewItemQuery["type"]) {
+  const includeDecision =
+    !typeFilter ||
+    typeFilter.includes("decision") ||
+    typeFilter.includes("open_issue");
+  const includeTasks = !typeFilter || typeFilter.includes("task_candidate");
+  const includeAmbiguousInfos = !typeFilter || typeFilter.includes("ambiguity");
+
+  // open_issue は decisionState が "open" または null（AI 未設定）のため OR が必要。
+  let decisionItemTypeWhere: Pick<
+    Prisma.DecisionItemWhereInput,
+    "decisionState" | "OR"
+  > = {};
+  if (typeFilter) {
+    const wantDecision = typeFilter.includes("decision");
+    const wantOpenIssue = typeFilter.includes("open_issue");
+    if (wantDecision && !wantOpenIssue) {
+      decisionItemTypeWhere = { decisionState: { in: ["confirmed", "tentative"] } };
+    } else if (!wantDecision && wantOpenIssue) {
+      decisionItemTypeWhere = {
+        OR: [{ decisionState: "open" }, { decisionState: null }],
+      };
+    }
+  }
+
+  return { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere };
+}

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -2,33 +2,13 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
+import {
+  validateAssigneesInOrg,
+  validateRecurringMeetingsInOrg,
+} from "../lib/org-validation.js";
 import { ambiguousInfoPatchSchema } from "../lib/schemas/review-item.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 import { requireOrgMembership } from "../middleware/authz.js";
-
-async function validateAssigneesInOrg(
-  organizationId: string,
-  userIds: string[],
-): Promise<boolean> {
-  if (userIds.length === 0) return true;
-  const members = await prisma.organizationMembership.findMany({
-    where: { organizationId, userId: { in: userIds } },
-    select: { userId: true },
-  });
-  return members.length === userIds.length;
-}
-
-async function validateRecurringMeetingsInOrg(
-  organizationId: string,
-  recurringMeetingIds: string[],
-): Promise<boolean> {
-  if (recurringMeetingIds.length === 0) return true;
-  const rms = await prisma.recurringMeeting.findMany({
-    where: { id: { in: recurringMeetingIds }, organizationId },
-    select: { id: true },
-  });
-  return rms.length === recurringMeetingIds.length;
-}
 
 async function requireAmbiguousInfoAccess(
   c: Context<{ Variables: AuthVariables }>,

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -43,7 +43,7 @@ async function requireAmbiguousInfoAccess(
     },
   });
   const organizationId = item?.meeting.recurringMeeting?.organizationId;
-  if (!organizationId) {
+  if (!item || !organizationId) {
     return {
       ok: false as const,
       res: c.json({ error: "アイテムが見つかりません" }, 404),
@@ -51,7 +51,7 @@ async function requireAmbiguousInfoAccess(
   }
   const guard = await requireOrgMembership(c, organizationId);
   if (!guard.ok) return { ok: false as const, res: guard.res };
-  return { ok: true as const, item: item!, organizationId };
+  return { ok: true as const, item, organizationId };
 }
 
 export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
@@ -122,7 +122,10 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
         );
       }
       if (
-        !(await validateRecurringMeetingsInOrg(organizationId, recurringMeetingIds))
+        !(await validateRecurringMeetingsInOrg(
+          organizationId,
+          recurringMeetingIds,
+        ))
       ) {
         return c.json({ error: "定例は組織に属している必要があります" }, 400);
       }
@@ -135,12 +138,17 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
             body: newTaskData.body,
             status: "todo",
             originMeetingId: item.meetingId,
-            dueDate: newTaskData.dueDate ? new Date(newTaskData.dueDate) : undefined,
+            dueDate: newTaskData.dueDate
+              ? new Date(newTaskData.dueDate)
+              : undefined,
           },
         });
         if (assigneeUserIds.length > 0) {
           await tx.taskAssignee.createMany({
-            data: assigneeUserIds.map((userId) => ({ taskId: task.id, userId })),
+            data: assigneeUserIds.map((userId) => ({
+              taskId: task.id,
+              userId,
+            })),
           });
         }
         if (recurringMeetingIds.length > 0) {

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -6,6 +6,10 @@ import {
   validateAssigneesInOrg,
   validateRecurringMeetingsInOrg,
 } from "../lib/org-validation.js";
+import {
+  ambiguousInfoReviewInclude,
+  serializeAmbiguousInfo,
+} from "../lib/review-item-serialization.js";
 import { ambiguousInfoPatchSchema } from "../lib/schemas/review-item.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 import { requireOrgMembership } from "../middleware/authz.js";
@@ -53,6 +57,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
         if (count === 0) return { kind: "version_conflict" as const };
         const updated = await tx.ambiguousInfo.findUniqueOrThrow({
           where: { id },
+          include: ambiguousInfoReviewInclude,
         });
         return { kind: "ok" as const, item: updated };
       });
@@ -62,7 +67,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
           409,
         );
       }
-      return c.json(result.item);
+      return c.json(serializeAmbiguousInfo(result.item));
     }
 
     if (input.resolutionType === "discarded") {
@@ -78,6 +83,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
         if (count === 0) return { kind: "version_conflict" as const };
         const updated = await tx.ambiguousInfo.findUniqueOrThrow({
           where: { id },
+          include: ambiguousInfoReviewInclude,
         });
         return { kind: "ok" as const, item: updated };
       });
@@ -87,7 +93,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
           409,
         );
       }
-      return c.json(result.item);
+      return c.json(serializeAmbiguousInfo(result.item));
     }
 
     if (input.resolutionType === "task") {
@@ -152,7 +158,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
         if (count === 0) return { kind: "version_conflict" as const };
         const updated = await tx.ambiguousInfo.findUniqueOrThrow({
           where: { id },
-          include: { resolvedToTask: { select: { id: true, title: true } } },
+          include: ambiguousInfoReviewInclude,
         });
         return { kind: "ok" as const, item: updated };
       });
@@ -163,7 +169,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
           409,
         );
       }
-      return c.json(result.item);
+      return c.json(serializeAmbiguousInfo(result.item));
     }
 
     // 未決事項に解決（resolutionType の残る唯一のケース）
@@ -191,9 +197,7 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
       if (count === 0) return { kind: "version_conflict" as const };
       const updated = await tx.ambiguousInfo.findUniqueOrThrow({
         where: { id },
-        include: {
-          resolvedToDecision: { select: { id: true, title: true } },
-        },
+        include: ambiguousInfoReviewInclude,
       });
       return { kind: "ok" as const, item: updated };
     });
@@ -204,5 +208,5 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
         409,
       );
     }
-    return c.json(result.item);
+    return c.json(serializeAmbiguousInfo(result.item));
   });

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -85,10 +85,6 @@ export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
       return c.json(result.item);
     }
 
-    if (!input.resolutionType) {
-      return c.json({ error: "resolutionType を指定してください" }, 400);
-    }
-
     if (input.resolutionType === "discarded") {
       const result = await prisma.$transaction(async (tx) => {
         const { count } = await tx.ambiguousInfo.updateMany({

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -1,0 +1,224 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { ambiguousInfoPatchSchema } from "../lib/schemas/review-item.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
+
+async function validateAssigneesInOrg(
+  organizationId: string,
+  userIds: string[],
+): Promise<boolean> {
+  if (userIds.length === 0) return true;
+  const members = await prisma.organizationMembership.findMany({
+    where: { organizationId, userId: { in: userIds } },
+    select: { userId: true },
+  });
+  return members.length === userIds.length;
+}
+
+async function validateRecurringMeetingsInOrg(
+  organizationId: string,
+  recurringMeetingIds: string[],
+): Promise<boolean> {
+  if (recurringMeetingIds.length === 0) return true;
+  const rms = await prisma.recurringMeeting.findMany({
+    where: { id: { in: recurringMeetingIds }, organizationId },
+    select: { id: true },
+  });
+  return rms.length === recurringMeetingIds.length;
+}
+
+async function requireAmbiguousInfoAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  itemId: string,
+) {
+  const item = await prisma.ambiguousInfo.findUnique({
+    where: { id: itemId },
+    include: {
+      meeting: {
+        select: { recurringMeeting: { select: { organizationId: true } } },
+      },
+    },
+  });
+  const organizationId = item?.meeting.recurringMeeting?.organizationId;
+  if (!organizationId) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "アイテムが見つかりません" }, 404),
+    };
+  }
+  const guard = await requireOrgMembership(c, organizationId);
+  if (!guard.ok) return { ok: false as const, res: guard.res };
+  return { ok: true as const, item: item!, organizationId };
+}
+
+export const ambiguousInfosRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .patch("/:id", zValidator("json", ambiguousInfoPatchSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const access = await requireAmbiguousInfoAccess(c, id);
+    if (!access.ok) return access.res;
+    const { item, organizationId } = access;
+
+    if (input.status === "rejected") {
+      const result = await prisma.$transaction(async (tx) => {
+        const { count } = await tx.ambiguousInfo.updateMany({
+          where: { id, version: input.version },
+          data: { status: "rejected", version: { increment: 1 } },
+        });
+        if (count === 0) return { kind: "version_conflict" as const };
+        const updated = await tx.ambiguousInfo.findUniqueOrThrow({
+          where: { id },
+        });
+        return { kind: "ok" as const, item: updated };
+      });
+      if (result.kind === "version_conflict") {
+        return c.json(
+          { error: "他のユーザーが先に更新しました。最新を取得してください" },
+          409,
+        );
+      }
+      return c.json(result.item);
+    }
+
+    if (!input.resolutionType) {
+      return c.json({ error: "resolutionType を指定してください" }, 400);
+    }
+
+    if (input.resolutionType === "discarded") {
+      const result = await prisma.$transaction(async (tx) => {
+        const { count } = await tx.ambiguousInfo.updateMany({
+          where: { id, version: input.version },
+          data: {
+            status: "resolved",
+            resolutionType: "discarded",
+            version: { increment: 1 },
+          },
+        });
+        if (count === 0) return { kind: "version_conflict" as const };
+        const updated = await tx.ambiguousInfo.findUniqueOrThrow({
+          where: { id },
+        });
+        return { kind: "ok" as const, item: updated };
+      });
+      if (result.kind === "version_conflict") {
+        return c.json(
+          { error: "他のユーザーが先に更新しました。最新を取得してください" },
+          409,
+        );
+      }
+      return c.json(result.item);
+    }
+
+    if (input.resolutionType === "task") {
+      const newTaskData = input.newTask ?? {};
+      const assigneeUserIds = newTaskData.assigneeUserIds ?? [];
+      const recurringMeetingIds = newTaskData.recurringMeetingIds ?? [];
+
+      if (!(await validateAssigneesInOrg(organizationId, assigneeUserIds))) {
+        return c.json(
+          { error: "担当者は組織のメンバーである必要があります" },
+          400,
+        );
+      }
+      if (
+        !(await validateRecurringMeetingsInOrg(organizationId, recurringMeetingIds))
+      ) {
+        return c.json({ error: "定例は組織に属している必要があります" }, 400);
+      }
+
+      const result = await prisma.$transaction(async (tx) => {
+        const task = await tx.task.create({
+          data: {
+            organizationId,
+            title: newTaskData.title ?? item.body,
+            body: newTaskData.body,
+            status: "todo",
+            originMeetingId: item.meetingId,
+            dueDate: newTaskData.dueDate ? new Date(newTaskData.dueDate) : undefined,
+          },
+        });
+        if (assigneeUserIds.length > 0) {
+          await tx.taskAssignee.createMany({
+            data: assigneeUserIds.map((userId) => ({ taskId: task.id, userId })),
+          });
+        }
+        if (recurringMeetingIds.length > 0) {
+          await tx.taskRecurringMeeting.createMany({
+            data: recurringMeetingIds.map((recurringMeetingId) => ({
+              taskId: task.id,
+              recurringMeetingId,
+            })),
+          });
+        }
+        // task 作成後に version チェック → version 不一致ならトランザクション全体をロールバック。
+        const { count } = await tx.ambiguousInfo.updateMany({
+          where: { id, version: input.version },
+          data: {
+            status: "resolved",
+            resolutionType: "task",
+            resolvedToTaskId: task.id,
+            version: { increment: 1 },
+          },
+        });
+        if (count === 0) return { kind: "version_conflict" as const };
+        const updated = await tx.ambiguousInfo.findUniqueOrThrow({
+          where: { id },
+          include: { resolvedToTask: { select: { id: true, title: true } } },
+        });
+        return { kind: "ok" as const, item: updated };
+      });
+
+      if (result.kind === "version_conflict") {
+        return c.json(
+          { error: "他のユーザーが先に更新しました。最新を取得してください" },
+          409,
+        );
+      }
+      return c.json(result.item);
+    }
+
+    // 未決事項に解決（resolutionType の残る唯一のケース）
+    const newDiData = input.newDecisionItem ?? {};
+
+    const result = await prisma.$transaction(async (tx) => {
+      const decisionItem = await tx.decisionItem.create({
+        data: {
+          meetingId: item.meetingId,
+          title: newDiData.title ?? item.body,
+          body: newDiData.body,
+          status: "open",
+          decisionState: "open",
+        },
+      });
+      const { count } = await tx.ambiguousInfo.updateMany({
+        where: { id, version: input.version },
+        data: {
+          status: "resolved",
+          resolutionType: "decision_item",
+          resolvedToDecisionItemId: decisionItem.id,
+          version: { increment: 1 },
+        },
+      });
+      if (count === 0) return { kind: "version_conflict" as const };
+      const updated = await tx.ambiguousInfo.findUniqueOrThrow({
+        where: { id },
+        include: {
+          resolvedToDecision: { select: { id: true, title: true } },
+        },
+      });
+      return { kind: "ok" as const, item: updated };
+    });
+
+    if (result.kind === "version_conflict") {
+      return c.json(
+        { error: "他のユーザーが先に更新しました。最新を取得してください" },
+        409,
+      );
+    }
+    return c.json(result.item);
+  });

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -19,7 +19,7 @@ async function requireDecisionItemAccess(
     },
   });
   const organizationId = item?.meeting.recurringMeeting?.organizationId;
-  if (!organizationId) {
+  if (!item || !organizationId) {
     return {
       ok: false as const,
       res: c.json({ error: "アイテムが見つかりません" }, 404),
@@ -27,7 +27,7 @@ async function requireDecisionItemAccess(
   }
   const guard = await requireOrgMembership(c, organizationId);
   if (!guard.ok) return { ok: false as const, res: guard.res };
-  return { ok: true as const, item: item!, organizationId };
+  return { ok: true as const, item, organizationId };
 }
 
 export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
@@ -97,7 +97,12 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
           assignees: {
             include: {
               user: {
-                select: { id: true, name: true, displayName: true, email: true },
+                select: {
+                  id: true,
+                  name: true,
+                  displayName: true,
+                  email: true,
+                },
               },
             },
           },

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
+import { validateAssigneesInOrg } from "../lib/org-validation.js";
 import { decisionItemPatchSchema } from "../lib/schemas/review-item.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 import { requireOrgMembership } from "../middleware/authz.js";
@@ -40,14 +41,12 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
     if (!access.ok) return access.res;
 
     if (input.assigneeUserIds !== undefined) {
-      const members = await prisma.organizationMembership.findMany({
-        where: {
-          organizationId: access.organizationId,
-          userId: { in: input.assigneeUserIds },
-        },
-        select: { userId: true },
-      });
-      if (members.length !== input.assigneeUserIds.length) {
+      if (
+        !(await validateAssigneesInOrg(
+          access.organizationId,
+          input.assigneeUserIds,
+        ))
+      ) {
         return c.json(
           { error: "担当者は組織のメンバーである必要があります" },
           400,

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -1,0 +1,118 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { decisionItemPatchSchema } from "../lib/schemas/review-item.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
+
+async function requireDecisionItemAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  itemId: string,
+) {
+  const item = await prisma.decisionItem.findUnique({
+    where: { id: itemId },
+    include: {
+      meeting: {
+        select: { recurringMeeting: { select: { organizationId: true } } },
+      },
+    },
+  });
+  const organizationId = item?.meeting.recurringMeeting?.organizationId;
+  if (!organizationId) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "アイテムが見つかりません" }, 404),
+    };
+  }
+  const guard = await requireOrgMembership(c, organizationId);
+  if (!guard.ok) return { ok: false as const, res: guard.res };
+  return { ok: true as const, item: item!, organizationId };
+}
+
+export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .patch("/:id", zValidator("json", decisionItemPatchSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const access = await requireDecisionItemAccess(c, id);
+    if (!access.ok) return access.res;
+
+    if (input.assigneeUserIds !== undefined) {
+      const members = await prisma.organizationMembership.findMany({
+        where: {
+          organizationId: access.organizationId,
+          userId: { in: input.assigneeUserIds },
+        },
+        select: { userId: true },
+      });
+      if (members.length !== input.assigneeUserIds.length) {
+        return c.json(
+          { error: "担当者は組織のメンバーである必要があります" },
+          400,
+        );
+      }
+    }
+
+    const updateData = {
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.decisionState !== undefined && {
+        decisionState: input.decisionState,
+      }),
+      ...(input.title !== undefined && { title: input.title }),
+      ...(input.body !== undefined && { body: input.body }),
+      ...(input.decisionDeadline !== undefined && {
+        decisionDeadline: input.decisionDeadline
+          ? new Date(input.decisionDeadline)
+          : null,
+      }),
+      version: { increment: 1 },
+    };
+
+    const result = await prisma.$transaction(async (tx) => {
+      const { count } = await tx.decisionItem.updateMany({
+        where: { id, version: input.version },
+        data: updateData,
+      });
+      if (count === 0) return { kind: "version_conflict" as const };
+
+      if (input.assigneeUserIds !== undefined) {
+        await tx.decisionItemAssignee.deleteMany({
+          where: { decisionItemId: id },
+        });
+        if (input.assigneeUserIds.length > 0) {
+          await tx.decisionItemAssignee.createMany({
+            data: input.assigneeUserIds.map((userId) => ({
+              decisionItemId: id,
+              userId,
+            })),
+          });
+        }
+      }
+
+      const updated = await tx.decisionItem.findUniqueOrThrow({
+        where: { id },
+        include: {
+          assignees: {
+            include: {
+              user: {
+                select: { id: true, name: true, displayName: true, email: true },
+              },
+            },
+          },
+        },
+      });
+      return { kind: "ok" as const, item: updated };
+    });
+
+    if (result.kind === "version_conflict") {
+      return c.json(
+        { error: "他のユーザーが先に更新しました。最新を取得してください" },
+        409,
+      );
+    }
+
+    const { assignees, ...rest } = result.item;
+    return c.json({ ...rest, assignees: assignees.map((a) => a.user) });
+  });

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -3,6 +3,10 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
 import { validateAssigneesInOrg } from "../lib/org-validation.js";
+import {
+  decisionItemReviewInclude,
+  serializeDecisionItem,
+} from "../lib/review-item-serialization.js";
 import { decisionItemPatchSchema } from "../lib/schemas/review-item.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 import { requireOrgMembership } from "../middleware/authz.js";
@@ -92,20 +96,7 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
 
       const updated = await tx.decisionItem.findUniqueOrThrow({
         where: { id },
-        include: {
-          assignees: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                  displayName: true,
-                  email: true,
-                },
-              },
-            },
-          },
-        },
+        include: decisionItemReviewInclude,
       });
       return { kind: "ok" as const, item: updated };
     });
@@ -117,6 +108,5 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
       );
     }
 
-    const { assignees, ...rest } = result.item;
-    return c.json({ ...rest, assignees: assignees.map((a) => a.user) });
+    return c.json(serializeDecisionItem(result.item));
   });

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -174,7 +174,7 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       );
     },
   )
-  // 動作確認用（後で削除予定）
+  // TODO: 動作確認用のため削除する
   .post(
     "/:id/review-items",
     zValidator("json", reviewItemCreateSchema),

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -100,28 +100,24 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         : null,
     });
   })
-  .get(
-    "/:id/tasks",
-    zValidator("query", taskListQuerySchema),
-    async (c) => {
-      const id = c.req.param("id");
-      const filters = c.req.valid("query");
+  .get("/:id/tasks", zValidator("query", taskListQuerySchema), async (c) => {
+    const id = c.req.param("id");
+    const filters = c.req.valid("query");
 
-      const access = await requireMeetingAccess(c, id);
-      if (!access.ok) return access.response;
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
 
-      // 当該会議を発生源とするタスクのみ。
-      const tasks = await prisma.task.findMany({
-        where: {
-          ...buildTaskListWhere(filters),
-          originMeetingId: id,
-        },
-        orderBy: taskListOrderBy,
-        include: taskListInclude,
-      });
-      return c.json(tasks.map(serializeTask));
-    },
-  )
+    // 当該会議を発生源とするタスクのみ。
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...buildTaskListWhere(filters),
+        originMeetingId: id,
+      },
+      orderBy: taskListOrderBy,
+      include: taskListInclude,
+    });
+    return c.json(tasks.map(serializeTask));
+  })
   .get(
     "/:id/review-items",
     zValidator("query", reviewItemQuerySchema),
@@ -132,8 +128,12 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       const access = await requireMeetingAccess(c, id);
       if (!access.ok) return access.response;
 
-      const { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere } =
-        buildReviewItemTypeFilter(filters.type);
+      const {
+        includeDecision,
+        includeTasks,
+        includeAmbiguousInfos,
+        decisionItemTypeWhere,
+      } = buildReviewItemTypeFilter(filters.type);
 
       const [decisionItems, tasks, ambiguousInfos] = await Promise.all([
         includeDecision
@@ -169,7 +169,9 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
           : [],
       ]);
 
-      return c.json(serializeReviewItems({ decisionItems, tasks, ambiguousInfos }));
+      return c.json(
+        serializeReviewItems({ decisionItems, tasks, ambiguousInfos }),
+      );
     },
   )
   // 動作確認用（後で削除予定）

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -48,7 +48,8 @@ const meetingUpdateSchema = z
 // 旧 GET / と POST /meetings は認証なしで叩ける状態だったため撤去した。
 // Meeting 作成は POST /recurring-meetings/:id/meetings に一本化されている。
 export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
-  .get("/:id", auth, async (c) => {
+  .use("*", auth)
+  .get("/:id", async (c) => {
     const id = c.req.param("id");
     // 認可検証は共通ヘルパーで実施。GET /:id は追加情報が必要なため、
     // 認可確定後に detail include 付きで再フェッチする。
@@ -101,7 +102,6 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   })
   .get(
     "/:id/tasks",
-    auth,
     zValidator("query", taskListQuerySchema),
     async (c) => {
       const id = c.req.param("id");
@@ -124,7 +124,6 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   )
   .get(
     "/:id/review-items",
-    auth,
     zValidator("query", reviewItemQuerySchema),
     async (c) => {
       const id = c.req.param("id");
@@ -176,7 +175,6 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
   // 動作確認用（後で削除予定）
   .post(
     "/:id/review-items",
-    auth,
     zValidator("json", reviewItemCreateSchema),
     async (c) => {
       const id = c.req.param("id");
@@ -232,7 +230,7 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       return c.json(item, 201);
     },
   )
-  .patch("/:id", auth, zValidator("json", meetingUpdateSchema), async (c) => {
+  .patch("/:id", zValidator("json", meetingUpdateSchema), async (c) => {
     const id = c.req.param("id");
     const data = c.req.valid("json");
 
@@ -256,7 +254,7 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
     });
     return c.json(updated);
   })
-  .post("/:id/analyze", auth, async (c) => {
+  .post("/:id/analyze", async (c) => {
     const id = c.req.param("id");
 
     const access = await requireMeetingAccess(c, id);

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -4,6 +4,17 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { sendToServiceBus } from "../lib/service-bus.js";
 import {
+  ambiguousInfoReviewInclude,
+  decisionItemReviewInclude,
+  serializeReviewItems,
+  taskReviewInclude,
+} from "../lib/review-item-serialization.js";
+import {
+  buildReviewItemTypeFilter,
+  reviewItemCreateSchema,
+  reviewItemQuerySchema,
+} from "../lib/schemas/review-item.js";
+import {
   buildTaskListWhere,
   taskListQuerySchema,
 } from "../lib/schemas/task.js";
@@ -109,6 +120,116 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         include: taskListInclude,
       });
       return c.json(tasks.map(serializeTask));
+    },
+  )
+  .get(
+    "/:id/review-items",
+    auth,
+    zValidator("query", reviewItemQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const filters = c.req.valid("query");
+
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
+
+      const { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere } =
+        buildReviewItemTypeFilter(filters.type);
+
+      const [decisionItems, tasks, ambiguousInfos] = await Promise.all([
+        includeDecision
+          ? prisma.decisionItem.findMany({
+              where: {
+                meetingId: id,
+                status: { in: ["draft", "reviewing"] },
+                ...decisionItemTypeWhere,
+              },
+              orderBy: { createdAt: "asc" },
+              include: decisionItemReviewInclude,
+            })
+          : [],
+        includeTasks
+          ? prisma.task.findMany({
+              where: {
+                originMeetingId: id,
+                status: { in: ["draft", "reviewing"] },
+              },
+              orderBy: { createdAt: "asc" },
+              include: taskReviewInclude,
+            })
+          : [],
+        includeAmbiguousInfos
+          ? prisma.ambiguousInfo.findMany({
+              where: {
+                meetingId: id,
+                status: { in: ["draft", "reviewing"] },
+              },
+              orderBy: { createdAt: "asc" },
+              include: ambiguousInfoReviewInclude,
+            })
+          : [],
+      ]);
+
+      return c.json(serializeReviewItems({ decisionItems, tasks, ambiguousInfos }));
+    },
+  )
+  // 動作確認用（後で削除予定）
+  .post(
+    "/:id/review-items",
+    auth,
+    zValidator("json", reviewItemCreateSchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const input = c.req.valid("json");
+
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
+
+      const { organizationId } = access.meeting.recurringMeeting;
+
+      if (input.type === "task_candidate") {
+        const task = await prisma.task.create({
+          data: {
+            organizationId,
+            title: input.title,
+            body: input.body,
+            sourceContext: input.sourceContext,
+            status: "draft",
+            originMeetingId: id,
+          },
+          select: { id: true, title: true, status: true },
+        });
+        return c.json(task, 201);
+      }
+
+      if (input.type === "ambiguity") {
+        const item = await prisma.ambiguousInfo.create({
+          data: {
+            meetingId: id,
+            body: input.title,
+            sourceContext: input.sourceContext,
+            status: "draft",
+          },
+          select: { id: true, body: true, status: true },
+        });
+        return c.json(item, 201);
+      }
+
+      // decision / open_issue → DecisionItem
+      const decisionState =
+        input.type === "decision" ? ("confirmed" as const) : ("open" as const);
+      const item = await prisma.decisionItem.create({
+        data: {
+          meetingId: id,
+          title: input.title,
+          body: input.body,
+          sourceContext: input.sourceContext,
+          status: "draft",
+          decisionState,
+        },
+        select: { id: true, title: true, status: true, decisionState: true },
+      });
+      return c.json(item, 201);
     },
   )
   .patch("/:id", auth, zValidator("json", meetingUpdateSchema), async (c) => {

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -153,8 +153,12 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
       const guard = await requireRecurringAccess(c, meeting);
       if (!guard.ok) return guard.res;
 
-      const { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere } =
-        buildReviewItemTypeFilter(filters.type);
+      const {
+        includeDecision,
+        includeTasks,
+        includeAmbiguousInfos,
+        decisionItemTypeWhere,
+      } = buildReviewItemTypeFilter(filters.type);
 
       const meetingWhere = filters.meetingId
         ? { meetingId: filters.meetingId }
@@ -197,7 +201,9 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
           : [],
       ]);
 
-      return c.json(serializeReviewItems({ decisionItems, tasks, ambiguousInfos }));
+      return c.json(
+        serializeReviewItems({ decisionItems, tasks, ambiguousInfos }),
+      );
     },
   )
   .get("/:id/meetings", async (c) => {

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -183,6 +183,7 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
           ? prisma.task.findMany({
               where: {
                 ...taskMeetingWhere,
+                originMeetingId: { not: null },
                 status: { in: ["draft", "reviewing"] },
               },
               orderBy: { createdAt: "asc" },

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -185,7 +185,9 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
                 ...taskMeetingWhere,
                 // meetingId 未指定時は originMeeting join でスコープするため originMeetingId: { not: null } が必要。
                 // meetingId 指定時は originMeetingId が既に specific ID で非 null 保証されるため不要。
-                ...(filters.meetingId ? {} : { originMeetingId: { not: null } }),
+                ...(filters.meetingId
+                  ? {}
+                  : { originMeetingId: { not: null } }),
                 status: { in: ["draft", "reviewing"] },
               },
               orderBy: { createdAt: "asc" },

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -183,7 +183,9 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
           ? prisma.task.findMany({
               where: {
                 ...taskMeetingWhere,
-                originMeetingId: { not: null },
+                // meetingId 未指定時は originMeeting join でスコープするため originMeetingId: { not: null } が必要。
+                // meetingId 指定時は originMeetingId が既に specific ID で非 null 保証されるため不要。
+                ...(filters.meetingId ? {} : { originMeetingId: { not: null } }),
                 status: { in: ["draft", "reviewing"] },
               },
               orderBy: { createdAt: "asc" },

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -4,6 +4,16 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
+import {
+  ambiguousInfoReviewInclude,
+  decisionItemReviewInclude,
+  serializeReviewItems,
+  taskReviewInclude,
+} from "../lib/review-item-serialization.js";
+import {
+  buildReviewItemTypeFilter,
+  recurringMeetingReviewItemQuerySchema,
+} from "../lib/schemas/review-item.js";
 import { recurringMeetingUpdateSchema } from "../lib/schemas/recurring-meeting.js";
 import {
   buildTaskListWhere,
@@ -130,6 +140,67 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
     });
     return c.json(tasks.map(serializeTask));
   })
+  .get(
+    "/:id/review-items",
+    zValidator("query", recurringMeetingReviewItemQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const filters = c.req.valid("query");
+
+      const meeting = await prisma.recurringMeeting.findUnique({
+        where: { id },
+      });
+      const guard = await requireRecurringAccess(c, meeting);
+      if (!guard.ok) return guard.res;
+
+      const { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere } =
+        buildReviewItemTypeFilter(filters.type);
+
+      // meetingId フィルタが指定された場合は当該会議のみに絞る。
+      const meetingWhere = filters.meetingId
+        ? { meetingId: filters.meetingId }
+        : { meeting: { recurringMeetingId: id } };
+      const taskMeetingWhere = filters.meetingId
+        ? { originMeetingId: filters.meetingId }
+        : { originMeeting: { recurringMeetingId: id } };
+
+      const [decisionItems, tasks, ambiguousInfos] = await Promise.all([
+        includeDecision
+          ? prisma.decisionItem.findMany({
+              where: {
+                ...meetingWhere,
+                status: { in: ["draft", "reviewing"] },
+                ...decisionItemTypeWhere,
+              },
+              orderBy: { createdAt: "asc" },
+              include: decisionItemReviewInclude,
+            })
+          : [],
+        includeTasks
+          ? prisma.task.findMany({
+              where: {
+                ...taskMeetingWhere,
+                status: { in: ["draft", "reviewing"] },
+              },
+              orderBy: { createdAt: "asc" },
+              include: taskReviewInclude,
+            })
+          : [],
+        includeAmbiguousInfos
+          ? prisma.ambiguousInfo.findMany({
+              where: {
+                ...meetingWhere,
+                status: { in: ["draft", "reviewing"] },
+              },
+              orderBy: { createdAt: "asc" },
+              include: ambiguousInfoReviewInclude,
+            })
+          : [],
+      ]);
+
+      return c.json(serializeReviewItems({ decisionItems, tasks, ambiguousInfos }));
+    },
+  )
   .get("/:id/meetings", async (c) => {
     const id = c.req.param("id");
 

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -156,7 +156,6 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
       const { includeDecision, includeTasks, includeAmbiguousInfos, decisionItemTypeWhere } =
         buildReviewItemTypeFilter(filters.type);
 
-      // meetingId フィルタが指定された場合は当該会議のみに絞る。
       const meetingWhere = filters.meetingId
         ? { meetingId: filters.meetingId }
         : { meeting: { recurringMeetingId: id } };

--- a/apps/api/test/ambiguous-infos.test.ts
+++ b/apps/api/test/ambiguous-infos.test.ts
@@ -51,7 +51,7 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
 
@@ -173,7 +173,12 @@ describe("PATCH /ambiguous-infos/:id", () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
     mockTransaction.mockResolvedValue({
       kind: "ok",
-      item: { ...sampleItem, status: "resolved", resolutionType: "discarded", version: 1 },
+      item: {
+        ...sampleItem,
+        status: "resolved",
+        resolutionType: "discarded",
+        version: 1,
+      },
     });
 
     const res = await app.request("/ambiguous-infos/ai-1", {

--- a/apps/api/test/ambiguous-infos.test.ts
+++ b/apps/api/test/ambiguous-infos.test.ts
@@ -1,0 +1,399 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    recurringMeeting: {
+      findMany: vi.fn(),
+    },
+    ambiguousInfo: {
+      findUnique: vi.fn(),
+    },
+    task: {
+      create: vi.fn(),
+    },
+    taskAssignee: {
+      createMany: vi.fn(),
+    },
+    taskRecurringMeeting: {
+      createMany: vi.fn(),
+    },
+    decisionItem: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { Prisma } from "@prisma/client";
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+type AmbiguousInfoWithAccess = Prisma.AmbiguousInfoGetPayload<{
+  include: {
+    meeting: {
+      select: { recurringMeeting: { select: { organizationId: true } } };
+    };
+  };
+}>;
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockMembershipFindMany = vi.mocked(
+  prisma.organizationMembership.findMany,
+);
+const mockRecurringFindMany = vi.mocked(prisma.recurringMeeting.findMany);
+const mockAmbiguousInfoFindUnique = vi.mocked(prisma.ambiguousInfo.findUnique);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+const sampleItem: AmbiguousInfoWithAccess = {
+  id: "ai-1",
+  meetingId: "mtg-1",
+  body: "担当者が不明",
+  sourceQuote: null,
+  sourceContext: null,
+  status: "reviewing",
+  ambiguityType: null,
+  severity: null,
+  inferenceBasis: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  affectedItemIds: null,
+  resolutionType: null,
+  resolvedToTaskId: null,
+  resolvedToDecisionItemId: null,
+  version: 0,
+  createdAt: new Date("2026-05-01T00:00:00Z"),
+  updatedAt: new Date("2026-05-01T00:00:00Z"),
+  meeting: { recurringMeeting: { organizationId: "org-1" } },
+};
+
+describe("PATCH /ambiguous-infos/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("アイテムが存在しない場合は 404", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/ambiguous-infos/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "rejected" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属の場合は 404", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "rejected" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("status=rejected で 200 を返す", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue({
+      kind: "ok",
+      item: { ...sampleItem, status: "rejected", version: 1 },
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "rejected" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; version: number };
+    expect(body.status).toBe("rejected");
+    expect(body.version).toBe(1);
+  });
+
+  it("status=rejected で version 不一致は 409", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue({ kind: "version_conflict" });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, status: "rejected" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("resolutionType=discarded で 200 を返す", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockResolvedValue({
+      kind: "ok",
+      item: { ...sampleItem, status: "resolved", resolutionType: "discarded", version: 1 },
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolutionType: "discarded" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resolutionType: string };
+    expect(body.resolutionType).toBe("discarded");
+  });
+
+  it("resolutionType=task でタスクを作成し 200 を返す", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const newTask = { id: "task-new", title: "担当者が不明" };
+    let taskCreated = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: {
+          create: vi.fn(() => {
+            taskCreated = true;
+            return Promise.resolve(newTask);
+          }),
+        },
+        taskAssignee: { createMany: vi.fn() },
+        taskRecurringMeeting: { createMany: vi.fn() },
+        ambiguousInfo: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            ...sampleItem,
+            status: "resolved",
+            resolutionType: "task",
+            resolvedToTaskId: "task-new",
+            version: 1,
+            resolvedToTask: newTask,
+          }),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolutionType: "task" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(taskCreated).toBe(true);
+    const body = (await res.json()) as { resolutionType: string };
+    expect(body.resolutionType).toBe("task");
+  });
+
+  it("resolutionType=task で他組織の assignee が含まれる場合は 400", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 2 名指定したが 1 名しか組織メンバーとして見つからない
+    mockMembershipFindMany.mockResolvedValue([membership()]);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "task",
+        newTask: { assigneeUserIds: ["user-1", "user-outside"] },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("resolutionType=task で他組織の recurringMeeting が含まれる場合は 400", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 指定した 2 件のうち 1 件しか見つからない
+    mockRecurringFindMany.mockResolvedValue([{ id: "rmtg-1" }]);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "task",
+        newTask: { recurringMeetingIds: ["rmtg-1", "rmtg-other"] },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("resolutionType=task で version 不一致は 409 かつタスクはロールバックされる", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        task: { create: vi.fn().mockResolvedValue({ id: "task-new" }) },
+        taskAssignee: { createMany: vi.fn() },
+        taskRecurringMeeting: { createMany: vi.fn() },
+        ambiguousInfo: {
+          // version 不一致で count=0 を返す
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+          findUniqueOrThrow: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, resolutionType: "task" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("resolutionType=decision_item で DecisionItem を作成し 200 を返す", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const newDi = { id: "di-new", title: "担当者が不明" };
+    let diCreated = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          create: vi.fn(() => {
+            diCreated = true;
+            return Promise.resolve(newDi);
+          }),
+        },
+        ambiguousInfo: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            ...sampleItem,
+            status: "resolved",
+            resolutionType: "decision_item",
+            resolvedToDecisionItemId: "di-new",
+            version: 1,
+            resolvedToDecision: newDi,
+          }),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolutionType: "decision_item" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(diCreated).toBe(true);
+    const body = (await res.json()) as { resolutionType: string };
+    expect(body.resolutionType).toBe("decision_item");
+  });
+
+  it("resolutionType=decision_item で version 不一致は 409", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: { create: vi.fn().mockResolvedValue({ id: "di-new" }) },
+        ambiguousInfo: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+          findUniqueOrThrow: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, resolutionType: "decision_item" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("status も resolutionType も未指定は 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0 }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAmbiguousInfoFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("version 欠落は 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "rejected" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("スキーマ外フィールドは 400（strict）", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        status: "rejected",
+        unknownField: "x",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/test/ambiguous-infos.test.ts
+++ b/apps/api/test/ambiguous-infos.test.ts
@@ -139,7 +139,12 @@ describe("PATCH /ambiguous-infos/:id", () => {
     mockMembershipFindUnique.mockResolvedValue(membership());
     mockTransaction.mockResolvedValue({
       kind: "ok",
-      item: { ...sampleItem, status: "rejected", version: 1 },
+      item: {
+        ...sampleItem,
+        status: "rejected",
+        version: 1,
+        meeting: { recurringMeetingId: "rmtg-1" },
+      },
     });
 
     const res = await app.request("/ambiguous-infos/ai-1", {
@@ -149,7 +154,14 @@ describe("PATCH /ambiguous-infos/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string; version: number };
+    const body = (await res.json()) as {
+      sourceTable: string;
+      type: string;
+      status: string;
+      version: number;
+    };
+    expect(body.sourceTable).toBe("ambiguous_info");
+    expect(body.type).toBe("ambiguity");
     expect(body.status).toBe("rejected");
     expect(body.version).toBe(1);
   });
@@ -178,6 +190,7 @@ describe("PATCH /ambiguous-infos/:id", () => {
         status: "resolved",
         resolutionType: "discarded",
         version: 1,
+        meeting: { recurringMeetingId: "rmtg-1" },
       },
     });
 
@@ -188,8 +201,9 @@ describe("PATCH /ambiguous-infos/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { resolutionType: string };
-    expect(body.resolutionType).toBe("discarded");
+    const body = (await res.json()) as { sourceTable: string; status: string };
+    expect(body.sourceTable).toBe("ambiguous_info");
+    expect(body.status).toBe("resolved");
   });
 
   it("resolutionType=task でタスクを作成し 200 を返す", async () => {
@@ -215,7 +229,7 @@ describe("PATCH /ambiguous-infos/:id", () => {
             resolutionType: "task",
             resolvedToTaskId: "task-new",
             version: 1,
-            resolvedToTask: newTask,
+            meeting: { recurringMeetingId: "rmtg-1" },
           }),
         },
       };
@@ -231,8 +245,9 @@ describe("PATCH /ambiguous-infos/:id", () => {
 
     expect(res.status).toBe(200);
     expect(taskCreated).toBe(true);
-    const body = (await res.json()) as { resolutionType: string };
-    expect(body.resolutionType).toBe("task");
+    const body = (await res.json()) as { sourceTable: string; status: string };
+    expect(body.sourceTable).toBe("ambiguous_info");
+    expect(body.status).toBe("resolved");
   });
 
   it("resolutionType=task で他組織の assignee が含まれる場合は 400", async () => {
@@ -323,7 +338,7 @@ describe("PATCH /ambiguous-infos/:id", () => {
             resolutionType: "decision_item",
             resolvedToDecisionItemId: "di-new",
             version: 1,
-            resolvedToDecision: newDi,
+            meeting: { recurringMeetingId: "rmtg-1" },
           }),
         },
       };
@@ -339,8 +354,9 @@ describe("PATCH /ambiguous-infos/:id", () => {
 
     expect(res.status).toBe(200);
     expect(diCreated).toBe(true);
-    const body = (await res.json()) as { resolutionType: string };
-    expect(body.resolutionType).toBe("decision_item");
+    const body = (await res.json()) as { sourceTable: string; status: string };
+    expect(body.sourceTable).toBe("ambiguous_info");
+    expect(body.status).toBe("resolved");
   });
 
   it("resolutionType=decision_item で version 不一致は 409", async () => {

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -40,7 +40,7 @@ vi.mock("../src/middleware/auth.js", () => ({
   },
 }));
 
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
 
@@ -130,9 +130,12 @@ describe("PATCH /decision-items/:id", () => {
       const tx = {
         decisionItem: {
           updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-          findUniqueOrThrow: vi
-            .fn()
-            .mockResolvedValue({ ...sampleItem, title: "更新後", version: 1, assignees: [] }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            ...sampleItem,
+            title: "更新後",
+            version: 1,
+            assignees: [],
+          }),
         },
         decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
       };

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -135,6 +135,7 @@ describe("PATCH /decision-items/:id", () => {
             title: "更新後",
             version: 1,
             assignees: [],
+            meeting: { recurringMeetingId: "rmtg-1" },
           }),
         },
         decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
@@ -208,9 +209,11 @@ describe("PATCH /decision-items/:id", () => {
       const tx = {
         decisionItem: {
           updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-          findUniqueOrThrow: vi
-            .fn()
-            .mockResolvedValue({ ...sampleItem, assignees: [] }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            ...sampleItem,
+            assignees: [],
+            meeting: { recurringMeetingId: "rmtg-1" },
+          }),
         },
         decisionItemAssignee: {
           deleteMany: vi.fn(() => {

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    decisionItem: {
+      findUnique: vi.fn(),
+    },
+    decisionItemAssignee: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { Prisma } from "@prisma/client";
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+type DecisionItemWithAccess = Prisma.DecisionItemGetPayload<{
+  include: {
+    meeting: {
+      select: { recurringMeeting: { select: { organizationId: true } } };
+    };
+  };
+}>;
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockMembershipFindMany = vi.mocked(
+  prisma.organizationMembership.findMany,
+);
+const mockDecisionItemFindUnique = vi.mocked(prisma.decisionItem.findUnique);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+const sampleItem: DecisionItemWithAccess = {
+  id: "di-1",
+  meetingId: "mtg-1",
+  title: "テスト決定事項",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "reviewing",
+  decisionState: "confirmed",
+  reason: null,
+  blockingItemId: null,
+  recurrenceCount: null,
+  ambiguityFlags: null,
+  decisionDeadline: null,
+  plannedMeetingId: null,
+  decidedAt: null,
+  decidedBy: null,
+  version: 0,
+  createdAt: new Date("2026-05-01T00:00:00Z"),
+  updatedAt: new Date("2026-05-01T00:00:00Z"),
+  meeting: { recurringMeeting: { organizationId: "org-1" } },
+};
+
+describe("PATCH /decision-items/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("アイテムが存在しない場合は 404", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/decision-items/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属の場合は 404", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("title 更新が 200 を返し version がインクリメントされる", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi
+            .fn()
+            .mockResolvedValue({ ...sampleItem, title: "更新後", version: 1, assignees: [] }),
+        },
+        decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { title: string; version: number };
+    expect(body.title).toBe("更新後");
+    expect(body.version).toBe(1);
+  });
+
+  it("version 不一致は 409", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+          findUniqueOrThrow: vi.fn(),
+        },
+        decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("assigneeUserIds に他組織メンバーが混在する場合は 400", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 2 名指定したが 1 名しか組織メンバーとして見つからない
+    mockMembershipFindMany.mockResolvedValue([membership()]);
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        assigneeUserIds: ["user-1", "user-outside"],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("assigneeUserIds:[] は既存アサイニーを全削除する", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(sampleItem);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 空配列で findMany を呼ぶと 0 件返る（DB の実挙動と一致）
+    mockMembershipFindMany.mockResolvedValue([]);
+    let deleteCalled = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi
+            .fn()
+            .mockResolvedValue({ ...sampleItem, assignees: [] }),
+        },
+        decisionItemAssignee: {
+          deleteMany: vi.fn(() => {
+            deleteCalled = true;
+            return Promise.resolve({ count: 0 });
+          }),
+          createMany: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, assigneeUserIds: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deleteCalled).toBe(true);
+  });
+
+  it("更新フィールドなし（version のみ）は 400", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0 }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockDecisionItemFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("version 欠落は 400", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "更新後" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("スキーマ外フィールドは 400（strict）", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新後", unknownField: "x" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -13,6 +13,12 @@ vi.mock("../src/lib/prisma.js", () => ({
     task: {
       findMany: vi.fn(),
     },
+    decisionItem: {
+      findMany: vi.fn(),
+    },
+    ambiguousInfo: {
+      findMany: vi.fn(),
+    },
     meetingAnalysisRun: {
       findFirst: vi.fn(),
       create: vi.fn(),
@@ -53,6 +59,11 @@ vi.mock("../src/middleware/auth.js", () => ({
 import type { Prisma } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type {
+  ambiguousInfoReviewInclude,
+  decisionItemReviewInclude,
+  taskReviewInclude,
+} from "../src/lib/review-item-serialization.js";
 import { sendToServiceBus } from "../src/lib/service-bus.js";
 import type { TaskWithList } from "../src/lib/task-serialization.js";
 
@@ -74,6 +85,16 @@ type MeetingDetail = Prisma.MeetingGetPayload<{
 type MeetingForUpdate = Prisma.MeetingGetPayload<{
   include: { recurringMeeting: { select: { organizationId: true } } };
 }>;
+// GET /meetings/:id/review-items ハンドラ用: review include に対応した各テーブルの型
+type DecisionItemWithReview = Prisma.DecisionItemGetPayload<{
+  include: typeof decisionItemReviewInclude;
+}>;
+type TaskWithReview = Prisma.TaskGetPayload<{
+  include: typeof taskReviewInclude;
+}>;
+type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
+  include: typeof ambiguousInfoReviewInclude;
+}>;
 
 const mockFindUnique = vi.mocked(prisma.meeting.findUnique);
 const mockMeetingUpdate = vi.mocked(prisma.meeting.update);
@@ -85,6 +106,8 @@ const mockAnalysisRunCreate = vi.mocked(prisma.meetingAnalysisRun.create);
 const mockSendToServiceBus = vi.mocked(sendToServiceBus);
 const mockAnalysisRunUpdate = vi.mocked(prisma.meetingAnalysisRun.update);
 const mockAnalysisRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
+const mockDecisionItemFindMany = vi.mocked(prisma.decisionItem.findMany);
+const mockAmbiguousInfoFindMany = vi.mocked(prisma.ambiguousInfo.findMany);
 
 describe("旧 GET / と POST /meetings は撤去済み", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -755,5 +778,243 @@ describe("POST /meetings/:id/analyze", () => {
         }),
       );
     });
+  });
+});
+
+describe("GET /meetings/:id/review-items", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const meetingBase = {
+    id: "mtg-1",
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  } as MeetingWithRecurringOrgId;
+
+  function setupAccess() {
+    mockFindUnique.mockResolvedValue(meetingBase);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+  }
+
+  const sampleDecisionItem = {
+    id: "di-1",
+    meetingId: "mtg-1",
+    title: "認証方式を決定する",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    decisionState: "confirmed",
+    decisionDeadline: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    assignees: [],
+    meeting: { recurringMeetingId: "rmtg-1" },
+  } as DecisionItemWithReview;
+
+  const sampleReviewTask = {
+    id: "task-review-1",
+    organizationId: "org-1",
+    originMeetingId: "mtg-1",
+    decisionItemId: null,
+    title: "ドキュメント整備",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    assignees: [],
+    originMeeting: { recurringMeetingId: "rmtg-1" },
+  } as TaskWithReview;
+
+  const sampleAmbiguousInfo = {
+    id: "ai-1",
+    meetingId: "mtg-1",
+    body: "要件が不明確",
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    severity: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    meeting: { recurringMeetingId: "rmtg-1" },
+  } as AmbiguousInfoWithReview;
+
+  it("type 未指定 → 3 テーブル全件を取得して統合レスポンスを返す", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+    // biome-ignore lint/suspicious/noExplicitAny: TaskWithReview は TaskWithList と include 形が異なるため
+    mockTaskFindMany.mockResolvedValue([sampleReviewTask] as any);
+    mockAmbiguousInfoFindMany.mockResolvedValue([sampleAmbiguousInfo]);
+
+    const res = await app.request("/meetings/mtg-1/review-items");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      sourceTable: string;
+      type: string;
+      id: string;
+      recurringMeetingId: string | null;
+    }>;
+    expect(body).toHaveLength(3);
+    expect(body[0].sourceTable).toBe("decision_item");
+    expect(body[0].type).toBe("decision");
+    expect(body[1].sourceTable).toBe("task");
+    expect(body[1].type).toBe("task_candidate");
+    expect(body[2].sourceTable).toBe("ambiguous_info");
+    expect(body[2].type).toBe("ambiguity");
+    expect(mockDecisionItemFindMany).toHaveBeenCalledTimes(1);
+    expect(mockTaskFindMany).toHaveBeenCalledTimes(1);
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("?type=decision → confirmed/tentative 制約が where に入り task・ambiguity は呼ばれない", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+
+    const res = await app.request("/meetings/mtg-1/review-items?type=decision");
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          meetingId: "mtg-1",
+          decisionState: { in: ["confirmed", "tentative"] },
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=open_issue → OR 条件が where に入り task・ambiguity は呼ばれない", async () => {
+    setupAccess();
+    const openItem = {
+      ...sampleDecisionItem,
+      id: "di-open",
+      decisionState: "open",
+    } as DecisionItemWithReview;
+    mockDecisionItemFindMany.mockResolvedValue([openItem]);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=open_issue",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ decisionState: "open" }, { decisionState: null }],
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=task_candidate → task のみ呼ばれ decisionItem・ambiguousInfo は呼ばれない", async () => {
+    setupAccess();
+    // biome-ignore lint/suspicious/noExplicitAny: TaskWithReview は TaskWithList と include 形が異なるため
+    mockTaskFindMany.mockResolvedValue([sampleReviewTask] as any);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=task_candidate",
+    );
+    expect(res.status).toBe(200);
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ originMeetingId: "mtg-1" }),
+      }),
+    );
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=ambiguity → ambiguousInfo のみ呼ばれ decisionItem・task は呼ばれない", async () => {
+    setupAccess();
+    mockAmbiguousInfoFindMany.mockResolvedValue([sampleAmbiguousInfo]);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=ambiguity",
+    );
+    expect(res.status).toBe(200);
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ meetingId: "mtg-1" }),
+      }),
+    );
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=decision,task_candidate → decisionItem・task が呼ばれ ambiguousInfo は呼ばれない", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+    // biome-ignore lint/suspicious/noExplicitAny: TaskWithReview は TaskWithList と include 形が異なるため
+    mockTaskFindMany.mockResolvedValue([sampleReviewTask] as any);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=decision,task_candidate",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledTimes(1);
+    expect(mockTaskFindMany).toHaveBeenCalledTimes(1);
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=decision,open_issue → decisionItem のみ呼ばれ decisionState 制約なし", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=decision,open_issue",
+    );
+    expect(res.status).toBe(200);
+    const callWhere = mockDecisionItemFindMany.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
+    // decision + open_issue の組み合わせは全 decisionState を含むため where に制約が入らない
+    expect(callWhere).not.toHaveProperty("decisionState");
+    expect(callWhere).not.toHaveProperty("OR");
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type 不正値は 400", async () => {
+    const res = await app.request("/meetings/mtg-1/review-items?type=unknown");
+    expect(res.status).toBe(400);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+
+  it("会議不存在は 404", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/review-items");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockFindUnique.mockResolvedValue(meetingBase);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/review-items");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -22,6 +22,12 @@ vi.mock("../src/lib/prisma.js", () => ({
     task: {
       findMany: vi.fn(),
     },
+    decisionItem: {
+      findMany: vi.fn(),
+    },
+    ambiguousInfo: {
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -58,6 +64,11 @@ vi.mock("../src/middleware/auth.js", () => ({
 import type { Prisma, RecurringMeeting } from "@prisma/client";
 import { app } from "../src/app.js";
 import { prisma } from "../src/lib/prisma.js";
+import type {
+  ambiguousInfoReviewInclude,
+  decisionItemReviewInclude,
+  taskReviewInclude,
+} from "../src/lib/review-item-serialization.js";
 import type { TaskWithList } from "../src/lib/task-serialization.js";
 
 // ハンドラ側で利用している include / select 形に合わせた Prisma 型エイリアス。
@@ -77,6 +88,16 @@ type MeetingListRow = Prisma.MeetingGetPayload<{
     recurringMeetingId: true;
   };
 }>;
+// GET /recurring-meetings/:id/review-items ハンドラ用
+type DecisionItemWithReview = Prisma.DecisionItemGetPayload<{
+  include: typeof decisionItemReviewInclude;
+}>;
+type TaskWithReview = Prisma.TaskGetPayload<{
+  include: typeof taskReviewInclude;
+}>;
+type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
+  include: typeof ambiguousInfoReviewInclude;
+}>;
 
 const mockMembershipFindUnique = vi.mocked(
   prisma.organizationMembership.findUnique,
@@ -90,6 +111,8 @@ const mockMeetingFindMany = vi.mocked(prisma.meeting.findMany);
 const mockMeetingCreate = vi.mocked(prisma.meeting.create);
 const mockTaskFindMany = vi.mocked(prisma.task.findMany);
 const mockTransaction = vi.mocked(prisma.$transaction);
+const mockDecisionItemFindMany = vi.mocked(prisma.decisionItem.findMany);
+const mockAmbiguousInfoFindMany = vi.mocked(prisma.ambiguousInfo.findMany);
 
 function membership(role: "owner" | "admin" | "member") {
   return {
@@ -1038,5 +1061,231 @@ describe("GET /recurring-meetings/:id/tasks", () => {
       assignees?: { some?: { userId?: string }; none?: unknown };
     };
     expect(where.assignees).toEqual({ some: { userId: "user-42" } });
+  });
+});
+
+describe("GET /recurring-meetings/:id/review-items", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function setupAccess() {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue(membership("member"));
+  }
+
+  const sampleDecisionItem = {
+    id: "di-1",
+    meetingId: "mtg-1",
+    title: "認証方式を決定する",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    decisionState: "confirmed",
+    decisionDeadline: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    assignees: [],
+    meeting: { recurringMeetingId: "rmtg-1" },
+  } as DecisionItemWithReview;
+
+  const sampleReviewTask = {
+    id: "task-review-1",
+    organizationId: "org-1",
+    originMeetingId: "mtg-1",
+    decisionItemId: null,
+    title: "ドキュメント整備",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    assignees: [],
+    originMeeting: { recurringMeetingId: "rmtg-1" },
+  } as TaskWithReview;
+
+  const sampleAmbiguousInfo = {
+    id: "ai-1",
+    meetingId: "mtg-1",
+    body: "要件が不明確",
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    severity: null,
+    version: 0,
+    createdAt: new Date("2026-05-17T00:00:00Z"),
+    updatedAt: new Date("2026-05-17T00:00:00Z"),
+    meeting: { recurringMeetingId: "rmtg-1" },
+  } as AmbiguousInfoWithReview;
+
+  it("type 未指定 → recurringMeetingId スコープで 3 テーブル全件を取得する", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+    // biome-ignore lint/suspicious/noExplicitAny: TaskWithReview は TaskWithList と include 形が異なるため
+    mockTaskFindMany.mockResolvedValue([sampleReviewTask] as any);
+    mockAmbiguousInfoFindMany.mockResolvedValue([sampleAmbiguousInfo]);
+
+    const res = await app.request("/recurring-meetings/rmtg-1/review-items");
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          meeting: { recurringMeetingId: "rmtg-1" },
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          originMeeting: { recurringMeetingId: "rmtg-1" },
+        }),
+      }),
+    );
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          meeting: { recurringMeetingId: "rmtg-1" },
+        }),
+      }),
+    );
+  });
+
+  it("?meetingId=mtg-1 → meetingId / originMeetingId スコープに切り替わる", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockAmbiguousInfoFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?meetingId=mtg-1",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ meetingId: "mtg-1" }),
+      }),
+    );
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ originMeetingId: "mtg-1" }),
+      }),
+    );
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ meetingId: "mtg-1" }),
+      }),
+    );
+  });
+
+  it("?type=decision → confirmed/tentative 制約が入り task・ambiguity は呼ばれない", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?type=decision",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          decisionState: { in: ["confirmed", "tentative"] },
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=open_issue → OR 条件が入り task・ambiguity は呼ばれない", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?type=open_issue",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ decisionState: "open" }, { decisionState: null }],
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=task_candidate → task のみ呼ばれ decisionItem・ambiguousInfo は呼ばれない", async () => {
+    setupAccess();
+    mockTaskFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?type=task_candidate",
+    );
+    expect(res.status).toBe(200);
+    expect(mockTaskFindMany).toHaveBeenCalledTimes(1);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?type=ambiguity → ambiguousInfo のみ呼ばれ decisionItem・task は呼ばれない", async () => {
+    setupAccess();
+    mockAmbiguousInfoFindMany.mockResolvedValue([]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?type=ambiguity",
+    );
+    expect(res.status).toBe(200);
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledTimes(1);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+
+  it("?meetingId + ?type=decision → meetingId スコープと confirmed/tentative 制約が組み合わさる", async () => {
+    setupAccess();
+    mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);
+
+    const res = await app.request(
+      "/recurring-meetings/rmtg-1/review-items?meetingId=mtg-1&type=decision",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          meetingId: "mtg-1",
+          decisionState: { in: ["confirmed", "tentative"] },
+        }),
+      }),
+    );
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
+    expect(mockAmbiguousInfoFindMany).not.toHaveBeenCalled();
+  });
+
+  it("定例不存在は 404", async () => {
+    mockRecurringFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/missing/review-items");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockRecurringFindUnique.mockResolvedValue(sampleRecurring);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/recurring-meetings/rmtg-1/review-items");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #242 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* 会議から AI 抽出された決定事項・タスク・未決事項をレビューするための API を実装する。
* 新規テーブルは追加せず、既存の `DecisionItem` / `Task` / `AmbiguousInfo` を統合して返す設計。

## 背景
* #235 のフロントエンド実装が完了しているが、バックエンドのレビューAPIが未実装のため localStorage を一時ストアとして使用している
* 状態遷移・担当者管理・AI解析結果との連携など要件が複雑で、フロントエンド単独で後から差し替えるよりも先にAPIを作った方がリスクが低いと判断

## 変更内容
  * **`GET /meetings/:id/review-items`** — ミーティング単位でレビューアイテムを一覧取得。`?type=decision,ambiguity` のようにカンマ区切りで絞り込み可。
  * **`GET /recurring-meetings/:id/review-items`** — 定例単位で一覧取得。`?meetingId=` で特定ミーティングに絞り込み可。
  * **`PATCH /decision-items/:id`** — ステータス・`decisionState`・タイトル・担当者などを更新。担当者の組織帰属バリデーション付き。
  * **`PATCH /ambiguous-infos/:id`** — 未決事項を `rejected` に却下、または `task` / `decision_item` / `discarded` のいずれかに解決。`task` /
  `decision_item` への解決時はトランザクション内で関連レコードを作成。
  * **`lib/review-item-serialization.ts`** — 3 テーブルを統一フォーマットにシリアライズするロジックを共通化。
  * **`lib/schemas/review-item.ts`** — クエリ・PATCH の Zod スキーマと `buildReviewItemTypeFilter` ユーティリティを定義。
  * **`POST /meetings/:id/review-items`**（動作確認用・後で削除予定）レビューアイテムをテスト投入するための一時エンドポイント。

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. `make install`（依存変更なしのため初回のみ）
  2. `make lint` で lint エラーが出ないこと
  3. `make test` で Vitest が `apps/api` の全テスト（`decision-items.test.ts` 7件・`ambiguous-infos.test.ts`
  11件を含む）すべて GREEN になること
  4. `make dev` でローカル環境を起動し、`make migrate` を一度実行しておく
  5. `POST http://localhost:3007/login` で FakeAuth からトークンを取得する
  6. `POST http://localhost:3001/meetings/:id/review-items` に `{"type": "decision", "title": "テスト"}`
  を送り、アイテムが作成されること
  7. `GET http://localhost:3001/meetings/:id/review-items` でアイテムが返ること。`?type=decision,open_issue` で絞り込めること
  8. `GET http://localhost:3001/recurring-meetings/:id/review-items` で定例単位でも同じアイテムが返ること
  9. `PATCH http://localhost:3001/decision-items/:id` に `{"version": 0, "title": "更新後"}` を送り、200 と `version: 1`
  が返ること。同じリクエストを再送して 409 が返ること（楽観的ロック確認）
  10. `PATCH http://localhost:3001/ambiguous-infos/:id` に `{"version": 0, "resolutionType": "discarded"}` を送り、`status:
  "resolved"` が返ること

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
  `GET /meetings/:id/review-items` レスポンス例:

  ```json
  [
    {
      "id": "di-xxx",
      "sourceTable": "decision_item",
      "type": "decision",
      "status": "reviewing",
      "title": "来週中に仕様を確定する",
      "body": null,
      "severity": null,
      "meetingId": "mtg-xxx",
      "recurringMeetingId": "rm-xxx",
      "assignees": [
        { "id": "u-1", "name": "alice", "displayName": "Alice", "email": "alice@example.com" }
      ],
      "deadline": null,
      "version": 0
    },
    {
      "id": "ai-xxx",
      "sourceTable": "ambiguous_info",
      "type": "ambiguity",
      "status": "reviewing",
      "title": "担当者が不明",
      "body": null,
      "severity": "high",
      "meetingId": "mtg-xxx",
      "recurringMeetingId": "rm-xxx",
      "assignees": [],
      "deadline": null,
      "version": 0
    }
  ]
```