### PR TITLE
feat(api): 次回会議の議題入力 API を追加

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -29,6 +29,7 @@ Table Meeting {
   originTasks Task [not null]
   ambiguousInfos AmbiguousInfo [not null]
   analysisRuns MeetingAnalysisRun [not null]
+  topicRequests TopicRequest [not null]
 }
 
 Table User {
@@ -48,6 +49,7 @@ Table User {
   taskAssignees TaskAssignee [not null]
   auditLogs AuditLog [not null]
   readLogs ReadLog [not null]
+  topicRequests TopicRequest [not null]
 }
 
 Table Organization {
@@ -299,6 +301,19 @@ Table AmbiguousInfo {
   resolvedToDecision DecisionItem
 }
 
+Table TopicRequest {
+  id String [pk]
+  meetingId String [not null]
+  requestedBy String [not null]
+  title String [not null]
+  body String
+  priority TopicRequestPriority
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+  meeting Meeting [not null]
+  requester User [not null]
+}
+
 Table MeetingAnalysisRun {
   id String [pk]
   meetingId String [not null]
@@ -381,6 +396,11 @@ Enum TaskStatus {
 }
 
 Enum TaskPriority {
+  required
+  optional
+}
+
+Enum TopicRequestPriority {
   required
   optional
 }
@@ -516,6 +536,10 @@ Ref: AmbiguousInfo.meetingId > Meeting.id [delete: Cascade]
 Ref: AmbiguousInfo.resolvedToTaskId > Task.id [delete: Set Null]
 
 Ref: AmbiguousInfo.resolvedToDecisionItemId > DecisionItem.id [delete: Set Null]
+
+Ref: TopicRequest.meetingId > Meeting.id [delete: Cascade]
+
+Ref: TopicRequest.requestedBy > User.id [delete: Restrict]
 
 Ref: MeetingAnalysisRun.meetingId > Meeting.id [delete: Cascade]
 

--- a/apps/api/prisma/migrations/20260521154011_add_topic_request/migration.sql
+++ b/apps/api/prisma/migrations/20260521154011_add_topic_request/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "TopicRequestPriority" AS ENUM ('required', 'optional');
+
+-- CreateTable
+CREATE TABLE "TopicRequest" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "requestedBy" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "priority" "TopicRequestPriority",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TopicRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TopicRequest_meetingId_idx" ON "TopicRequest"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "TopicRequest_requestedBy_idx" ON "TopicRequest"("requestedBy");
+
+-- AddForeignKey
+ALTER TABLE "TopicRequest" ADD CONSTRAINT "TopicRequest_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TopicRequest" ADD CONSTRAINT "TopicRequest_requestedBy_fkey" FOREIGN KEY ("requestedBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Meeting {
   originTasks          Task[]
   ambiguousInfos       AmbiguousInfo[]
   analysisRuns         MeetingAnalysisRun[]
+  // 当該会議を「次回会議」として紐付くユーザー入力議題群。会議削除時は議題ごと削除する。
+  topicRequests        TopicRequest[]
 
   // インデックス
   @@index([previousMeetingId])
@@ -77,6 +79,8 @@ model User {
   taskAssignees         TaskAssignee[]
   auditLogs             AuditLog[]
   readLogs              ReadLog[]
+  // ユーザーが起票した次回議題。User 削除時は履歴保持のため Restrict する。
+  topicRequests         TopicRequest[]
 }
 
 // 決定事項のステータス
@@ -115,6 +119,14 @@ enum TaskStatus {
 
 // タスクの必須度
 enum TaskPriority {
+  required
+  optional
+}
+
+// 次回会議の議題（TopicRequest）の必須度。
+// AI 仕様の Task.priority と意味を揃えており、required は次回会議冒頭で必ず触れる前提。
+// 将来分岐する可能性に備えて Task とは別 enum として定義する。
+enum TopicRequestPriority {
   required
   optional
 }
@@ -501,6 +513,27 @@ model AmbiguousInfo {
 
   @@index([meetingId])
   @@index([status])
+}
+
+// 次回会議に向けた、ユーザーが事前に登録する議題。
+// AI が生成する recommendedAgenda（MeetingAnalysisRun.recommendedAgenda）とは別経路で、
+// 議事録生成（フェーズ2）時にプロンプトへ user_topic_requests として注入される想定。
+// meetingId は「議題を提示する次回会議」を指す。
+model TopicRequest {
+  id          String                @id @default(cuid())
+  meetingId   String
+  requestedBy String
+  title       String
+  body        String?
+  priority    TopicRequestPriority?
+  createdAt   DateTime              @default(now())
+  updatedAt   DateTime              @updatedAt
+
+  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  requester User    @relation(fields: [requestedBy], references: [id], onDelete: Restrict)
+
+  @@index([meetingId])
+  @@index([requestedBy])
 }
 
 // 解析ランの実行状態。queued → analyzing → completed | failed の遷移を取る。

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
 import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
 import { tasksRoute } from "./routes/tasks.js";
+import { topicRequestsRoute } from "./routes/topic-requests.js";
 import { internalRoute } from "./routes/internal.js";
 import { internalAuth } from "./middleware/internal-auth.js";
 
@@ -53,6 +54,7 @@ const routes = app
   .route("/organizations", organizationsRoute)
   .route("/recurring-meetings", recurringMeetingsRoute)
   .route("/tasks", tasksRoute)
+  .route("/topic-requests", topicRequestsRoute)
   .route("/internal", internalRoute);
 
 export { app };

--- a/apps/api/src/lib/schemas/topic-request.ts
+++ b/apps/api/src/lib/schemas/topic-request.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+// TopicRequest の優先度。Prisma enum TopicRequestPriority と合わせる。
+const topicRequestPrioritySchema = z.enum(["required", "optional"]);
+
+// 作成リクエスト。title は必須、body / priority は任意。
+// 認可は呼び出し元（meeting に対する membership 確認）で行うため、ここでは meetingId・requestedBy を含めない。
+export const topicRequestCreateSchema = z.object({
+  title: z.string().min(1, "title は必須です"),
+  body: z.string().optional(),
+  priority: topicRequestPrioritySchema.optional(),
+});
+
+// 更新リクエスト。全フィールド任意だが、最低 1 つは指定する。
+// priority は null で「未指定に戻す」を許容する。body も null で「空に戻す」を許容。
+export const topicRequestUpdateSchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    body: z.string().nullable().optional(),
+    priority: topicRequestPrioritySchema.nullable().optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.title !== undefined || d.body !== undefined || d.priority !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type TopicRequestCreateInput = z.infer<typeof topicRequestCreateSchema>;
+export type TopicRequestUpdateInput = z.infer<typeof topicRequestUpdateSchema>;

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -7,6 +7,7 @@ import {
   buildTaskListWhere,
   taskListQuerySchema,
 } from "../lib/schemas/task.js";
+import { topicRequestCreateSchema } from "../lib/schemas/topic-request.js";
 import {
   serializeTask,
   taskListInclude,
@@ -109,6 +110,43 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         include: taskListInclude,
       });
       return c.json(tasks.map(serializeTask));
+    },
+  )
+  .get("/:id/topic-requests", auth, async (c) => {
+    const id = c.req.param("id");
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
+
+    // 当該会議を「次回会議」として紐付く議題のみ。古い順で並べる
+    // （会議当日にユーザーが追加した順で確認しやすい）。
+    const topicRequests = await prisma.topicRequest.findMany({
+      where: { meetingId: id },
+      orderBy: { createdAt: "asc" },
+    });
+    return c.json(topicRequests);
+  })
+  .post(
+    "/:id/topic-requests",
+    auth,
+    zValidator("json", topicRequestCreateSchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const input = c.req.valid("json");
+
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
+
+      // 認証済みユーザーを requestedBy とする。クライアントからの指定は受け付けない。
+      const created = await prisma.topicRequest.create({
+        data: {
+          meetingId: id,
+          requestedBy: c.var.user.id,
+          title: input.title,
+          body: input.body,
+          priority: input.priority,
+        },
+      });
+      return c.json(created, 201);
     },
   )
   .patch("/:id", auth, zValidator("json", meetingUpdateSchema), async (c) => {

--- a/apps/api/src/routes/topic-requests.ts
+++ b/apps/api/src/routes/topic-requests.ts
@@ -1,0 +1,71 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { topicRequestUpdateSchema } from "../lib/schemas/topic-request.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
+
+// 単体 TopicRequest を取得し、組織メンバーシップを確認するヘルパー。
+// 認可 NG / 不存在いずれも 404 で揃え、リソース存在の露出を避ける。
+async function requireTopicRequestAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  topicRequestId: string,
+) {
+  const topicRequest = await prisma.topicRequest.findUnique({
+    where: { id: topicRequestId },
+    include: {
+      meeting: {
+        include: { recurringMeeting: { select: { organizationId: true } } },
+      },
+    },
+  });
+  if (!topicRequest?.meeting.recurringMeeting) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "議題が見つかりません" }, 404),
+    };
+  }
+  const guard = await requireOrgMembership(
+    c,
+    topicRequest.meeting.recurringMeeting.organizationId,
+  );
+  if (!guard.ok) {
+    // 組織不一致でも露出を避けるため、メッセージを「議題が見つかりません」に差し替える。
+    return {
+      ok: false as const,
+      res: c.json({ error: "議題が見つかりません" }, 404),
+    };
+  }
+  return { ok: true as const, topicRequest };
+}
+
+export const topicRequestsRoute = new Hono<{ Variables: AuthVariables }>()
+  .use("*", auth)
+  .patch("/:id", zValidator("json", topicRequestUpdateSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const access = await requireTopicRequestAccess(c, id);
+    if (!access.ok) return access.res;
+
+    // undefined はスキップ、null は明示的なクリアとして扱う。
+    const updateData: Record<string, unknown> = {};
+    if (input.title !== undefined) updateData.title = input.title;
+    if (input.body !== undefined) updateData.body = input.body;
+    if (input.priority !== undefined) updateData.priority = input.priority;
+
+    const updated = await prisma.topicRequest.update({
+      where: { id },
+      data: updateData,
+    });
+    return c.json(updated);
+  })
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const access = await requireTopicRequestAccess(c, id);
+    if (!access.ok) return access.res;
+
+    await prisma.topicRequest.delete({ where: { id } });
+    return c.body(null, 204);
+  });

--- a/apps/api/test/topic-requests.test.ts
+++ b/apps/api/test/topic-requests.test.ts
@@ -1,0 +1,427 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// DB をモックしてルートロジックのみを検証する
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    meeting: {
+      findUnique: vi.fn(),
+    },
+    organizationMembership: {
+      findUnique: vi.fn(),
+    },
+    topicRequest: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+// auth ミドルウェアを差し替え、認証済みユーザーを c.var.user に注入する。
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import type { Prisma } from "@prisma/client";
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+// 認可検証で使う meeting 型。recurringMeeting.organizationId のみ含む。
+type MeetingWithRecurringOrgId = Prisma.MeetingGetPayload<{
+  include: { recurringMeeting: { select: { organizationId: true } } };
+}>;
+
+// PATCH/DELETE 用に TopicRequest を meeting → recurringMeeting.organizationId 込みで取得する。
+type TopicRequestWithMeeting = Prisma.TopicRequestGetPayload<{
+  include: {
+    meeting: {
+      include: { recurringMeeting: { select: { organizationId: true } } };
+    };
+  };
+}>;
+
+const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockTopicRequestFindUnique = vi.mocked(prisma.topicRequest.findUnique);
+const mockTopicRequestFindMany = vi.mocked(prisma.topicRequest.findMany);
+const mockTopicRequestCreate = vi.mocked(prisma.topicRequest.create);
+const mockTopicRequestUpdate = vi.mocked(prisma.topicRequest.update);
+const mockTopicRequestDelete = vi.mocked(prisma.topicRequest.delete);
+
+const meetingWithRecurring = {
+  id: "mtg-1",
+  title: "第3回",
+  heldAt: new Date("2026-05-17T10:00:00Z"),
+  recurringMeetingId: "rmtg-1",
+  recurringMeeting: { organizationId: "org-1" },
+} satisfies Partial<MeetingWithRecurringOrgId>;
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+function sampleTopicRequest(overrides: Partial<TopicRequestWithMeeting> = {}) {
+  return {
+    id: "tr-1",
+    meetingId: "mtg-1",
+    requestedBy: "user-1",
+    title: "次回の議題",
+    body: null,
+    priority: null,
+    createdAt: new Date("2026-05-17T10:00:00Z"),
+    updatedAt: new Date("2026-05-17T10:00:00Z"),
+    meeting: {
+      id: "mtg-1",
+      recurringMeeting: { organizationId: "org-1" },
+    },
+    ...overrides,
+  } as unknown as TopicRequestWithMeeting;
+}
+
+describe("POST /meetings/:id/topic-requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 201 で作成された議題を返す", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestCreate.mockResolvedValue({
+      id: "tr-1",
+      meetingId: "mtg-1",
+      requestedBy: "user-1",
+      title: "次回の議題",
+      body: "詳細",
+      priority: "required",
+      createdAt: new Date("2026-05-17T10:00:00Z"),
+      updatedAt: new Date("2026-05-17T10:00:00Z"),
+    });
+
+    const res = await app.request("/meetings/mtg-1/topic-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "次回の議題",
+        body: "詳細",
+        priority: "required",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      id: "tr-1",
+      title: "次回の議題",
+      body: "詳細",
+      priority: "required",
+      meetingId: "mtg-1",
+      requestedBy: "user-1",
+    });
+
+    // requestedBy は認証済みユーザーから埋まり、クライアント指定は無視される
+    expect(mockTopicRequestCreate).toHaveBeenCalledWith({
+      data: {
+        meetingId: "mtg-1",
+        requestedBy: "user-1",
+        title: "次回の議題",
+        body: "詳細",
+        priority: "required",
+      },
+    });
+  });
+
+  it("title 省略時は 400", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/meetings/mtg-1/topic-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "詳細" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockTopicRequestCreate).not.toHaveBeenCalled();
+  });
+
+  it("title 空文字は 400", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/meetings/mtg-1/topic-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("組織非所属の場合 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/meetings/mtg-1/topic-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "次回の議題" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockTopicRequestCreate).not.toHaveBeenCalled();
+  });
+
+  it("会議が存在しない場合 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/meetings/missing/topic-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "次回の議題" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /meetings/:id/topic-requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 当該会議の議題一覧を createdAt 昇順で返す", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestFindMany.mockResolvedValue([
+      {
+        id: "tr-1",
+        meetingId: "mtg-1",
+        requestedBy: "user-1",
+        title: "古い議題",
+        body: null,
+        priority: null,
+        createdAt: new Date("2026-05-17T10:00:00Z"),
+        updatedAt: new Date("2026-05-17T10:00:00Z"),
+      },
+      {
+        id: "tr-2",
+        meetingId: "mtg-1",
+        requestedBy: "user-1",
+        title: "新しい議題",
+        body: null,
+        priority: "optional",
+        createdAt: new Date("2026-05-17T11:00:00Z"),
+        updatedAt: new Date("2026-05-17T11:00:00Z"),
+      },
+    ]);
+
+    const res = await app.request("/meetings/mtg-1/topic-requests");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Array<{ id: string }>;
+    expect(json.map((x) => x.id)).toEqual(["tr-1", "tr-2"]);
+    expect(mockTopicRequestFindMany).toHaveBeenCalledWith({
+      where: { meetingId: "mtg-1" },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("組織非所属の場合 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(
+      meetingWithRecurring as unknown as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/meetings/mtg-1/topic-requests");
+    expect(res.status).toBe(404);
+    expect(mockTopicRequestFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /topic-requests/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 指定フィールドのみ更新する", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(sampleTopicRequest());
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestUpdate.mockResolvedValue({
+      id: "tr-1",
+      meetingId: "mtg-1",
+      requestedBy: "user-1",
+      title: "更新後タイトル",
+      body: null,
+      priority: null,
+      createdAt: new Date("2026-05-17T10:00:00Z"),
+      updatedAt: new Date("2026-05-17T11:00:00Z"),
+    });
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "更新後タイトル" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockTopicRequestUpdate).toHaveBeenCalledWith({
+      where: { id: "tr-1" },
+      data: { title: "更新後タイトル" },
+    });
+  });
+
+  it("priority を null で送ると未指定にクリアできる", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(
+      sampleTopicRequest({ priority: "required" }),
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestUpdate.mockResolvedValue({
+      id: "tr-1",
+      meetingId: "mtg-1",
+      requestedBy: "user-1",
+      title: "次回の議題",
+      body: null,
+      priority: null,
+      createdAt: new Date("2026-05-17T10:00:00Z"),
+      updatedAt: new Date("2026-05-17T11:00:00Z"),
+    });
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: null }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockTopicRequestUpdate).toHaveBeenCalledWith({
+      where: { id: "tr-1" },
+      data: { priority: null },
+    });
+  });
+
+  it("空オブジェクトの PATCH は 400", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(sampleTopicRequest());
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(mockTopicRequestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("不存在 → 404", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/topic-requests/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属 → 404", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(sampleTopicRequest());
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockTopicRequestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("作成者以外のメンバーも更新可能（MVP: 組織メンバー全員可）", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(
+      sampleTopicRequest({ requestedBy: "other-user" }),
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestUpdate.mockResolvedValue({
+      id: "tr-1",
+      meetingId: "mtg-1",
+      requestedBy: "other-user",
+      title: "他人の議題を編集",
+      body: null,
+      priority: null,
+      createdAt: new Date("2026-05-17T10:00:00Z"),
+      updatedAt: new Date("2026-05-17T11:00:00Z"),
+    });
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "他人の議題を編集" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /topic-requests/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 204 を返す", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(sampleTopicRequest());
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTopicRequestDelete.mockResolvedValue(
+      sampleTopicRequest() as unknown as Prisma.TopicRequestGetPayload<true>,
+    );
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(mockTopicRequestDelete).toHaveBeenCalledWith({
+      where: { id: "tr-1" },
+    });
+  });
+
+  it("不存在 → 404", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/topic-requests/missing", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockTopicRequestDelete).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属 → 404", async () => {
+    mockTopicRequestFindUnique.mockResolvedValue(sampleTopicRequest());
+    mockMembershipFindUnique.mockResolvedValue(null);
+
+    const res = await app.request("/topic-requests/tr-1", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockTopicRequestDelete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #285

## 概要・目的
* 次回会議に向けた議題（TopicRequest）の保存・編集・削除を担う Backend を追加する。
* AI 仕様書のフェーズ2解析で `user_topic_requests` としてプロンプトへ注入する経路の前提を整える。

## 背景
* ユーザーが次回会議に向けた議題を事前に登録する機能が無く、AI が出力する `recommendedAgenda` とは別経路でユーザー入力議題を保持する手段が存在しなかった。
* 後続の Frontend Issue (#286) と AI 連携 Issue (#287) の依存先として、まず DB モデルと CRUD API を確立する。

## 変更内容
* Prisma スキーマに `TopicRequest` モデルと `TopicRequestPriority` enum を追加（次回 Meeting に紐付け、削除時 Cascade）。
* 認可は組織メンバーシップ確認のみで、編集・削除は組織メンバー全員可（MVP 割り切り）。
* `requestedBy` はクライアント指定を受け付けず、認証済みユーザーから自動付与。
* エンドポイント追加
  * `POST   /meetings/:id/topic-requests`
  * `GET    /meetings/:id/topic-requests`（createdAt 昇順）
  * `PATCH  /topic-requests/:id`（priority の null クリア対応）
  * `DELETE /topic-requests/:id`
* vitest で 16 件のユニットテストを追加（apps/api 全 294 通過）。

## 動作確認手順
1. `make migrate NAME=add_topic_request` で migration を適用済みであることを確認する。
2. `docker compose exec api sh -c "cd /app/apps/api && pnpm exec prisma generate" && docker compose restart api` で Prisma Client を再生成する。
3. `make test` または `cd apps/api && pnpm exec vitest run` で全テストを実行し、294 件パスすることを確認する。
4. `POST /meetings/:id/topic-requests` に `{ "title": "次回の議題", "priority": "required" }` を送り、201 と作成データが返ることを確認する。
5. `GET /meetings/:id/topic-requests` で一覧取得し、createdAt 昇順で並ぶことを確認する。
6. `PATCH /topic-requests/:id` に `{ "priority": null }` を送り、priority がクリアされることを確認する。
7. `DELETE /topic-requests/:id` で 204 が返ることを確認する。
8. 別組織のメンバーで上記を叩き、すべて 404 が返ることを確認する。

## スクリーンショット
API 変更のためレスポンス例で代替する。

POST レスポンス例:

```json
{
  "id": "clxxxxxxxxxx",
  "meetingId": "mtg-1",
  "requestedBy": "user-1",
  "title": "次回の議題",
  "body": null,
  "priority": "required",
  "createdAt": "2026-05-21T16:00:00.000Z",
  "updatedAt": "2026-05-21T16:00:00.000Z"
}
```

GET レスポンス例:

```json
[
  { "id": "tr-1", "title": "前の議題", "priority": null },
  { "id": "tr-2", "title": "次の議題", "priority": "optional" }
]
```
