### PR TITLE
feat(web): 次回会議の議題入力 UI を会議詳細ページに追加

### DIFF
--- a/apps/web/src/features/topic-requests/components/CreateTopicRequestDialog.tsx
+++ b/apps/web/src/features/topic-requests/components/CreateTopicRequestDialog.tsx
@@ -1,0 +1,149 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateTopicRequest } from "@/features/topic-requests/hooks/useCreateTopicRequest";
+import { topicRequestPriorityLabels } from "@/features/topic-requests/labels";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type ReactNode, useId, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+// priority は select 用に "" を「未指定」として扱うフォーム表現。送信時に undefined に変換する。
+const formSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string(),
+  priority: z.enum(["", "required", "optional"]),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function CreateTopicRequestDialog({
+  meetingId,
+  trigger,
+}: {
+  meetingId: string;
+  trigger?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+  const bodyId = useId();
+  const priorityId = useId();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { title: "", body: "", priority: "" },
+  });
+
+  const mutation = useCreateTopicRequest(meetingId);
+
+  const onSubmit = (data: FormValues) => {
+    mutation.mutate(
+      {
+        title: data.title,
+        body: data.body || undefined,
+        priority: data.priority || undefined,
+      },
+      {
+        onSuccess: () => {
+          reset();
+          setOpen(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? <Button>議題を追加</Button>}
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle>次回会議の議題を追加</DialogTitle>
+            <DialogDescription>
+              この会議で取り上げる議題を事前に登録します。AI
+              が生成する推奨アジェンダとは別枠で扱われます。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 py-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={titleId}>タイトル</Label>
+              <Input
+                id={titleId}
+                placeholder="例: 次回までに決めたい仕様"
+                {...register("title")}
+              />
+              {errors.title && (
+                <p className="text-sm text-destructive">
+                  {errors.title.message}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={bodyId}>詳細（任意）</Label>
+              <Textarea
+                id={bodyId}
+                placeholder="議題の背景や前提条件など"
+                rows={4}
+                {...register("body")}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={priorityId}>優先度（任意）</Label>
+              <select
+                id={priorityId}
+                className="border rounded-md px-3 py-2 text-sm bg-background"
+                {...register("priority")}
+              >
+                <option value="">未指定</option>
+                <option value="required">
+                  {topicRequestPriorityLabels.required}
+                </option>
+                <option value="optional">
+                  {topicRequestPriorityLabels.optional}
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "追加中..." : "追加"}
+            </Button>
+          </DialogFooter>
+          {mutation.isError && (
+            <p className="text-sm text-destructive mt-2">
+              追加に失敗しました。時間をおいて再度お試しください。
+            </p>
+          )}
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/topic-requests/components/DeleteTopicRequestDialog.tsx
+++ b/apps/web/src/features/topic-requests/components/DeleteTopicRequestDialog.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDeleteTopicRequest } from "@/features/topic-requests/hooks/useDeleteTopicRequest";
+import type { TopicRequest } from "@/features/topic-requests/types";
+
+export function DeleteTopicRequestDialog({
+  meetingId,
+  topicRequest,
+  open,
+  onOpenChange,
+}: {
+  meetingId: string;
+  topicRequest: TopicRequest;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const mutation = useDeleteTopicRequest(meetingId);
+
+  const onDelete = () => {
+    mutation.mutate(topicRequest.id, {
+      onSuccess: () => onOpenChange(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>議題を削除しますか？</DialogTitle>
+          <DialogDescription>
+            「{topicRequest.title}」を削除します。この操作は元に戻せません。
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onDelete}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? "削除中..." : "削除"}
+          </Button>
+        </DialogFooter>
+        {mutation.isError && (
+          <p className="text-sm text-destructive mt-2">
+            削除に失敗しました。時間をおいて再度お試しください。
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/topic-requests/components/EditTopicRequestDialog.tsx
+++ b/apps/web/src/features/topic-requests/components/EditTopicRequestDialog.tsx
@@ -1,0 +1,156 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useUpdateTopicRequest } from "@/features/topic-requests/hooks/useUpdateTopicRequest";
+import { topicRequestPriorityLabels } from "@/features/topic-requests/labels";
+import type { TopicRequest } from "@/features/topic-requests/types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useId } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string(),
+  priority: z.enum(["", "required", "optional"]),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+// 既存議題 → フォーム表現への変換。null は空文字 / "" に丸める。
+function toFormValues(topicRequest: TopicRequest): FormValues {
+  return {
+    title: topicRequest.title,
+    body: topicRequest.body ?? "",
+    priority: topicRequest.priority ?? "",
+  };
+}
+
+export function EditTopicRequestDialog({
+  meetingId,
+  topicRequest,
+  open,
+  onOpenChange,
+}: {
+  meetingId: string;
+  topicRequest: TopicRequest;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const titleId = useId();
+  const bodyId = useId();
+  const priorityId = useId();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: toFormValues(topicRequest),
+  });
+
+  // 別の議題を編集対象に切り替えたら、フォームを最新値で reset する。
+  useEffect(() => {
+    reset(toFormValues(topicRequest));
+  }, [topicRequest, reset]);
+
+  const mutation = useUpdateTopicRequest(meetingId);
+
+  const onSubmit = (data: FormValues) => {
+    // body は空文字 → null で「クリア」を表現する。
+    // priority は "" → null で同様に未指定へ戻す。
+    mutation.mutate(
+      {
+        id: topicRequest.id,
+        patch: {
+          title: data.title,
+          body: data.body === "" ? null : data.body,
+          priority: data.priority === "" ? null : data.priority,
+        },
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle>議題を編集</DialogTitle>
+            <DialogDescription>
+              タイトル・詳細・優先度を変更できます。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 py-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={titleId}>タイトル</Label>
+              <Input id={titleId} {...register("title")} />
+              {errors.title && (
+                <p className="text-sm text-destructive">
+                  {errors.title.message}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={bodyId}>詳細（任意）</Label>
+              <Textarea id={bodyId} rows={4} {...register("body")} />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={priorityId}>優先度（任意）</Label>
+              <select
+                id={priorityId}
+                className="border rounded-md px-3 py-2 text-sm bg-background"
+                {...register("priority")}
+              >
+                <option value="">未指定</option>
+                <option value="required">
+                  {topicRequestPriorityLabels.required}
+                </option>
+                <option value="optional">
+                  {topicRequestPriorityLabels.optional}
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中..." : "保存"}
+            </Button>
+          </DialogFooter>
+          {mutation.isError && (
+            <p className="text-sm text-destructive mt-2">
+              更新に失敗しました。時間をおいて再度お試しください。
+            </p>
+          )}
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/topic-requests/components/TopicRequestItem.tsx
+++ b/apps/web/src/features/topic-requests/components/TopicRequestItem.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/button";
+import { topicRequestPriorityLabels } from "@/features/topic-requests/labels";
+import type { TopicRequest } from "@/features/topic-requests/types";
+import { useState } from "react";
+import { DeleteTopicRequestDialog } from "./DeleteTopicRequestDialog";
+import { EditTopicRequestDialog } from "./EditTopicRequestDialog";
+
+export function TopicRequestItem({
+  meetingId,
+  topicRequest,
+}: {
+  meetingId: string;
+  topicRequest: TopicRequest;
+}) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <div className="rounded-md border p-3 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium">{topicRequest.title}</span>
+            {topicRequest.priority && (
+              <span
+                className={`text-xs rounded-full px-2 py-0.5 border ${
+                  topicRequest.priority === "required"
+                    ? "border-destructive text-destructive"
+                    : "border-muted-foreground text-muted-foreground"
+                }`}
+              >
+                {topicRequestPriorityLabels[topicRequest.priority]}
+              </span>
+            )}
+          </div>
+          {topicRequest.body && (
+            <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap break-words">
+              {topicRequest.body}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+            編集
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setDeleteOpen(true)}>
+            削除
+          </Button>
+        </div>
+      </div>
+
+      <EditTopicRequestDialog
+        meetingId={meetingId}
+        topicRequest={topicRequest}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+      <DeleteTopicRequestDialog
+        meetingId={meetingId}
+        topicRequest={topicRequest}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/topic-requests/components/TopicRequestSection.tsx
+++ b/apps/web/src/features/topic-requests/components/TopicRequestSection.tsx
@@ -1,0 +1,56 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useMeetingTopicRequests } from "@/features/topic-requests/hooks/useMeetingTopicRequests";
+import { CreateTopicRequestDialog } from "./CreateTopicRequestDialog";
+import { TopicRequestItem } from "./TopicRequestItem";
+
+export function TopicRequestSection({ meetingId }: { meetingId: string }) {
+  const query = useMeetingTopicRequests(meetingId);
+
+  const topicRequests = query.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3 w-full">
+          <div className="flex flex-col gap-1">
+            <CardTitle>次回会議の議題</CardTitle>
+            <CardDescription>
+              この会議で取り上げる議題を事前に登録できます。AI
+              が生成する推奨アジェンダとは別枠で管理されます。
+            </CardDescription>
+          </div>
+          <CreateTopicRequestDialog meetingId={meetingId} />
+        </div>
+      </CardHeader>
+      <CardContent>
+        {query.isLoading ? (
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
+        ) : query.isError ? (
+          <p className="text-sm text-destructive">
+            議題の読み込みに失敗しました。
+          </p>
+        ) : topicRequests.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            まだ議題が登録されていません。「議題を追加」から登録してください。
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topicRequests.map((topicRequest) => (
+              <TopicRequestItem
+                key={topicRequest.id}
+                meetingId={meetingId}
+                topicRequest={topicRequest}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/topic-requests/hooks/useCreateTopicRequest.ts
+++ b/apps/web/src/features/topic-requests/hooks/useCreateTopicRequest.ts
@@ -1,0 +1,35 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { topicRequestQueryKeys } from "../queryKeys";
+import type { TopicRequestPriority, TopicRequest } from "../types";
+
+// API に送る形。priority 未指定は undefined で送り、サーバー側で null として保存される。
+export type CreateTopicRequestPayload = {
+  title: string;
+  body?: string;
+  priority?: TopicRequestPriority;
+};
+
+// 次回議題を作成する mutation。
+// 成功時は当該 meeting の一覧キャッシュを invalidate する。
+export function useCreateTopicRequest(meetingId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<TopicRequest, Error, CreateTopicRequestPayload>({
+    mutationFn: async (input) => {
+      const res = await api.meetings[":id"]["topic-requests"].$post(
+        { param: { id: meetingId }, json: input },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to create topic request: ${res.status}`);
+      }
+      return (await res.json()) as TopicRequest;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: topicRequestQueryKeys.meeting(meetingId),
+      });
+    },
+  });
+}

--- a/apps/web/src/features/topic-requests/hooks/useDeleteTopicRequest.ts
+++ b/apps/web/src/features/topic-requests/hooks/useDeleteTopicRequest.ts
@@ -1,0 +1,25 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { topicRequestQueryKeys } from "../queryKeys";
+
+// 次回議題を削除する mutation。成功時は当該 meeting の一覧キャッシュを invalidate する。
+export function useDeleteTopicRequest(meetingId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (id) => {
+      const res = await api["topic-requests"][":id"].$delete(
+        { param: { id } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to delete topic request: ${res.status}`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: topicRequestQueryKeys.meeting(meetingId),
+      });
+    },
+  });
+}

--- a/apps/web/src/features/topic-requests/hooks/useMeetingTopicRequests.ts
+++ b/apps/web/src/features/topic-requests/hooks/useMeetingTopicRequests.ts
@@ -1,0 +1,22 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { topicRequestQueryKeys } from "../queryKeys";
+import type { TopicRequest } from "../types";
+
+// 指定 meeting に紐づく次回議題の一覧を取得する。createdAt 昇順で返る。
+export function useMeetingTopicRequests(meetingId: string) {
+  return useQuery<TopicRequest[]>({
+    queryKey: topicRequestQueryKeys.meeting(meetingId),
+    queryFn: async () => {
+      const res = await api.meetings[":id"]["topic-requests"].$get(
+        { param: { id: meetingId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch topic requests: ${res.status}`);
+      }
+      return (await res.json()) as TopicRequest[];
+    },
+    enabled: meetingId !== "",
+  });
+}

--- a/apps/web/src/features/topic-requests/hooks/useUpdateTopicRequest.ts
+++ b/apps/web/src/features/topic-requests/hooks/useUpdateTopicRequest.ts
@@ -1,0 +1,39 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { topicRequestQueryKeys } from "../queryKeys";
+import type { TopicRequest, TopicRequestPriority } from "../types";
+
+// PATCH 用 payload。body / priority は null 送出で「未指定にクリア」を表現する。
+export type UpdateTopicRequestPayload = {
+  title?: string;
+  body?: string | null;
+  priority?: TopicRequestPriority | null;
+};
+
+export type UpdateTopicRequestVariables = {
+  id: string;
+  patch: UpdateTopicRequestPayload;
+};
+
+// 次回議題を更新する mutation。一覧キャッシュを invalidate する。
+export function useUpdateTopicRequest(meetingId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<TopicRequest, Error, UpdateTopicRequestVariables>({
+    mutationFn: async ({ id, patch }) => {
+      const res = await api["topic-requests"][":id"].$patch(
+        { param: { id }, json: patch },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to update topic request: ${res.status}`);
+      }
+      return (await res.json()) as TopicRequest;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: topicRequestQueryKeys.meeting(meetingId),
+      });
+    },
+  });
+}

--- a/apps/web/src/features/topic-requests/labels.ts
+++ b/apps/web/src/features/topic-requests/labels.ts
@@ -1,0 +1,8 @@
+import type { TopicRequestPriority } from "./types";
+
+// priority 表示用ラベル。AI 仕様の Task.priority と意味を揃えている。
+export const topicRequestPriorityLabels: Record<TopicRequestPriority, string> =
+  {
+    required: "必須",
+    optional: "任意",
+  };

--- a/apps/web/src/features/topic-requests/queryKeys.ts
+++ b/apps/web/src/features/topic-requests/queryKeys.ts
@@ -1,0 +1,7 @@
+// TanStack Query の queryKey factory。
+// meeting に紐づく一覧キャッシュを invalidate しやすいよう、meeting ID をキーに含める。
+export const topicRequestQueryKeys = {
+  all: ["topic-requests"] as const,
+  meeting: (meetingId: string) =>
+    [...topicRequestQueryKeys.all, "meeting", meetingId] as const,
+};

--- a/apps/web/src/features/topic-requests/schemas.ts
+++ b/apps/web/src/features/topic-requests/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+// API 側 (apps/api/src/lib/schemas/topic-request.ts) のバリデーションと整合する。
+// クライアントでも先にチェックして無駄な往復を避ける。
+const priorityFormSchema = z.enum(["required", "optional"]);
+
+// 作成フォーム。priority は未指定（null）も許容するため、フォーム側では
+// "unset" センチネルを採用し、送信時に undefined へ変換する。
+export const createTopicRequestFormSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  body: z.string().optional(),
+  priority: z.union([priorityFormSchema, z.literal("unset")]).optional(),
+});
+
+export type CreateTopicRequestFormInput = z.infer<
+  typeof createTopicRequestFormSchema
+>;
+
+// 編集フォーム。最低 1 項目の指定を refine で要求する。
+// priority は null で「未指定にクリア」を許容する。
+export const updateTopicRequestFormSchema = z
+  .object({
+    title: z.string().min(1, "タイトルは必須です").optional(),
+    body: z.string().nullable().optional(),
+    priority: priorityFormSchema.nullable().optional(),
+  })
+  .refine(
+    (d) =>
+      d.title !== undefined || d.body !== undefined || d.priority !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type UpdateTopicRequestFormInput = z.infer<
+  typeof updateTopicRequestFormSchema
+>;

--- a/apps/web/src/features/topic-requests/types.ts
+++ b/apps/web/src/features/topic-requests/types.ts
@@ -1,0 +1,15 @@
+// TopicRequest 機能のフロント側型定義。
+// API レスポンス (apps/api 側 prisma model) と整合する。
+
+export type TopicRequestPriority = "required" | "optional";
+
+export type TopicRequest = {
+  id: string;
+  meetingId: string;
+  requestedBy: string;
+  title: string;
+  body: string | null;
+  priority: TopicRequestPriority | null;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,4 +1,5 @@
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { TopicRequestSection } from "@/features/topic-requests/components/TopicRequestSection";
 import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
@@ -273,6 +274,10 @@ export function MeetingDetailView({
             now={now}
           />
         )}
+      </section>
+
+      <section aria-label="次回会議の議題">
+        <TopicRequestSection meetingId={id} />
       </section>
     </section>
   );

--- a/apps/web/src/test/topic-requests.test.tsx
+++ b/apps/web/src/test/topic-requests.test.tsx
@@ -1,0 +1,159 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockJson } from "./helpers/mockJson";
+import { renderWithQuery } from "./test-utils";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    meetings: {
+      ":id": {
+        "topic-requests": {
+          $get: vi.fn(),
+          $post: vi.fn(),
+        },
+      },
+    },
+    "topic-requests": {
+      ":id": {
+        $patch: vi.fn(),
+        $delete: vi.fn(),
+      },
+    },
+  },
+  authHeaders: () => ({ headers: {} }),
+}));
+
+import { api } from "@/lib/api";
+import { TopicRequestSection } from "@/features/topic-requests/components/TopicRequestSection";
+import type { TopicRequest } from "@/features/topic-requests/types";
+
+const sample: TopicRequest = {
+  id: "tr-1",
+  meetingId: "mtg-1",
+  requestedBy: "user-1",
+  title: "次回までに決めたい仕様",
+  body: "API レスポンスの形を決めたい",
+  priority: "required",
+  createdAt: "2026-05-17T10:00:00.000Z",
+  updatedAt: "2026-05-17T10:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.mocked(api.meetings[":id"]["topic-requests"].$get).mockResolvedValue(
+    mockJson([]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("TopicRequestSection", () => {
+  it("0 件のときは空メッセージを表示する", async () => {
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    expect(
+      await screen.findByText(/まだ議題が登録されていません/),
+    ).toBeInTheDocument();
+  });
+
+  it("一覧をタイトル・本文・優先度バッジ付きで表示する", async () => {
+    vi.mocked(api.meetings[":id"]["topic-requests"].$get).mockResolvedValue(
+      mockJson([sample]),
+    );
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    expect(
+      await screen.findByText("次回までに決めたい仕様"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("API レスポンスの形を決めたい"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("必須")).toBeInTheDocument();
+  });
+
+  it("「議題を追加」ボタンでダイアログが開く", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    await user.click(await screen.findByRole("button", { name: "議題を追加" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "次回会議の議題を追加",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("ダイアログのフォームから議題を作成できる", async () => {
+    vi.mocked(api.meetings[":id"]["topic-requests"].$post).mockResolvedValue(
+      mockJson({
+        ...sample,
+        id: "tr-new",
+        title: "新規議題",
+        body: null,
+        priority: null,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    await user.click(await screen.findByRole("button", { name: "議題を追加" }));
+    await user.type(await screen.findByLabelText("タイトル"), "新規議題");
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    // 1 回目の呼び出し検証。json には title だけが入り、空 body / 未指定 priority は送らない。
+    const calls = vi.mocked(api.meetings[":id"]["topic-requests"].$post).mock
+      .calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const [arg] = calls[0];
+    expect((arg as { json: { title: string } }).json.title).toBe("新規議題");
+    expect((arg as { json: { body?: string } }).json.body).toBeUndefined();
+    expect(
+      (arg as { json: { priority?: string } }).json.priority,
+    ).toBeUndefined();
+  });
+
+  it("タイトル未入力で送信するとバリデーションエラーが出る", async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    await user.click(await screen.findByRole("button", { name: "議題を追加" }));
+    await user.click(screen.getByRole("button", { name: "追加" }));
+    expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
+    expect(
+      vi.mocked(api.meetings[":id"]["topic-requests"].$post),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("編集ボタンで EditDialog が開き既存値が初期表示される", async () => {
+    vi.mocked(api.meetings[":id"]["topic-requests"].$get).mockResolvedValue(
+      mockJson([sample]),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    await screen.findByText("次回までに決めたい仕様");
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    const dialog = await screen.findByRole("dialog", { name: /議題を編集/ });
+    const titleInput = within(dialog).getByLabelText(
+      "タイトル",
+    ) as HTMLInputElement;
+    expect(titleInput.value).toBe("次回までに決めたい仕様");
+  });
+
+  it("削除ボタン → 確認ダイアログで削除 API が呼ばれる", async () => {
+    vi.mocked(api.meetings[":id"]["topic-requests"].$get).mockResolvedValue(
+      mockJson([sample]),
+    );
+    vi.mocked(api["topic-requests"][":id"].$delete).mockResolvedValue(
+      mockJson(null, 204),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(<TopicRequestSection meetingId="mtg-1" />);
+    await screen.findByText("次回までに決めたい仕様");
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: /議題を削除しますか/,
+    });
+    await user.click(within(dialog).getByRole("button", { name: "削除" }));
+    expect(api["topic-requests"][":id"].$delete).toHaveBeenCalledWith(
+      { param: { id: "tr-1" } },
+      { headers: {} },
+    );
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #286

## 概要・目的
* 次回会議の議題（TopicRequest）を会議詳細ページから入力・編集・削除できる UI を追加する。
* AI が生成する `recommendedAgenda` とは別枠のカードとして表示し、ユーザー入力議題であることを UI 上で明確にする。

## 背景
* Backend (#285) で TopicRequest CRUD API が用意されたため、ユーザー操作経路として Frontend を整える必要がある。
* この PR は #285 にスタックされており、`feat/285-topic-request-backend` をベースに作成している。`#285` が main にマージされたタイミングで base を main へ切り替える。

## 変更内容
* `apps/web/src/features/topic-requests/` を新設し、以下を実装。
  * `hooks/`: TanStack Query の `useMeetingTopicRequests` / `useCreateTopicRequest` / `useUpdateTopicRequest` / `useDeleteTopicRequest`。
  * `components/`: `TopicRequestSection` / `CreateTopicRequestDialog` / `EditTopicRequestDialog` / `DeleteTopicRequestDialog` / `TopicRequestItem`。
  * `schemas.ts` / `types.ts` / `queryKeys.ts` / `labels.ts`。
* `routes/meetings.$id.tsx` のタスクセクション直下に `TopicRequestSection` を追加。
* 優先度 (`priority`) は `select` で「未指定 / 必須 / 任意」を表現し、編集時は `null` 送出で「未指定にクリア」を可能にする。
* React Hook Form + Zod でクライアント側バリデーション。タイトル必須・空 body は送らない。
* vitest で 7 件のテストを追加（apps/web 全 375 通過）。

## 動作確認手順
1. `feat/285-topic-request-backend` のマイグレーションが適用済みで、`/meetings/:id` のページが開ける状態にする。
2. 会議詳細ページを開き、「次回会議の議題」カードがタスクセクションの下に表示されることを確認する。
3. 「議題を追加」ボタンでダイアログが開き、タイトル・詳細・優先度を入力して「追加」で送信できることを確認する。
4. タイトル未入力で送信するとバリデーションエラー「タイトルは必須です」が表示されることを確認する。
5. リスト上の「編集」で既存値が初期表示されたダイアログが開き、優先度を「未指定」に変更して保存すると priority がクリアされることを確認する。
6. 「削除」で確認ダイアログが出てから DELETE が走り、一覧から消えることを確認する。
7. `cd apps/web && pnpm run lint && pnpm exec tsc -b --noEmit && pnpm exec vitest run` をすべてパスすることを確認する。

## スクリーンショット
ローカル起動できなかったため、UI 要素の構成を ASCII で示す（実描画は手元で確認推奨）。

```
┌─────────────────────────────────────────────┐
│ 次回会議の議題                  [議題を追加] │
│ AI 推奨アジェンダとは別枠で管理されます      │
├─────────────────────────────────────────────┤
│ ┌─────────────────────────────────────────┐ │
│ │ 次回までに決めたい仕様       [必須]      │ │
│ │ API レスポンスの形を決めたい             │ │
│ │                       [編集] [削除]      │ │
│ └─────────────────────────────────────────┘ │
└─────────────────────────────────────────────┘
```
