### PR TITLE
feat(api): 議事録生成時に TopicRequest を AI Service へ渡す経路を追加

### DIFF
--- a/apps/api/src/routes/analysis-runs.ts
+++ b/apps/api/src/routes/analysis-runs.ts
@@ -43,6 +43,14 @@ export const analysisRunsRoute = new Hono()
     // heldAt を "YYYY-MM-DD" 形式に変換する
     const meetingDate = meeting.heldAt.toISOString().split("T")[0];
 
+    // 当該会議に紐づくユーザー入力議題。古い順で渡す（フェーズ2のプロンプト注入で
+    // 順序保持が必要なため）。0 件のときは空配列で渡し、AI 側が必ずキーを取得できる状態を保つ。
+    const topicRequests = await prisma.topicRequest.findMany({
+      where: { meetingId: meeting.id },
+      orderBy: { createdAt: "asc" },
+      include: { requester: { select: { displayName: true } } },
+    });
+
     return c.json({
       analysis_run_id: id,
       meeting_id: meeting.id,
@@ -60,6 +68,12 @@ export const analysisRunsRoute = new Hono()
         resolution_status: s.resolutionStatus,
       })),
       previous_report_json: previousReportJson,
+      user_topic_requests: topicRequests.map((tr) => ({
+        title: tr.title,
+        body: tr.body,
+        priority: tr.priority,
+        requested_by_name: tr.requester.displayName,
+      })),
     });
   })
   // PATCH /:id/result — AI Service が解析結果を保存する

--- a/apps/api/test/analysis-runs.test.ts
+++ b/apps/api/test/analysis-runs.test.ts
@@ -8,6 +8,9 @@ vi.mock("../src/lib/prisma.js", () => ({
       findFirst: vi.fn(),
       update: vi.fn(),
     },
+    topicRequest: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -18,6 +21,7 @@ import { prisma } from "../src/lib/prisma.js";
 const mockRunFindUnique = vi.mocked(prisma.meetingAnalysisRun.findUnique);
 const mockRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
 const mockRunUpdate = vi.mocked(prisma.meetingAnalysisRun.update);
+const mockTopicRequestFindMany = vi.mocked(prisma.topicRequest.findMany);
 
 const SECRET = "test-secret";
 const AUTH_HEADER = { "x-internal-secret": SECRET };
@@ -87,6 +91,9 @@ describe("GET /internal/analysis-runs/:id/input", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.INTERNAL_API_SECRET = SECRET;
+    // topic-requests のデフォルトは空配列。AI Service 側が必ず key を取得できるよう、
+    // 0 件の Meeting でも user_topic_requests を含めて返す挙動を維持する。
+    mockTopicRequestFindMany.mockResolvedValue([]);
   });
 
   it("存在する解析ランの入力情報を 200 で返す", async () => {
@@ -104,6 +111,7 @@ describe("GET /internal/analysis-runs/:id/input", () => {
       transcription_quality: string;
       speakers: Array<{ speaker_key: string; name: string }>;
       previous_report_json: null;
+      user_topic_requests: unknown[];
     };
     expect(body.analysis_run_id).toBe("run-1");
     expect(body.meeting_id).toBe("mtg-1");
@@ -114,6 +122,72 @@ describe("GET /internal/analysis-runs/:id/input", () => {
     expect(body.speakers[0]?.speaker_key).toBe("spk-1");
     expect(body.speakers[0]?.name).toBe("田中");
     expect(body.previous_report_json).toBeNull();
+    // topic-requests 未登録時でも user_topic_requests は空配列で必ず含まれる
+    expect(body.user_topic_requests).toEqual([]);
+  });
+
+  it("ユーザー入力議題があれば user_topic_requests に createdAt 昇順で含まれる", async () => {
+    mockRunFindUnique.mockResolvedValue(baseRun as RunWithMeeting);
+    mockTopicRequestFindMany.mockResolvedValue([
+      {
+        id: "tr-1",
+        meetingId: "mtg-1",
+        requestedBy: "user-1",
+        title: "古い議題",
+        body: null,
+        priority: null,
+        createdAt: new Date("2026-05-17T09:00:00Z"),
+        updatedAt: new Date("2026-05-17T09:00:00Z"),
+        requester: { displayName: "alice" },
+        // satisfies で型を明示せず、include を含む payload としてキャストする
+      },
+      {
+        id: "tr-2",
+        meetingId: "mtg-1",
+        requestedBy: "user-2",
+        title: "新しい議題",
+        body: "詳細",
+        priority: "required",
+        createdAt: new Date("2026-05-17T10:00:00Z"),
+        updatedAt: new Date("2026-05-17T10:00:00Z"),
+        requester: { displayName: "bob" },
+      },
+    ] as unknown as Prisma.TopicRequestGetPayload<{
+      include: { requester: { select: { displayName: true } } };
+    }>[]);
+
+    const res = await app.request("/internal/analysis-runs/run-1/input", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      user_topic_requests: Array<{
+        title: string;
+        body: string | null;
+        priority: string | null;
+        requested_by_name: string;
+      }>;
+    };
+    expect(body.user_topic_requests).toEqual([
+      {
+        title: "古い議題",
+        body: null,
+        priority: null,
+        requested_by_name: "alice",
+      },
+      {
+        title: "新しい議題",
+        body: "詳細",
+        priority: "required",
+        requested_by_name: "bob",
+      },
+    ]);
+    expect(mockTopicRequestFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { meetingId: "mtg-1" },
+        orderBy: { createdAt: "asc" },
+      }),
+    );
   });
 
   it("前回会議の completed 解析ランがある場合 previous_report_json を含む", async () => {


### PR DESCRIPTION
## 関連Issue
Closes #287

## 概要・目的
* 議事録生成（次回会議の解析・フェーズ2）時に、ユーザー入力議題（TopicRequest）を AI Service へ渡す経路を整える。
* AI Service 側のコードには手を入れず、apps/api のレスポンスにフィールドを追加するだけにとどめる。AI 担当が `services/ai/schemas/analysis.py` の `AnalysisJobInput` に 1 行追加するだけで即読める状態を作る。

## 背景
* AI 仕様書のフェーズ2解析では、前回会議の `reportJson` と「ユーザー入力議題」を統合して次回ブリーフ（`recommended_agenda`）を生成する設計になっている。
* これまで `GET /internal/analysis-runs/:id/input` には `supplementary_memo` しか無く、構造化された議題リストを渡す枠が存在しなかった。
* この PR は #286 にスタックされており、`feat/286-topic-request-frontend` をベースに作成している。

## 変更内容
* `apps/api/src/routes/analysis-runs.ts` の GET `/:id/input` レスポンスに `user_topic_requests` を追加。
  * Meeting に紐づく TopicRequest を `createdAt` 昇順で取得し、`{ title, body, priority, requested_by_name }` の配列で返す。
  * 0 件のときも空配列で必ず key を返す（フェーズ1や議題未登録会議でも AI 側の処理を安定させる）。
  * `requested_by_name` は `User.displayName` を join して埋める。
* `apps/api/test/analysis-runs.test.ts` に 1 件テストを追加（apps/api 全 295 通過）。
* `services/ai/` 配下のコードは一切変更しない。Pydantic v2 の extra フィールド無視によって、AI 担当のスキーマ拡張が間に合わなくても既存処理は壊れない。

## 動作確認手順
1. `feat/286-topic-request-frontend` のマイグレーション・Frontend を適用済みの状態にする。
2. `cd apps/api && pnpm run lint && pnpm exec tsc --noEmit && pnpm exec vitest run` で 295 件パスを確認する。
3. 任意の会議に対して TopicRequest を 2 件追加し、その会議に対して `POST /meetings/:id/analyze` で解析ランを開始する。
4. AI Service コンテナのログで `analysis_run_id` を確認し、`curl -H "x-internal-secret: ..." http://localhost:3001/internal/analysis-runs/<id>/input` を叩いて `user_topic_requests` に 2 件が `createdAt` 昇順で並ぶことを確認する。
5. 議題が 0 件の会議でも `user_topic_requests: []` で空配列が返ることを確認する。

## スクリーンショット
API 変更のためレスポンス例で代替する。

`user_topic_requests` が含まれる GET レスポンス例:

```json
{
  "analysis_run_id": "run-xxx",
  "meeting_id": "mtg-1",
  "transcript": "...",
  "previous_report_json": null,
  "user_topic_requests": [
    {
      "title": "次回までに決めたい仕様",
      "body": "API レスポンスの形を決めたい",
      "priority": "required",
      "requested_by_name": "alice"
    },
    {
      "title": "予算の見直し",
      "body": null,
      "priority": null,
      "requested_by_name": "bob"
    }
  ]
}
```

議題未登録会議のレスポンス例（key 自体は維持）:

```json
{
  "analysis_run_id": "run-yyy",
  "user_topic_requests": []
}
```
