### PR TITLE
fix(ai): AIサービスから complete エンドポイントを呼び出し成果物のDB反映経路を接続する

### DIFF
--- a/services/ai/integrations/app_api_client.py
+++ b/services/ai/integrations/app_api_client.py
@@ -39,3 +39,24 @@ class AppApiClient:
                 timeout=30.0,
             )
             response.raise_for_status()
+
+    async def complete_analysis_run(
+        self,
+        analysis_run_id: str,
+        decision_items: list[dict],
+        tasks: list[dict],
+        ambiguous_infos: list[dict],
+    ) -> None:
+        """POST /internal/analysis-runs/:id/complete"""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/internal/analysis-runs/{analysis_run_id}/complete",
+                json={
+                    "decisionItems": decision_items,
+                    "tasks": tasks,
+                    "ambiguousInfos": ambiguous_infos,
+                },
+                headers=self._headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -53,8 +53,8 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
     # 取り出し失敗で Consumer が落ちないよう、パース段階で完結させる
     try:
         body = json.loads(_parse_message_body(message).decode("utf-8"))
-    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as e:
-        logger.error("メッセージのデコードに失敗 (破棄): %s", e)
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as error:
+        logger.error("メッセージのデコードに失敗 (破棄): %s", error)
         return
     if not isinstance(body, dict):
         logger.error("メッセージボディが dict ではありません: %s", type(body).__name__)
@@ -76,45 +76,45 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
         if result.status == "completed" and result.report_json:
             report = result.report_json
             decision_items = []
-            for d in report.get("decisions", []):
-                if not isinstance(d, dict):
+            for decision in report.get("decisions", []):
+                if not isinstance(decision, dict):
                     continue
-                if not isinstance(d.get("topic"), str) or not d["topic"]:
+                if not isinstance(decision.get("topic"), str) or not decision["topic"]:
                     continue
-                di: dict = {"title": d["topic"]}
-                if isinstance(d.get("content"), str):
-                    di["body"] = d["content"]
-                if isinstance(d.get("source_quote"), str):
-                    di["sourceQuote"] = d["source_quote"]
-                decision_items.append(di)
+                decision_item: dict = {"title": decision["topic"]}
+                if isinstance(decision.get("content"), str):
+                    decision_item["body"] = decision["content"]
+                if isinstance(decision.get("source_quote"), str):
+                    decision_item["sourceQuote"] = decision["source_quote"]
+                decision_items.append(decision_item)
             task_items = []
-            for t in report.get("tasks", []):
-                if not isinstance(t, dict):
+            for task in report.get("tasks", []):
+                if not isinstance(task, dict):
                     continue
-                if not isinstance(t.get("title"), str) or not t["title"]:
+                if not isinstance(task.get("title"), str) or not task["title"]:
                     continue
-                ti: dict = {"title": t["title"]}
-                if isinstance(t.get("body"), str):
-                    ti["body"] = t["body"]
-                if isinstance(t.get("source_quote"), str):
-                    ti["sourceQuote"] = t["source_quote"]
-                if t.get("priority") in VALID_PRIORITY:
-                    ti["priority"] = t["priority"]
-                task_items.append(ti)
+                task_item: dict = {"title": task["title"]}
+                if isinstance(task.get("body"), str):
+                    task_item["body"] = task["body"]
+                if isinstance(task.get("source_quote"), str):
+                    task_item["sourceQuote"] = task["source_quote"]
+                if task.get("priority") in VALID_PRIORITY:
+                    task_item["priority"] = task["priority"]
+                task_items.append(task_item)
             ambiguous_infos = []
-            for a in report.get("ambiguities", []):
-                if not isinstance(a, dict):
+            for ambiguity in report.get("ambiguities", []):
+                if not isinstance(ambiguity, dict):
                     continue
-                if not isinstance(a.get("body"), str) or not a["body"]:
+                if not isinstance(ambiguity.get("body"), str) or not ambiguity["body"]:
                     continue
-                ai: dict = {"body": a["body"]}
-                if isinstance(a.get("source_quote"), str):
-                    ai["sourceQuote"] = a["source_quote"]
-                if a.get("ambiguity_type") in VALID_AMBIGUITY_TYPE:
-                    ai["ambiguityType"] = a["ambiguity_type"]
-                if a.get("severity") in VALID_SEVERITY:
-                    ai["severity"] = a["severity"]
-                ambiguous_infos.append(ai)
+                ambiguity_item: dict = {"body": ambiguity["body"]}
+                if isinstance(ambiguity.get("source_quote"), str):
+                    ambiguity_item["sourceQuote"] = ambiguity["source_quote"]
+                if ambiguity.get("ambiguity_type") in VALID_AMBIGUITY_TYPE:
+                    ambiguity_item["ambiguityType"] = ambiguity["ambiguity_type"]
+                if ambiguity.get("severity") in VALID_SEVERITY:
+                    ambiguity_item["severity"] = ambiguity["severity"]
+                ambiguous_infos.append(ambiguity_item)
             complete_attempted = True
             await api_client.complete_analysis_run(
                 analysis_run_id,
@@ -132,8 +132,8 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
             analysis_run_id,
             result.status,
         )
-    except Exception as e:
-        logger.error("解析失敗 analysis_run_id=%s: %s", analysis_run_id, e)
+    except Exception as error:
+        logger.error("解析失敗 analysis_run_id=%s: %s", analysis_run_id, error)
         if not complete_attempted:
             # complete 未呼び出しなので失敗確定、failed に落として再配送させる
             try:
@@ -141,7 +141,7 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                     analysis_run_id,
                     {
                         "status": "failed",
-                        "error_message": str(e),
+                        "error_message": str(error),
                         "failed_at": datetime.now(timezone.utc).isoformat(),
                     },
                 )
@@ -158,19 +158,19 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 analysis_run_id,
             )
             raise
-        elif isinstance(e, httpx.HTTPStatusError) and e.response.status_code < 500:
+        elif isinstance(error, httpx.HTTPStatusError) and error.response.status_code < 500:
             # 4xx は恒久失敗：failed 保存後raise せず、 再配送ループを防ぐ
             logger.error(
                 "complete が 4xx で拒否 analysis_run_id=%s: %s",
                 analysis_run_id,
-                e,
+                error,
             )
             try:
                 await api_client.update_analysis_run_result(
                     analysis_run_id,
                     {
                         "status": "failed",
-                        "error_message": str(e),
+                        "error_message": str(error),
                         "failed_at": datetime.now(timezone.utc).isoformat(),
                     },
                 )
@@ -185,7 +185,7 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
             logger.error(
                 "complete失敗（DB状態不明）再配送 analysis_run_id=%s: %s",
                 analysis_run_id,
-                e,
+                error,
             )
             raise
 

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -5,6 +5,7 @@ import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
+import httpx
 from azure.servicebus import ServiceBusReceivedMessage
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -42,6 +43,21 @@ def _parse_message_body(message: ServiceBusReceivedMessage) -> bytes:
     raise TypeError(f"未対応の message.body 型: {type(body)}")
 
 
+_VALID_PRIORITY = {"required", "optional"}
+_VALID_SEVERITY = {"high", "medium", "low"}
+_VALID_AMBIGUITY_TYPE = {
+    "missing_speaker",
+    "transcription_error_low",
+    "transcription_error_high",
+    "no_assignee",
+    "no_deadline_mentioned",
+    "no_deadline_absolute",
+    "unclear_decision",
+    "insufficient_basis",
+    "unclear_scope",
+}
+
+
 async def _handle_message(message: ServiceBusReceivedMessage) -> None:
     """Service Busからのメッセージを受信し、解析パイプラインを実行する。"""
     # 取り出し失敗で Consumer が落ちないよう、パース段階で完結させる
@@ -61,10 +77,56 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
         return
     api_client = AppApiClient()
     llm_client = AzureOpenAIClient()
+    complete_attempted = False
+    complete_done = False
     try:
         input_data = await api_client.get_analysis_run_input(analysis_run_id)
         job = AnalysisJobInput(**input_data)
         result = await analyze_meeting(job, llm_client)
+        if result.status == "completed" and result.report_json:
+            report = result.report_json
+            decision_items = []
+            for d in report.get("decisions", []):
+                if not isinstance(d.get("topic"), str) or not d["topic"]:
+                    continue
+                di: dict = {"title": d["topic"]}
+                if isinstance(d.get("content"), str):
+                    di["body"] = d["content"]
+                if isinstance(d.get("source_quote"), str):
+                    di["sourceQuote"] = d["source_quote"]
+                decision_items.append(di)
+            task_items = []
+            for t in report.get("tasks", []):
+                if not isinstance(t.get("title"), str) or not t["title"]:
+                    continue
+                ti: dict = {"title": t["title"]}
+                if isinstance(t.get("body"), str):
+                    ti["body"] = t["body"]
+                if isinstance(t.get("source_quote"), str):
+                    ti["sourceQuote"] = t["source_quote"]
+                if t.get("priority") in _VALID_PRIORITY:
+                    ti["priority"] = t["priority"]
+                task_items.append(ti)
+            ambiguous_infos = []
+            for a in report.get("ambiguities", []):
+                if not isinstance(a.get("body"), str) or not a["body"]:
+                    continue
+                ai: dict = {"body": a["body"]}
+                if isinstance(a.get("source_quote"), str):
+                    ai["sourceQuote"] = a["source_quote"]
+                if a.get("ambiguity_type") in _VALID_AMBIGUITY_TYPE:
+                    ai["ambiguityType"] = a["ambiguity_type"]
+                if a.get("severity") in _VALID_SEVERITY:
+                    ai["severity"] = a["severity"]
+                ambiguous_infos.append(ai)
+            complete_attempted = True
+            await api_client.complete_analysis_run(
+                analysis_run_id,
+                decision_items=decision_items,
+                tasks=task_items,
+                ambiguous_infos=ambiguous_infos,
+            )
+            complete_done = True
         await api_client.update_analysis_run_result(
             analysis_run_id,
             result.model_dump(exclude_none=True),
@@ -76,18 +138,59 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
         )
     except Exception as e:
         logger.error("解析失敗 analysis_run_id=%s: %s", analysis_run_id, e)
-        try:
-            await api_client.update_analysis_run_result(
+        if not complete_attempted:
+            # complete 未呼び出しなので失敗確定、failed に落として再配送させる
+            try:
+                await api_client.update_analysis_run_result(
+                    analysis_run_id,
+                    {
+                        "status": "failed",
+                        "error_message": str(e),
+                        "failed_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "エラー保存にも失敗 analysis_run_id=%s", analysis_run_id
+                )
+            raise
+        elif complete_done:
+            # complete 成功後に update_analysis_run_result が失敗、再配送で update を再試行させる
+            logger.error(
+                "complete済みだが詳細結果の保存に失敗 analysis_run_id=%s",
                 analysis_run_id,
-                {
-                    "status": "failed",
-                    "error_message": str(e),
-                    "failed_at": datetime.now(timezone.utc).isoformat(),
-                },
             )
-        except Exception:
-            logger.exception("エラー保存にも失敗 analysis_run_id=%s", analysis_run_id)
-        raise  # Consumer に失敗を伝えて再配送させる
+            raise
+        elif isinstance(e, httpx.HTTPStatusError) and e.response.status_code < 500:
+            # 4xx は恒久失敗：failed 保存後、raise せずメッセージを完了させる（再配送ループを防ぐ）
+            logger.error(
+                "complete が 4xx で拒否 analysis_run_id=%s: %s",
+                analysis_run_id,
+                e,
+            )
+            try:
+                await api_client.update_analysis_run_result(
+                    analysis_run_id,
+                    {
+                        "status": "failed",
+                        "error_message": str(e),
+                        "failed_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "エラー保存にも失敗 analysis_run_id=%s", analysis_run_id
+                )
+                raise  # failed 保存に失敗した場合は再配送させる
+            # raise しない → failed 保存成功時のみ Consumer がメッセージを complete
+        else:
+            # 5xx / 通信断 / timeout → DB 状態不明のため再配送に委ねる
+            logger.error(
+                "complete呼び出し失敗（DB状態不明）再配送に委ねる analysis_run_id=%s: %s",
+                analysis_run_id,
+                e,
+            )
+            raise
 
 
 def _on_consumer_done(task: asyncio.Task) -> None:

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -48,7 +48,6 @@ def _parse_message_body(message: ServiceBusReceivedMessage) -> bytes:
     raise TypeError(f"未対応の message.body 型: {type(body)}")
 
 
-
 async def _handle_message(message: ServiceBusReceivedMessage) -> None:
     """Service Busからのメッセージを受信し、解析パイプラインを実行する。"""
     # 取り出し失敗で Consumer が落ちないよう、パース段階で完結させる
@@ -78,6 +77,8 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
             report = result.report_json
             decision_items = []
             for d in report.get("decisions", []):
+                if not isinstance(d, dict):
+                    continue
                 if not isinstance(d.get("topic"), str) or not d["topic"]:
                     continue
                 di: dict = {"title": d["topic"]}
@@ -88,6 +89,8 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 decision_items.append(di)
             task_items = []
             for t in report.get("tasks", []):
+                if not isinstance(t, dict):
+                    continue
                 if not isinstance(t.get("title"), str) or not t["title"]:
                     continue
                 ti: dict = {"title": t["title"]}
@@ -100,6 +103,8 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 task_items.append(ti)
             ambiguous_infos = []
             for a in report.get("ambiguities", []):
+                if not isinstance(a, dict):
+                    continue
                 if not isinstance(a.get("body"), str) or not a["body"]:
                     continue
                 ai: dict = {"body": a["body"]}

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -17,10 +17,10 @@ from pipeline.analyze_meeting import analyze_meeting
 from routers.analysis import router as analysis_router
 from routers.health import router as health_router
 from schemas.analysis import (
-    AnalysisJobInput,
     VALID_AMBIGUITY_TYPE,
     VALID_PRIORITY,
     VALID_SEVERITY,
+    AnalysisJobInput,
 )
 
 logger = logging.getLogger(__name__)

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -16,7 +16,12 @@ from llm.client import AzureOpenAIClient
 from pipeline.analyze_meeting import analyze_meeting
 from routers.analysis import router as analysis_router
 from routers.health import router as health_router
-from schemas.analysis import AnalysisJobInput
+from schemas.analysis import (
+    AnalysisJobInput,
+    VALID_AMBIGUITY_TYPE,
+    VALID_PRIORITY,
+    VALID_SEVERITY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,20 +47,6 @@ def _parse_message_body(message: ServiceBusReceivedMessage) -> bytes:
         return b"".join(chunks)
     raise TypeError(f"未対応の message.body 型: {type(body)}")
 
-
-_VALID_PRIORITY = {"required", "optional"}
-_VALID_SEVERITY = {"high", "medium", "low"}
-_VALID_AMBIGUITY_TYPE = {
-    "missing_speaker",
-    "transcription_error_low",
-    "transcription_error_high",
-    "no_assignee",
-    "no_deadline_mentioned",
-    "no_deadline_absolute",
-    "unclear_decision",
-    "insufficient_basis",
-    "unclear_scope",
-}
 
 
 async def _handle_message(message: ServiceBusReceivedMessage) -> None:
@@ -104,7 +95,7 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                     ti["body"] = t["body"]
                 if isinstance(t.get("source_quote"), str):
                     ti["sourceQuote"] = t["source_quote"]
-                if t.get("priority") in _VALID_PRIORITY:
+                if t.get("priority") in VALID_PRIORITY:
                     ti["priority"] = t["priority"]
                 task_items.append(ti)
             ambiguous_infos = []
@@ -114,9 +105,9 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 ai: dict = {"body": a["body"]}
                 if isinstance(a.get("source_quote"), str):
                     ai["sourceQuote"] = a["source_quote"]
-                if a.get("ambiguity_type") in _VALID_AMBIGUITY_TYPE:
+                if a.get("ambiguity_type") in VALID_AMBIGUITY_TYPE:
                     ai["ambiguityType"] = a["ambiguity_type"]
-                if a.get("severity") in _VALID_SEVERITY:
+                if a.get("severity") in VALID_SEVERITY:
                     ai["severity"] = a["severity"]
                 ambiguous_infos.append(ai)
             complete_attempted = True

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -158,7 +158,10 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 analysis_run_id,
             )
             raise
-        elif isinstance(error, httpx.HTTPStatusError) and error.response.status_code < 500:
+        elif (
+            isinstance(error, httpx.HTTPStatusError)
+            and error.response.status_code < 500
+        ):
             # 4xx は恒久失敗：failed 保存後raise せず、 再配送ループを防ぐ
             logger.error(
                 "complete が 4xx で拒否 analysis_run_id=%s: %s",

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -155,14 +155,15 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
                 )
             raise
         elif complete_done:
-            # complete 成功後に update_analysis_run_result が失敗、再配送で update を再試行させる
+            # complete 成功後に update_analysis_run_result が失敗
+            # 再配送で update を再試行させる
             logger.error(
                 "complete済みだが詳細結果の保存に失敗 analysis_run_id=%s",
                 analysis_run_id,
             )
             raise
         elif isinstance(e, httpx.HTTPStatusError) and e.response.status_code < 500:
-            # 4xx は恒久失敗：failed 保存後、raise せずメッセージを完了させる（再配送ループを防ぐ）
+            # 4xx は恒久失敗：failed 保存後raise せず、 再配送ループを防ぐ
             logger.error(
                 "complete が 4xx で拒否 analysis_run_id=%s: %s",
                 analysis_run_id,
@@ -186,7 +187,7 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
         else:
             # 5xx / 通信断 / timeout → DB 状態不明のため再配送に委ねる
             logger.error(
-                "complete呼び出し失敗（DB状態不明）再配送に委ねる analysis_run_id=%s: %s",
+                "complete失敗（DB状態不明）再配送 analysis_run_id=%s: %s",
                 analysis_run_id,
                 e,
             )

--- a/services/ai/schemas/analysis.py
+++ b/services/ai/schemas/analysis.py
@@ -54,12 +54,16 @@ class AnalysisRunResult(BaseModel):
 VALID_PRIORITY: frozenset[str] = frozenset({"required", "optional"})
 
 # schema.prisma: enum AmbiguitySeverity { high medium low }
-# ⚠️ この値を変更する場合は schema.prisma の AmbiguitySeverity enum も合わせて更新すること
+# ⚠️ この値を変更する場合は schema.prisma の AmbiguitySeverity enum も
+# 合わせて更新すること
 VALID_SEVERITY: frozenset[str] = frozenset({"high", "medium", "low"})
 
-# schema.prisma: enum AmbiguityType { missing_speaker transcription_error_low transcription_error_high
-#   no_assignee no_deadline_mentioned no_deadline_absolute unclear_decision insufficient_basis unclear_scope }
-# ⚠️ この値を変更する場合は schema.prisma の AmbiguityType enum も合わせて更新すること
+# schema.prisma: enum AmbiguityType {
+#   missing_speaker transcription_error_low transcription_error_high
+#   no_assignee no_deadline_mentioned no_deadline_absolute
+#   unclear_decision insufficient_basis unclear_scope }
+# ⚠️ この値を変更する場合は schema.prisma の AmbiguityType enum も
+# 合わせて更新すること
 VALID_AMBIGUITY_TYPE: frozenset[str] = frozenset(
     {
         "missing_speaker",

--- a/services/ai/schemas/analysis.py
+++ b/services/ai/schemas/analysis.py
@@ -47,3 +47,29 @@ class AnalysisRunResult(BaseModel):
     completed_at: Optional[str] = None
     failed_at: Optional[str] = None
     error_message: Optional[str] = None
+
+
+# schema.prisma: enum TaskPriority { required optional }
+# ⚠️ この値を変更する場合は schema.prisma の TaskPriority enum も合わせて更新すること
+VALID_PRIORITY: frozenset[str] = frozenset({"required", "optional"})
+
+# schema.prisma: enum AmbiguitySeverity { high medium low }
+# ⚠️ この値を変更する場合は schema.prisma の AmbiguitySeverity enum も合わせて更新すること
+VALID_SEVERITY: frozenset[str] = frozenset({"high", "medium", "low"})
+
+# schema.prisma: enum AmbiguityType { missing_speaker transcription_error_low transcription_error_high
+#   no_assignee no_deadline_mentioned no_deadline_absolute unclear_decision insufficient_basis unclear_scope }
+# ⚠️ この値を変更する場合は schema.prisma の AmbiguityType enum も合わせて更新すること
+VALID_AMBIGUITY_TYPE: frozenset[str] = frozenset(
+    {
+        "missing_speaker",
+        "transcription_error_low",
+        "transcription_error_high",
+        "no_assignee",
+        "no_deadline_mentioned",
+        "no_deadline_absolute",
+        "unclear_decision",
+        "insufficient_basis",
+        "unclear_scope",
+    }
+)

--- a/services/ai/tests/test_handle_message.py
+++ b/services/ai/tests/test_handle_message.py
@@ -3,6 +3,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import httpx
 
 from main import _handle_message
 from schemas.analysis import AnalysisRunResult
@@ -19,6 +20,8 @@ _INPUT_DATA = {
 _FAKE_RESULT = AnalysisRunResult(
     status="completed", completed_at="2026-05-17T11:00:00Z"
 )
+
+_REPORT_JSON_EMPTY = {"decisions": [], "tasks": [], "ambiguities": []}
 
 
 def _make_message(analysis_run_id: str = "run-1") -> MagicMock:
@@ -91,3 +94,208 @@ async def test_handle_message_update_failure_logs_error(caplog):
                         await _handle_message(msg)
 
     assert any("エラー保存にも失敗" in r.message for r in caplog.records)
+
+
+# ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+
+def _make_completed_result(report_json: dict | None = None) -> AnalysisRunResult:
+    """status=completed かつ report_json が truthy な結果を返す"""
+    return AnalysisRunResult(
+        status="completed",
+        completed_at="2026-05-17T11:00:00Z",
+        report_json=report_json if report_json is not None else _REPORT_JSON_EMPTY,
+    )
+
+
+def _make_http_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://localhost/complete")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=request, response=response
+    )
+
+
+# ── テスト 1：complete と update の呼び出し順 ─────────────────────────────────
+async def test_handle_message_calls_complete_before_update():
+    """complete_analysis_run が先、update_analysis_run_result が後に呼ばれること"""
+    call_order: list[str] = []
+
+    async def _on_complete(*args, **kwargs):
+        call_order.append("complete")
+
+    async def _on_update(*args, **kwargs):
+        call_order.append("update")
+
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock(side_effect=_on_complete)
+    mock_api.update_analysis_run_result = AsyncMock(side_effect=_on_update)
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result()),
+            ):
+                await _handle_message(msg)
+
+    assert call_order == ["complete", "update"]
+
+
+# ── テスト 2：camelCase 変換 ──────────────────────────────────────────────────
+async def test_handle_message_camel_case_conversion():
+    """decisions/tasks/ambiguities の camelCase 変換が正しいこと"""
+    report_json = {
+        "decisions": [
+            {"topic": "意思決定1", "content": "内容1", "source_quote": "引用D"},
+        ],
+        "tasks": [
+            {
+                "title": "タスク1",
+                "body": "タスク内容1",
+                "source_quote": "引用T",
+                "priority": "required",
+            },
+        ],
+        "ambiguities": [
+            {
+                "body": "曖昧点1",
+                "source_quote": "引用A",
+                "ambiguity_type": "no_assignee",
+                "severity": "high",
+            },
+        ],
+    }
+
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock()
+    mock_api.update_analysis_run_result = AsyncMock()
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result(report_json)),
+            ):
+                await _handle_message(msg)
+
+    mock_api.complete_analysis_run.assert_awaited_once()
+    kwargs = mock_api.complete_analysis_run.call_args.kwargs
+
+    assert kwargs["decision_items"] == [
+        {"title": "意思決定1", "body": "内容1", "sourceQuote": "引用D"}
+    ]
+    assert kwargs["tasks"] == [
+        {
+            "title": "タスク1",
+            "body": "タスク内容1",
+            "sourceQuote": "引用T",
+            "priority": "required",
+        }
+    ]
+    assert kwargs["ambiguous_infos"] == [
+        {
+            "body": "曖昧点1",
+            "sourceQuote": "引用A",
+            "ambiguityType": "no_assignee",
+            "severity": "high",
+        }
+    ]
+
+
+# ── テスト 3：complete 成功後に update が失敗 → raise ──────────────────────────
+async def test_handle_message_raises_when_update_fails_after_complete():
+    """complete 成功後に update が失敗 → raise されること"""
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock()
+    mock_api.update_analysis_run_result = AsyncMock(
+        side_effect=RuntimeError("update失敗")
+    )
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result()),
+            ):
+                with pytest.raises(RuntimeError, match="update失敗"):
+                    await _handle_message(msg)
+
+    mock_api.complete_analysis_run.assert_awaited_once()
+    # failed 保存の再試行がされていないこと（1回のみ = 正常系の update 呼び出し）
+    mock_api.update_analysis_run_result.assert_awaited_once()
+
+
+# ── テスト 4：complete が 4xx → failed 保存 → raise しない ────────────────────
+async def test_handle_message_saves_failed_and_not_raise_on_complete_4xx():
+    """complete が 4xx → failed 保存 → raise しないこと"""
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock(side_effect=_make_http_error(422))
+    mock_api.update_analysis_run_result = AsyncMock()
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result()),
+            ):
+                await _handle_message(msg)  # raise しないこと
+
+    mock_api.update_analysis_run_result.assert_awaited_once()
+    result_arg = mock_api.update_analysis_run_result.call_args.args[1]
+    assert result_arg["status"] == "failed"
+
+
+# ── テスト 5：complete が 5xx → failed 保存せず raise ────────────────────────
+async def test_handle_message_raises_without_saving_failed_on_complete_5xx():
+    """complete が 5xx → failed 保存せず raise"""
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock(side_effect=_make_http_error(500))
+    mock_api.update_analysis_run_result = AsyncMock()
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result()),
+            ):
+                with pytest.raises(httpx.HTTPStatusError):
+                    await _handle_message(msg)
+
+    mock_api.complete_analysis_run.assert_awaited_once()
+    mock_api.update_analysis_run_result.assert_not_awaited()
+
+
+# ── テスト 6：complete が 4xx かつ failed 保存も失敗 → raise ─────────────────
+async def test_handle_message_raises_when_failed_save_also_fails_on_complete_4xx():
+    """complete が 4xx かつ failed 保存も失敗 → raise されること"""
+    mock_api = MagicMock()
+    mock_api.get_analysis_run_input = AsyncMock(return_value=_INPUT_DATA)
+    mock_api.complete_analysis_run = AsyncMock(side_effect=_make_http_error(422))
+    mock_api.update_analysis_run_result = AsyncMock(
+        side_effect=RuntimeError("保存エラー")
+    )
+
+    msg = _make_message()
+    with patch("main.AppApiClient", return_value=mock_api):
+        with patch("main.AzureOpenAIClient"):
+            with patch(
+                "main.analyze_meeting",
+                new=AsyncMock(return_value=_make_completed_result()),
+            ):
+                with pytest.raises(RuntimeError, match="保存エラー"):
+                    await _handle_message(msg)
+
+    mock_api.update_analysis_run_result.assert_awaited_once()
+    result_arg = mock_api.update_analysis_run_result.call_args.args[1]
+    assert result_arg["status"] == "failed"

--- a/services/ai/tests/test_handle_message.py
+++ b/services/ai/tests/test_handle_message.py
@@ -21,7 +21,7 @@ _FAKE_RESULT = AnalysisRunResult(
     status="completed", completed_at="2026-05-17T11:00:00Z"
 )
 
-_REPORT_JSON_EMPTY = {"decisions": [], "tasks": [], "ambiguities": []}
+_REPORT_JSON_EMPTY: dict[str, list] = {"decisions": [], "tasks": [], "ambiguities": []}
 
 
 def _make_message(analysis_run_id: str = "run-1") -> MagicMock:

--- a/services/ai/tests/test_handle_message.py
+++ b/services/ai/tests/test_handle_message.py
@@ -2,8 +2,8 @@ import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 import httpx
+import pytest
 
 from main import _handle_message
 from schemas.analysis import AnalysisRunResult

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -135,8 +135,8 @@ async def test_lifespan_raises_when_deployment_name_not_set():
         try:
             async with main.lifespan(main.app):
                 pass
-        except RuntimeError as e:
-            assert _DEPLOY_KEY in str(e)
+        except RuntimeError as error:
+            assert _DEPLOY_KEY in str(error)
         else:
             raise AssertionError("RuntimeError が raise されなかった")
 
@@ -152,8 +152,8 @@ async def test_lifespan_raises_when_api_key_not_set():
         try:
             async with main.lifespan(main.app):
                 pass
-        except RuntimeError as e:
-            assert _API_KEY in str(e)
+        except RuntimeError as error:
+            assert _API_KEY in str(error)
         else:
             raise AssertionError("RuntimeError が raise されなかった")
 
@@ -170,7 +170,7 @@ async def test_lifespan_raises_when_endpoint_not_set():
         try:
             async with main.lifespan(main.app):
                 pass
-        except RuntimeError as e:
-            assert "AZURE_OPENAI_ENDPOINT" in str(e)
+        except RuntimeError as error:
+            assert "AZURE_OPENAI_ENDPOINT" in str(error)
         else:
             raise AssertionError("RuntimeError が raise されなかった")

--- a/services/ai/uv.lock
+++ b/services/ai/uv.lock
@@ -34,8 +34,8 @@ requires-dist = [
     { name = "azure-servicebus", specifier = ">=7.14.3" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "openai", specifier = ">=1.0.0" },
-    { name = "python-dateutil", specifier = ">=2.9.0" },
+    { name = "openai", specifier = ">=2.37.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
 ]
 
 [package.metadata.requires-dev]
@@ -43,8 +43,8 @@ dev = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "respx", specifier = ">=0.22.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.15.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 関連Issue
Closes #281

## 概要・目的
- AIサービスが解析後に `POST /internal/analysis-runs/:id/complete` を呼んでいなかったため、LLMが抽出した DecisionItem / Task / AmbiguousInfo が1件もDBに作成されない状態になっていた
- 本PRはその経路を接続し、成果物がDBに反映されるようにする

## 背景
- Issue #242（レビューアイテムAPI）はこのエンドポイントが正常に動作していることを前提としているため、先決対応として実施した

## 変更内容

### `services/ai/integrations/app_api_client.py`
- `complete_analysis_run()` メソッドを追加
- `POST /internal/analysis-runs/:id/complete` を呼び出し、`decisionItems` / `tasks` / `ambiguousInfos` を送信する

### `services/ai/main.py`
- `_handle_message` 内で `complete_analysis_run()` を `update_analysis_run_result()` より**先**に呼び出すよう修正
  - `PATCH /result` が `status=completed` を直接書き込むため、先に呼ぶと run が analyzing 状態でなくなり noop になるため
- `report_json` から `decisions` / `tasks` / `ambiguities` を取り出し、APIが受け付けるフィールド名にマッピング
  - `topic` → `title`、`content` → `body`、`source_quote` → `sourceQuote`、`ambiguity_type` → `ambiguityType`
- 文字列フィールドを `isinstance(..., str)` で型検証し、非文字列のアイテムを除外
- enum フィールド（`priority` / `severity` / `ambiguity_type`）をホワイトリストで検証
- `complete_attempted` / `complete_done` フラグによるエラーハンドリングを整備
  - complete 未呼び出し → failed 保存 → 再配送
  - complete 成功後に update 失敗 → 再配送で update を再試行
  - complete が 4xx で失敗（恒久失敗） → failed 保存 → 再配送ループを防ぐため raise しない
  - complete が 5xx / 通信断 → DB状態不明のため再配送
- レビュー中に判明した `PATCH /result` の状態遷移ガード不足は Issue #292  として別途起票、本PRのマージ後に対応予定

## 動作確認手順
1. AIサービスを起動し、Service Bus 経由でメッセージを送信して解析を実行する
2. 解析完了後、対象 meeting の DecisionItem / Task / AmbiguousInfo がDBに作成されていることを確認する
3. 解析失敗時に run の status が `failed` になっていることを確認する

## スクリーンショット
- APIの変更のためなし
