### PR TITLE
feat: DecisionItem / AmbiguousInfo の CRUD API を追加する

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(git *)",
       "Bash(npx tsc *)",
       "Bash(node *)",
-      "Bash(npx prisma *)"
+      "Bash(npx prisma *)",
+      "Bash(npx vitest *)"
     ]
   }
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,8 @@ import { meetingsRoute } from "./routes/meetings.js";
 import { organizationsRoute } from "./routes/organizations.js";
 import { recurringMeetingsRoute } from "./routes/recurring-meetings.js";
 import { tasksRoute } from "./routes/tasks.js";
+import { decisionItemsRoute } from "./routes/decision-items.js";
+import { ambiguousInfosRoute } from "./routes/ambiguous-infos.js";
 import { internalRoute } from "./routes/internal.js";
 import { internalAuth } from "./middleware/internal-auth.js";
 
@@ -53,6 +55,8 @@ const routes = app
   .route("/organizations", organizationsRoute)
   .route("/recurring-meetings", recurringMeetingsRoute)
   .route("/tasks", tasksRoute)
+  .route("/decision-items", decisionItemsRoute)
+  .route("/ambiguous-infos", ambiguousInfosRoute)
   .route("/internal", internalRoute);
 
 export { app };

--- a/apps/api/src/lib/decision-item-serialization.ts
+++ b/apps/api/src/lib/decision-item-serialization.ts
@@ -1,0 +1,43 @@
+import type { Prisma } from "@prisma/client";
+
+// 詳細 API 用の include。担当者ユーザーは email まで含めて返す。
+export const decisionItemDetailInclude = {
+  assignees: {
+    include: {
+      user: {
+        select: { id: true, name: true, displayName: true, email: true },
+      },
+    },
+  },
+} as const satisfies Prisma.DecisionItemInclude;
+
+// 一覧 API 用の include。email を省いて最小化する。
+export const decisionItemListInclude = {
+  assignees: {
+    include: {
+      user: { select: { id: true, name: true, displayName: true } },
+    },
+  },
+} as const satisfies Prisma.DecisionItemInclude;
+
+export type DecisionItemWithDetail = Prisma.DecisionItemGetPayload<{
+  include: typeof decisionItemDetailInclude;
+}>;
+export type DecisionItemWithList = Prisma.DecisionItemGetPayload<{
+  include: typeof decisionItemListInclude;
+}>;
+
+// 更新日時降順。
+export const decisionItemListOrderBy: Prisma.DecisionItemOrderByWithRelationInput[] =
+  [{ updatedAt: "desc" }];
+
+// Prisma の中間テーブル構造をフロント向けに平坦化する。
+export function serializeDecisionItem(
+  item: DecisionItemWithDetail | DecisionItemWithList,
+) {
+  const { assignees, ...rest } = item;
+  return {
+    ...rest,
+    assignees: assignees.map((a) => a.user),
+  };
+}

--- a/apps/api/src/lib/schemas/ambiguous-info.ts
+++ b/apps/api/src/lib/schemas/ambiguous-info.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+// 手動で変更可能なステータス値。draft / reviewing は AI 専用なので除外する。
+const manualAmbiguousInfoStatusSchema = z.enum(["resolved", "rejected"]);
+
+// 更新リクエスト。全フィールド optional だが、version は必須で楽観的ロックに用いる。
+// resolvedToTaskId / resolvedToDecisionItemId は同一会議内のアイテムのみ許可する。
+export const ambiguousInfoUpdateSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    status: manualAmbiguousInfoStatusSchema.optional(),
+    resolutionType: z
+      .enum(["task", "decision_item", "discarded"])
+      .nullable()
+      .optional(),
+    resolvedToTaskId: z.string().min(1).nullable().optional(),
+    resolvedToDecisionItemId: z.string().min(1).nullable().optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.status !== undefined ||
+      d.resolutionType !== undefined ||
+      d.resolvedToTaskId !== undefined ||
+      d.resolvedToDecisionItemId !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type AmbiguousInfoUpdateInput = z.infer<
+  typeof ambiguousInfoUpdateSchema
+>;
+
+// 一覧 API のクエリパラメータ。status はカンマ区切りで複数指定可。
+const ambiguousInfoStatusValuesSchema = z
+  .string()
+  .transform((s) =>
+    s
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean),
+  )
+  .pipe(z.array(z.enum(["draft", "reviewing", "resolved", "rejected"])));
+
+export const ambiguousInfoListQuerySchema = z.object({
+  status: ambiguousInfoStatusValuesSchema.optional(),
+});
+
+export type AmbiguousInfoListQuery = z.infer<
+  typeof ambiguousInfoListQuerySchema
+>;
+
+type AmbiguousInfoListWhere = {
+  status?: {
+    in: Array<"draft" | "reviewing" | "resolved" | "rejected">;
+  };
+};
+
+export function buildAmbiguousInfoListWhere(
+  filters: AmbiguousInfoListQuery,
+): AmbiguousInfoListWhere {
+  const where: AmbiguousInfoListWhere = {};
+  if (filters.status && filters.status.length > 0) {
+    where.status = { in: filters.status };
+  }
+  return where;
+}

--- a/apps/api/src/lib/schemas/ambiguous-info.ts
+++ b/apps/api/src/lib/schemas/ambiguous-info.ts
@@ -24,6 +24,28 @@ export const ambiguousInfoUpdateSchema = z
       d.resolvedToTaskId !== undefined ||
       d.resolvedToDecisionItemId !== undefined,
     { message: "更新する項目を 1 つ以上指定してください" },
+  )
+  // resolutionType と解消先 ID の種別が矛盾しないことを保証する。
+  // resolutionType=task        → resolvedToTaskId のみ許可
+  // resolutionType=decision_item → resolvedToDecisionItemId のみ許可
+  // resolutionType=discarded   → 解消先 ID は両方 null/未指定
+  .refine(
+    (d) => {
+      if (d.resolutionType === "task" && d.resolvedToDecisionItemId) {
+        return false;
+      }
+      if (d.resolutionType === "decision_item" && d.resolvedToTaskId) {
+        return false;
+      }
+      if (
+        d.resolutionType === "discarded" &&
+        (d.resolvedToTaskId || d.resolvedToDecisionItemId)
+      ) {
+        return false;
+      }
+      return true;
+    },
+    { message: "resolutionType と解消先 ID の種別が一致していません" },
   );
 
 export type AmbiguousInfoUpdateInput = z.infer<

--- a/apps/api/src/lib/schemas/decision-item.ts
+++ b/apps/api/src/lib/schemas/decision-item.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+// 手動で変更可能なステータス値。draft / reviewing は AI 専用なので除外する。
+const manualDecisionItemStatusSchema = z.enum(["open", "decided", "cancelled"]);
+
+// ID 配列は重複を排除する。
+const idArraySchema = z
+  .array(z.string().min(1))
+  .transform((arr) => [...new Set(arr)]);
+
+// 更新リクエスト。全フィールド optional だが、version は必須で楽観的ロックに用いる。
+// assigneeUserIds: undefined = 変更なし、空配列 = 全削除。
+export const decisionItemUpdateSchema = z
+  .object({
+    version: z.number().int().nonnegative(),
+    title: z.string().min(1).optional(),
+    body: z.string().optional(),
+    status: manualDecisionItemStatusSchema.optional(),
+    decisionState: z
+      .enum(["confirmed", "tentative", "open"])
+      .nullable()
+      .optional(),
+    reason: z
+      .enum([
+        "no_consensus",
+        "information_lack",
+        "intentional_defer",
+        "not_discussed",
+      ])
+      .nullable()
+      .optional(),
+    decisionDeadline: z.string().datetime().nullable().optional(),
+    assigneeUserIds: idArraySchema.optional(),
+  })
+  .strict()
+  .refine(
+    (d) =>
+      d.title !== undefined ||
+      d.body !== undefined ||
+      d.status !== undefined ||
+      d.decisionState !== undefined ||
+      d.reason !== undefined ||
+      d.decisionDeadline !== undefined ||
+      d.assigneeUserIds !== undefined,
+    { message: "更新する項目を 1 つ以上指定してください" },
+  );
+
+export type DecisionItemUpdateInput = z.infer<typeof decisionItemUpdateSchema>;
+
+// 一覧 API のクエリパラメータ。status はカンマ区切りで複数指定可。
+const decisionItemStatusValuesSchema = z
+  .string()
+  .transform((s) =>
+    s
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean),
+  )
+  .pipe(
+    z.array(z.enum(["draft", "reviewing", "open", "decided", "cancelled"])),
+  );
+
+export const decisionItemListQuerySchema = z.object({
+  status: decisionItemStatusValuesSchema.optional(),
+});
+
+export type DecisionItemListQuery = z.infer<typeof decisionItemListQuerySchema>;
+
+type DecisionItemListWhere = {
+  status?: {
+    in: Array<"draft" | "reviewing" | "open" | "decided" | "cancelled">;
+  };
+};
+
+export function buildDecisionItemListWhere(
+  filters: DecisionItemListQuery,
+): DecisionItemListWhere {
+  const where: DecisionItemListWhere = {};
+  if (filters.status && filters.status.length > 0) {
+    where.status = { in: filters.status };
+  }
+  return where;
+}

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -34,7 +34,7 @@ async function requireAmbiguousInfoAccess(
   if (!organizationId) {
     return {
       ok: false as const,
-      res: c.json({ error: "組織情報が取得できません" }, 422),
+      res: c.json({ error: "曖昧情報が見つかりません" }, 404),
     };
   }
   const guard = await requireOrgMembership(c, organizationId);

--- a/apps/api/src/routes/ambiguous-infos.ts
+++ b/apps/api/src/routes/ambiguous-infos.ts
@@ -1,0 +1,141 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { ambiguousInfoUpdateSchema } from "../lib/schemas/ambiguous-info.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
+
+// AmbiguousInfo を ID から取得し、会議の組織メンバーであることを確認する。
+// 不存在・非所属いずれも 404 で統一し、存在自体を露出させない。
+async function requireAmbiguousInfoAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  infoId: string,
+) {
+  const raw = await prisma.ambiguousInfo.findUnique({
+    where: { id: infoId },
+    select: {
+      id: true,
+      meetingId: true,
+      meeting: {
+        select: {
+          recurringMeeting: { select: { organizationId: true } },
+        },
+      },
+    },
+  });
+  if (!raw) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "曖昧情報が見つかりません" }, 404),
+    };
+  }
+  const organizationId = raw.meeting.recurringMeeting?.organizationId;
+  if (!organizationId) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "組織情報が取得できません" }, 422),
+    };
+  }
+  const guard = await requireOrgMembership(c, organizationId);
+  if (!guard.ok) {
+    return { ok: false as const, res: guard.res };
+  }
+  const { meeting: _meeting, ...info } = raw;
+  return { ok: true as const, info };
+}
+
+// resolvedToTaskId が同一会議内のタスク（originMeetingId 一致）かを検証する。
+async function validateResolvedToTask(
+  meetingId: string,
+  taskId: string,
+): Promise<boolean> {
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: { originMeetingId: true },
+  });
+  return task?.originMeetingId === meetingId;
+}
+
+// resolvedToDecisionItemId が同一会議内の決定事項かを検証する。
+async function validateResolvedToDecisionItem(
+  meetingId: string,
+  decisionItemId: string,
+): Promise<boolean> {
+  const item = await prisma.decisionItem.findUnique({
+    where: { id: decisionItemId },
+    select: { meetingId: true },
+  });
+  return item?.meetingId === meetingId;
+}
+
+export const ambiguousInfosRoute = new Hono<{
+  Variables: AuthVariables;
+}>()
+  .use("*", auth)
+  .patch("/:id", zValidator("json", ambiguousInfoUpdateSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const access = await requireAmbiguousInfoAccess(c, id);
+    if (!access.ok) return access.res;
+
+    const { meetingId } = access.info;
+
+    // 解消先タスクは同一会議から抽出されたものに限定する。
+    if (input.resolvedToTaskId) {
+      const valid = await validateResolvedToTask(
+        meetingId,
+        input.resolvedToTaskId,
+      );
+      if (!valid) {
+        return c.json({ error: "解消先タスクが同一会議に属していません" }, 400);
+      }
+    }
+
+    // 解消先決定事項は同一会議のものに限定する。
+    if (input.resolvedToDecisionItemId) {
+      const valid = await validateResolvedToDecisionItem(
+        meetingId,
+        input.resolvedToDecisionItemId,
+      );
+      if (!valid) {
+        return c.json(
+          { error: "解消先決定事項が同一会議に属していません" },
+          400,
+        );
+      }
+    }
+
+    const updateData = {
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.resolutionType !== undefined && {
+        resolutionType: input.resolutionType,
+      }),
+      ...(input.resolvedToTaskId !== undefined && {
+        resolvedToTaskId: input.resolvedToTaskId,
+      }),
+      ...(input.resolvedToDecisionItemId !== undefined && {
+        resolvedToDecisionItemId: input.resolvedToDecisionItemId,
+      }),
+      version: { increment: 1 },
+    };
+
+    const { count } = await prisma.ambiguousInfo.updateMany({
+      where: { id, version: input.version },
+      data: updateData,
+    });
+    if (count === 0) {
+      return c.json(
+        {
+          error: "他のユーザーが先に更新しました。最新を取得してください",
+        },
+        409,
+      );
+    }
+
+    const updated = await prisma.ambiguousInfo.findUniqueOrThrow({
+      where: { id },
+    });
+    return c.json(updated);
+  });

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -52,7 +52,7 @@ async function requireDecisionItemAccess(
   if (!organizationId) {
     return {
       ok: false as const,
-      res: c.json({ error: "組織情報が取得できません" }, 422),
+      res: c.json({ error: "決定事項が見つかりません" }, 404),
     };
   }
   const guard = await requireOrgMembership(c, organizationId);

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -1,0 +1,159 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { prisma } from "../lib/prisma.js";
+import { decisionItemUpdateSchema } from "../lib/schemas/decision-item.js";
+import {
+  decisionItemDetailInclude,
+  serializeDecisionItem,
+} from "../lib/decision-item-serialization.js";
+import { auth, type AuthVariables } from "../middleware/auth.js";
+import { requireOrgMembership } from "../middleware/authz.js";
+
+// assigneeUserIds が全員 organizationId のメンバーかを検証する。
+async function validateAssigneesInOrg(
+  organizationId: string,
+  userIds: string[],
+): Promise<boolean> {
+  if (userIds.length === 0) return true;
+  const members = await prisma.organizationMembership.findMany({
+    where: { organizationId, userId: { in: userIds } },
+    select: { userId: true },
+  });
+  return members.length === userIds.length;
+}
+
+// DecisionItem を ID から取得し、会議の組織メンバーであることを確認する。
+// 不存在・非所属いずれも 404 で統一し、存在自体を露出させない。
+async function requireDecisionItemAccess(
+  c: Context<{ Variables: AuthVariables }>,
+  itemId: string,
+) {
+  const raw = await prisma.decisionItem.findUnique({
+    where: { id: itemId },
+    select: {
+      id: true,
+      status: true,
+      meetingId: true,
+      meeting: {
+        select: {
+          recurringMeeting: { select: { organizationId: true } },
+        },
+      },
+    },
+  });
+  if (!raw) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "決定事項が見つかりません" }, 404),
+    };
+  }
+  const organizationId = raw.meeting.recurringMeeting?.organizationId;
+  if (!organizationId) {
+    return {
+      ok: false as const,
+      res: c.json({ error: "組織情報が取得できません" }, 422),
+    };
+  }
+  const guard = await requireOrgMembership(c, organizationId);
+  if (!guard.ok) {
+    return { ok: false as const, res: guard.res };
+  }
+  const { meeting: _meeting, ...item } = raw;
+  return { ok: true as const, item, organizationId };
+}
+
+export const decisionItemsRoute = new Hono<{
+  Variables: AuthVariables;
+}>()
+  .use("*", auth)
+  .patch("/:id", zValidator("json", decisionItemUpdateSchema), async (c) => {
+    const id = c.req.param("id");
+    const input = c.req.valid("json");
+
+    const access = await requireDecisionItemAccess(c, id);
+    if (!access.ok) return access.res;
+
+    const { organizationId } = access;
+
+    if (input.assigneeUserIds !== undefined) {
+      if (
+        !(await validateAssigneesInOrg(organizationId, input.assigneeUserIds))
+      ) {
+        return c.json(
+          { error: "担当者は組織のメンバーである必要があります" },
+          400,
+        );
+      }
+    }
+
+    // status が "decided" になったら decidedBy / decidedAt を自動設定。
+    // "decided" 以外のステータスへ変わったら decidedBy / decidedAt をクリア。
+    const prevStatus = access.item.status;
+    const nextStatus = input.status;
+    let decidedBy: string | null | undefined;
+    let decidedAt: Date | null | undefined;
+    if (nextStatus === "decided") {
+      decidedBy = c.var.user.id;
+      decidedAt = new Date();
+    } else if (nextStatus !== undefined && prevStatus === "decided") {
+      decidedBy = null;
+      decidedAt = null;
+    }
+
+    const updateData = {
+      ...(input.title !== undefined && { title: input.title }),
+      ...(input.body !== undefined && { body: input.body }),
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.decisionState !== undefined && {
+        decisionState: input.decisionState,
+      }),
+      ...(input.reason !== undefined && { reason: input.reason }),
+      ...(input.decisionDeadline !== undefined && {
+        decisionDeadline: input.decisionDeadline
+          ? new Date(input.decisionDeadline)
+          : null,
+      }),
+      ...(decidedBy !== undefined && { decidedBy }),
+      ...(decidedAt !== undefined && { decidedAt }),
+      version: { increment: 1 },
+    };
+
+    const result = await prisma.$transaction(async (tx) => {
+      const { count } = await tx.decisionItem.updateMany({
+        where: { id, version: input.version },
+        data: updateData,
+      });
+      if (count === 0) {
+        return { kind: "version_conflict" as const };
+      }
+      if (input.assigneeUserIds !== undefined) {
+        await tx.decisionItemAssignee.deleteMany({
+          where: { decisionItemId: id },
+        });
+        if (input.assigneeUserIds.length > 0) {
+          await tx.decisionItemAssignee.createMany({
+            data: input.assigneeUserIds.map((userId) => ({
+              decisionItemId: id,
+              userId,
+            })),
+          });
+        }
+      }
+      const item = await tx.decisionItem.findUniqueOrThrow({
+        where: { id },
+        include: decisionItemDetailInclude,
+      });
+      return { kind: "ok" as const, item };
+    });
+
+    if (result.kind === "version_conflict") {
+      return c.json(
+        {
+          error: "他のユーザーが先に更新しました。最新を取得してください",
+        },
+        409,
+      );
+    }
+    return c.json(serializeDecisionItem(result.item));
+  });

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -4,9 +4,22 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma.js";
 import { sendToServiceBus } from "../lib/service-bus.js";
 import {
+  buildDecisionItemListWhere,
+  decisionItemListQuerySchema,
+} from "../lib/schemas/decision-item.js";
+import {
+  buildAmbiguousInfoListWhere,
+  ambiguousInfoListQuerySchema,
+} from "../lib/schemas/ambiguous-info.js";
+import {
   buildTaskListWhere,
   taskListQuerySchema,
 } from "../lib/schemas/task.js";
+import {
+  decisionItemListInclude,
+  decisionItemListOrderBy,
+  serializeDecisionItem,
+} from "../lib/decision-item-serialization.js";
 import {
   serializeTask,
   taskListInclude,
@@ -110,6 +123,46 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         include: taskListInclude,
       });
       return c.json(tasks.map(serializeTask));
+    },
+  )
+  .get(
+    "/:id/decision-items",
+    auth,
+    zValidator("query", decisionItemListQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const filters = c.req.valid("query");
+
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
+
+      const items = await prisma.decisionItem.findMany({
+        where: { ...buildDecisionItemListWhere(filters), meetingId: id },
+        orderBy: decisionItemListOrderBy,
+        include: decisionItemListInclude,
+      });
+      return c.json(items.map(serializeDecisionItem));
+    },
+  )
+  .get(
+    "/:id/ambiguous-infos",
+    auth,
+    zValidator("query", ambiguousInfoListQuerySchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const filters = c.req.valid("query");
+
+      const access = await requireMeetingAccess(c, id);
+      if (!access.ok) return access.response;
+
+      const infos = await prisma.ambiguousInfo.findMany({
+        where: {
+          ...buildAmbiguousInfoListWhere(filters),
+          meetingId: id,
+        },
+        orderBy: { updatedAt: "desc" },
+      });
+      return c.json(infos);
     },
   )
   .patch("/:id", auth, zValidator("json", meetingUpdateSchema), async (c) => {

--- a/apps/api/test/ambiguous-infos.test.ts
+++ b/apps/api/test/ambiguous-infos.test.ts
@@ -360,6 +360,58 @@ describe("PATCH /ambiguous-infos/:id", () => {
     expect(mockAmbiguousInfoUpdateMany).not.toHaveBeenCalled();
   });
 
+  it("resolutionType=task のとき resolvedToDecisionItemId を指定すると 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "task",
+        resolvedToDecisionItemId: "di-1",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("resolutionType=decision_item のとき resolvedToTaskId を指定すると 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "decision_item",
+        resolvedToTaskId: "task-1",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("resolutionType=discarded のとき resolvedToTaskId を指定すると 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "discarded",
+        resolvedToTaskId: "task-1",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("resolutionType=discarded のとき resolvedToDecisionItemId を指定すると 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolutionType: "discarded",
+        resolvedToDecisionItemId: "di-1",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("resolutionType を null に設定できる", async () => {
     mockAmbiguousInfoFindUnique.mockResolvedValue(
       mockAmbiguousInfoRaw() as never,

--- a/apps/api/test/ambiguous-infos.test.ts
+++ b/apps/api/test/ambiguous-infos.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma を全モックして ambiguous-infos / meetings ルートのロジックのみを検証する。
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+    },
+    meeting: {
+      findUnique: vi.fn(),
+    },
+    ambiguousInfo: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+    },
+    task: {
+      findUnique: vi.fn(),
+    },
+    decisionItem: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
+const mockAmbiguousInfoFindUnique = vi.mocked(prisma.ambiguousInfo.findUnique);
+const mockAmbiguousInfoFindMany = vi.mocked(prisma.ambiguousInfo.findMany);
+const mockAmbiguousInfoUpdateMany = vi.mocked(prisma.ambiguousInfo.updateMany);
+const mockAmbiguousInfoFindUniqueOrThrow = vi.mocked(
+  prisma.ambiguousInfo.findUniqueOrThrow,
+);
+const mockTaskFindUnique = vi.mocked(prisma.task.findUnique);
+const mockDecisionItemFindUnique = vi.mocked(prisma.decisionItem.findUnique);
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+function mockMeeting() {
+  return {
+    id: "mtg-1",
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  };
+}
+
+// requireAmbiguousInfoAccess で返すモック（select 形式）。
+function mockAmbiguousInfoRaw(overrides = {}) {
+  return {
+    id: "ai-1",
+    meetingId: "mtg-1",
+    meeting: { recurringMeeting: { organizationId: "org-1" } },
+    ...overrides,
+  };
+}
+
+const sampleAmbiguousInfo = {
+  id: "ai-1",
+  meetingId: "mtg-1",
+  body: "話者が不明瞭",
+  sourceQuote: null,
+  sourceContext: null,
+  status: "draft" as const,
+  ambiguityType: null,
+  severity: null,
+  inferenceBasis: null,
+  dueDateRaw: null,
+  dueDateEstimated: null,
+  affectedItemIds: null,
+  resolutionType: null,
+  resolvedToTaskId: null,
+  resolvedToDecisionItemId: null,
+  version: 0,
+  createdAt: new Date("2026-05-17T00:00:00Z"),
+  updatedAt: new Date("2026-05-17T00:00:00Z"),
+};
+
+// ──────────────────────────────────────────────
+// GET /meetings/:id/ambiguous-infos
+// ──────────────────────────────────────────────
+describe("GET /meetings/:id/ambiguous-infos", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは 200 でリストを取得できる", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockAmbiguousInfoFindMany.mockResolvedValue([
+      sampleAmbiguousInfo,
+    ] as never);
+
+    const res = await app.request("/meetings/mtg-1/ambiguous-infos");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string }[];
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("ai-1");
+  });
+
+  it("status フィルタで絞り込める", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockAmbiguousInfoFindMany.mockResolvedValue([] as never);
+
+    const res = await app.request(
+      "/meetings/mtg-1/ambiguous-infos?status=resolved",
+    );
+    expect(res.status).toBe(200);
+    expect(mockAmbiguousInfoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["resolved"] },
+          meetingId: "mtg-1",
+        }),
+      }),
+    );
+  });
+
+  it("不正な status 値は 400", async () => {
+    const res = await app.request(
+      "/meetings/mtg-1/ambiguous-infos?status=invalid",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("会議が存在しない場合は 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/ambiguous-infos");
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属は 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/ambiguous-infos");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ──────────────────────────────────────────────
+// PATCH /ambiguous-infos/:id
+// ──────────────────────────────────────────────
+describe("PATCH /ambiguous-infos/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("status 更新が 200 を返す", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockAmbiguousInfoUpdateMany.mockResolvedValue({ count: 1 } as never);
+    mockAmbiguousInfoFindUniqueOrThrow.mockResolvedValue({
+      ...sampleAmbiguousInfo,
+      status: "resolved",
+      version: 1,
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "resolved" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; version: number };
+    expect(body.status).toBe("resolved");
+    expect(body.version).toBe(1);
+  });
+
+  it("version 不一致は 409", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockAmbiguousInfoUpdateMany.mockResolvedValue({ count: 0 } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, status: "resolved" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("status=draft は 400（AI 専用なので手動 PATCH で受け付けない）", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("全フィールド未指定の更新は 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("version 欠落は 400", async () => {
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "resolved" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("曖昧情報が存在しない場合は 404", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(null);
+    const res = await app.request("/ambiguous-infos/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "resolved" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属は 404", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "resolved" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("resolvedToTaskId が同一会議に属する場合は 200", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // task.originMeetingId が同一会議と一致する
+    mockTaskFindUnique.mockResolvedValue({
+      originMeetingId: "mtg-1",
+    } as never);
+    mockAmbiguousInfoUpdateMany.mockResolvedValue({ count: 1 } as never);
+    mockAmbiguousInfoFindUniqueOrThrow.mockResolvedValue({
+      ...sampleAmbiguousInfo,
+      resolvedToTaskId: "task-1",
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolvedToTaskId: "task-1" }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("resolvedToTaskId が別会議のタスクなら 400", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 別会議のタスク
+    mockTaskFindUnique.mockResolvedValue({
+      originMeetingId: "mtg-other",
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolvedToTaskId: "task-other" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAmbiguousInfoUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("resolvedToDecisionItemId が同一会議に属する場合は 200", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockDecisionItemFindUnique.mockResolvedValue({
+      meetingId: "mtg-1",
+    } as never);
+    mockAmbiguousInfoUpdateMany.mockResolvedValue({ count: 1 } as never);
+    mockAmbiguousInfoFindUniqueOrThrow.mockResolvedValue({
+      ...sampleAmbiguousInfo,
+      resolvedToDecisionItemId: "di-1",
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolvedToDecisionItemId: "di-1",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("resolvedToDecisionItemId が別会議の決定事項なら 400", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 別会議の決定事項
+    mockDecisionItemFindUnique.mockResolvedValue({
+      meetingId: "mtg-other",
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        resolvedToDecisionItemId: "di-other",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAmbiguousInfoUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("resolutionType を null に設定できる", async () => {
+    mockAmbiguousInfoFindUnique.mockResolvedValue(
+      mockAmbiguousInfoRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockAmbiguousInfoUpdateMany.mockResolvedValue({ count: 1 } as never);
+    mockAmbiguousInfoFindUniqueOrThrow.mockResolvedValue({
+      ...sampleAmbiguousInfo,
+      resolutionType: null,
+    } as never);
+
+    const res = await app.request("/ambiguous-infos/ai-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, resolutionType: null }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockAmbiguousInfoUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ resolutionType: null }),
+      }),
+    );
+  });
+});

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -1,0 +1,472 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma を全モックして decision-items / meetings ルートのロジックのみを検証する。
+vi.mock("../src/lib/prisma.js", () => ({
+  prisma: {
+    organizationMembership: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    meeting: {
+      findUnique: vi.fn(),
+    },
+    decisionItem: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    decisionItemAssignee: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+const authState = vi.hoisted(() => {
+  const defaultUser = {
+    id: "user-1",
+    externalId: "ext-1",
+    email: "alice@example.com",
+    name: "alice",
+    displayName: "alice",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+  return { defaultUser, current: { ...defaultUser } };
+});
+
+vi.mock("../src/middleware/auth.js", () => ({
+  auth: async (
+    c: { set: (key: string, value: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", authState.current);
+    await next();
+  },
+}));
+
+import { app } from "../src/app.js";
+import { prisma } from "../src/lib/prisma.js";
+import type { DecisionItemWithDetail } from "../src/lib/decision-item-serialization.js";
+
+const mockMembershipFindUnique = vi.mocked(
+  prisma.organizationMembership.findUnique,
+);
+const mockMembershipFindMany = vi.mocked(
+  prisma.organizationMembership.findMany,
+);
+const mockMeetingFindUnique = vi.mocked(prisma.meeting.findUnique);
+const mockDecisionItemFindUnique = vi.mocked(prisma.decisionItem.findUnique);
+const mockDecisionItemFindMany = vi.mocked(prisma.decisionItem.findMany);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+function membership(role: "owner" | "admin" | "member" = "member") {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    role,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+}
+
+// requireMeetingAccess で返す meeting モック。
+function mockMeeting() {
+  return {
+    id: "mtg-1",
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  };
+}
+
+// requireDecisionItemAccess で返す DecisionItem モック（select 形式）。
+function mockDecisionItemRaw(overrides = {}) {
+  return {
+    id: "di-1",
+    status: "open" as const,
+    meetingId: "mtg-1",
+    meeting: { recurringMeeting: { organizationId: "org-1" } },
+    ...overrides,
+  };
+}
+
+const sampleDecisionItem: DecisionItemWithDetail = {
+  id: "di-1",
+  meetingId: "mtg-1",
+  title: "AI 導入を承認する",
+  body: null,
+  sourceQuote: null,
+  sourceContext: null,
+  status: "open",
+  decisionState: null,
+  reason: null,
+  blockingItemId: null,
+  recurrenceCount: null,
+  ambiguityFlags: null,
+  decisionDeadline: null,
+  plannedMeetingId: null,
+  decidedAt: null,
+  decidedBy: null,
+  version: 0,
+  createdAt: new Date("2026-05-17T00:00:00Z"),
+  updatedAt: new Date("2026-05-17T00:00:00Z"),
+  assignees: [],
+};
+
+// ──────────────────────────────────────────────
+// GET /meetings/:id/decision-items
+// ──────────────────────────────────────────────
+describe("GET /meetings/:id/decision-items", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは 200 でリストを取得できる", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockDecisionItemFindMany.mockResolvedValue([
+      sampleDecisionItem,
+    ] as never);
+
+    const res = await app.request("/meetings/mtg-1/decision-items");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string }[];
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("di-1");
+  });
+
+  it("status フィルタで絞り込める", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockDecisionItemFindMany.mockResolvedValue([] as never);
+
+    const res = await app.request(
+      "/meetings/mtg-1/decision-items?status=decided",
+    );
+    expect(res.status).toBe(200);
+    expect(mockDecisionItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["decided"] },
+          meetingId: "mtg-1",
+        }),
+      }),
+    );
+  });
+
+  it("不正な status 値は 400", async () => {
+    const res = await app.request(
+      "/meetings/mtg-1/decision-items?status=invalid",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("会議が存在しない場合は 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/decision-items");
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属は 404", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/decision-items");
+    expect(res.status).toBe(404);
+  });
+
+  it("担当者の user 情報が平坦化される", async () => {
+    mockMeetingFindUnique.mockResolvedValue(mockMeeting() as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockDecisionItemFindMany.mockResolvedValue([
+      {
+        ...sampleDecisionItem,
+        assignees: [
+          {
+            user: { id: "user-1", name: "alice", displayName: "alice" },
+          },
+        ],
+      },
+    ] as never);
+
+    const res = await app.request("/meetings/mtg-1/decision-items");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      assignees: { id: string }[];
+    }[];
+    expect(body[0].assignees).toHaveLength(1);
+    expect(body[0].assignees[0].id).toBe("user-1");
+  });
+});
+
+// ──────────────────────────────────────────────
+// PATCH /decision-items/:id
+// ──────────────────────────────────────────────
+describe("PATCH /decision-items/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("title 更新が 200 を返す", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi
+            .fn()
+            .mockResolvedValue({ ...sampleDecisionItem, title: "更新後" }),
+        },
+        decisionItemAssignee: {
+          deleteMany: vi.fn(),
+          createMany: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { title: string };
+    expect(body.title).toBe("更新後");
+  });
+
+  it("version 不一致は 409", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+        decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 99, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("status=decided のとき decidedBy / decidedAt が自動設定される", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw({ status: "open" }) as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    let capturedData: Record<string, unknown> | undefined;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockImplementation(({ data }) => {
+            capturedData = data;
+            return Promise.resolve({ count: 1 });
+          }),
+          findUniqueOrThrow: vi
+            .fn()
+            .mockResolvedValue({ ...sampleDecisionItem, status: "decided" }),
+        },
+        decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "decided" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedData?.decidedBy).toBe("user-1");
+    expect(capturedData?.decidedAt).toBeInstanceOf(Date);
+  });
+
+  it("decided → open にすると decidedBy / decidedAt がクリアされる", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw({ status: "decided" }) as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    let capturedData: Record<string, unknown> | undefined;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockImplementation(({ data }) => {
+            capturedData = data;
+            return Promise.resolve({ count: 1 });
+          }),
+          findUniqueOrThrow: vi
+            .fn()
+            .mockResolvedValue({ ...sampleDecisionItem, status: "open" }),
+        },
+        decisionItemAssignee: { deleteMany: vi.fn(), createMany: vi.fn() },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "open" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedData?.decidedBy).toBeNull();
+    expect(capturedData?.decidedAt).toBeNull();
+  });
+
+  it("status=draft は 400（AI 専用なので手動 PATCH で受け付けない）", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("全フィールド未指定の更新は 400", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("version 欠落は 400", async () => {
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "更新後" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("決定事項が存在しない場合は 404", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(null);
+    const res = await app.request("/decision-items/missing", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("組織非所属は 404", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("assigneeUserIds に他組織のメンバーが混在する場合は 400", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    // 2 名指定したが 1 名しか組織メンバーとして見つからない
+    mockMembershipFindMany.mockResolvedValue([membership()] as never);
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        version: 0,
+        assigneeUserIds: ["user-1", "user-outside"],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("assigneeUserIds:[] は全削除を行う", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    let deletedAssignees = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue(sampleDecisionItem),
+        },
+        decisionItemAssignee: {
+          deleteMany: vi.fn(() => {
+            deletedAssignees = true;
+            return Promise.resolve({ count: 0 });
+          }),
+          createMany: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, assigneeUserIds: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deletedAssignees).toBe(true);
+  });
+
+  it("assigneeUserIds が未指定のとき担当者テーブルは変更しない", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw() as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+
+    let calledDeleteMany = false;
+    mockTransaction.mockImplementation(async (fn) => {
+      const tx = {
+        decisionItem: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue(sampleDecisionItem),
+        },
+        decisionItemAssignee: {
+          deleteMany: vi.fn(() => {
+            calledDeleteMany = true;
+            return Promise.resolve({ count: 0 });
+          }),
+          createMany: vi.fn(),
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: テスト用 tx スタブ
+      return await (fn as (t: any) => Promise<unknown>)(tx);
+    });
+
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, title: "更新後" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calledDeleteMany).toBe(false);
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #301 
Closes #299 

 ## 概要・目的

  - DecisionItem（決定事項）と AmbiguousInfo（曖昧情報）の一覧取得・更新 API を追加した
  - フロントエンドが AI 解析結果を表示・編集するために必要なエンドポイントが未実装だったため対応する

 ## 背景

  - AI 解析完了後、DecisionItem / AmbiguousInfo は DB に保存されるようになった（#299）が、それらを取得・更新する API
  がなかった
  - タスクの CRUD（PR #289）と同等の設計で実装し、一貫性を保つ

  ## 変更内容

  - GET /meetings/:id/decision-items — 会議に紐づく決定事項一覧（status フィルタ対応）
  - GET /meetings/:id/ambiguous-infos — 会議に紐づく曖昧情報一覧（status フィルタ対応）
  - PATCH /decision-items/:id — 決定事項の更新（楽観的ロック、担当者置換、status=decided 時に decidedBy / decidedAt
  を自動設定）
  - PATCH /ambiguous-infos/:id — 曖昧情報の更新（楽観的ロック、resolvedToTaskId / resolvedToDecisionItemId
  は同一会議内のアイテムのみ許可）
  - 手動変更可能なステータス値から draft / reviewing（AI 専用）を除外

 ## 動作確認手順

  1. docker compose up でサービスを起動し、make migrate でマイグレーションを適用する
  2. fake-auth からトークンを取得し、組織・定例・会議を作成してテストデータを用意する
  3. GET /meetings/:id/decision-items?status=open でフィルタが効いていること、PATCH /decision-items/:id に
  {"version":0,"status":"decided"} を送って decidedBy / decidedAt が自動セットされることを確認する

  GET /meetings/:id/decision-items レスポンス例
  [
    {
      "id": "di-xxx",
      "meetingId": "mtg-xxx",
      "title": "AI 導入の承認",
      "status": "open",
      "assignees": [],
      "version": 0
    }
  ]

  PATCH /decision-items/:id — status=decided 時
  // リクエスト
  { "version": 0, "status": "decided" }

  // レスポンス
  {
    "id": "di-xxx",
    "status": "decided",
    "decidedBy": "user-xxx",
    "decidedAt": "2026-05-24T10:00:00.000Z",
    "version": 1
  }