### PR TITLE
fix(api): PATCH /result に終端状態ガードを追加しcompleted→failedの上書きを防ぐ

### DIFF
--- a/apps/api/src/routes/analysis-runs.ts
+++ b/apps/api/src/routes/analysis-runs.ts
@@ -134,10 +134,19 @@ export const analysisRunsRoute = new Hono()
       if (data.error_message !== undefined)
         updateData.errorMessage = data.error_message;
 
-      const updated = await prisma.meetingAnalysisRun.update({
-        where: { id },
+      // 終端状態でない場合のみ更新する（CAS方式で並行競合を防ぐ）
+      await prisma.meetingAnalysisRun.updateMany({
+        where: {
+          id,
+          status: { notIn: ["completed", "failed"] },
+        },
         data: updateData,
       });
-      return c.json(updated);
+
+      // 最新状態を取得して返す（更新件数0の場合も現状をそのまま返し冪等を保証）
+      const currentRun = await prisma.meetingAnalysisRun.findUnique({
+        where: { id },
+      });
+      return c.json(currentRun);
     },
   );

--- a/apps/api/test/analysis-runs.test.ts
+++ b/apps/api/test/analysis-runs.test.ts
@@ -6,7 +6,7 @@ vi.mock("../src/lib/prisma.js", () => ({
     meetingAnalysisRun: {
       findUnique: vi.fn(),
       findFirst: vi.fn(),
-      update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
 }));
@@ -17,7 +17,7 @@ import { prisma } from "../src/lib/prisma.js";
 
 const mockRunFindUnique = vi.mocked(prisma.meetingAnalysisRun.findUnique);
 const mockRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
-const mockRunUpdate = vi.mocked(prisma.meetingAnalysisRun.update);
+const mockRunUpdateMany = vi.mocked(prisma.meetingAnalysisRun.updateMany);
 
 const SECRET = "test-secret";
 const AUTH_HEADER = { "x-internal-secret": SECRET };
@@ -197,13 +197,16 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
   } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>;
 
   it("completed ステータスで解析結果を保存できる", async () => {
-    mockRunFindUnique.mockResolvedValue(existingRun);
-    mockRunUpdate.mockResolvedValue({
+    const updatedRun = {
       ...existingRun,
       status: "completed",
       summary: "解析サマリー",
       alertLevel: "low",
-    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>);
+    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>;
+    mockRunFindUnique
+      .mockResolvedValueOnce(existingRun) // 1回目：404チェック
+      .mockResolvedValueOnce(updatedRun); // 2回目：更新後の再取得
+    mockRunUpdateMany.mockResolvedValue({ count: 1 });
 
     const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
@@ -217,9 +220,9 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
       }),
     });
     expect(res.status).toBe(200);
-    expect(mockRunUpdate).toHaveBeenCalledWith(
+    expect(mockRunUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "run-1" },
+        where: { id: "run-1", status: { notIn: ["completed", "failed"] } },
         data: expect.objectContaining({
           status: "completed",
           summary: "解析サマリー",
@@ -232,12 +235,15 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
   });
 
   it("failed ステータスでエラー情報を保存できる", async () => {
-    mockRunFindUnique.mockResolvedValue(existingRun);
-    mockRunUpdate.mockResolvedValue({
+    const updatedRun = {
       ...existingRun,
       status: "failed",
       errorMessage: "解析エラー",
-    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>);
+    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>;
+    mockRunFindUnique
+      .mockResolvedValueOnce(existingRun)
+      .mockResolvedValueOnce(updatedRun);
+    mockRunUpdateMany.mockResolvedValue({ count: 1 });
 
     const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
@@ -250,7 +256,7 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
       }),
     });
     expect(res.status).toBe(200);
-    expect(mockRunUpdate).toHaveBeenCalledWith(
+    expect(mockRunUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           status: "failed",
@@ -262,6 +268,71 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
     );
   });
 
+  it("すでに completed 状態のrunは更新せずに現状を返す", async () => {
+    const completedRun = {
+      ...existingRun,
+      status: "completed",
+      summary: "既存サマリー",
+      alertLevel: "high",
+    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>;
+    mockRunFindUnique
+      .mockResolvedValueOnce(completedRun) // 1回目：404チェック
+      .mockResolvedValueOnce(completedRun); // 2回目：再取得（更新なし）
+    mockRunUpdateMany.mockResolvedValue({ count: 0 });
+
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+      body: JSON.stringify({ status: "failed", error_message: "再配送エラー" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      summary: string;
+      errorMessage: null;
+    };
+    expect(body.status).toBe("completed");
+    expect(body.summary).toBe("既存サマリー");
+    expect(body.errorMessage).toBeNull(); // リクエストの値で上書きされていない
+    expect(mockRunUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "run-1", status: { notIn: ["completed", "failed"] } },
+      }),
+    );
+  });
+
+  it("すでに failed 状態のrunは更新せずに現状を返す", async () => {
+    const failedRun = {
+      ...existingRun,
+      status: "failed",
+      errorMessage: "元のエラー",
+    } as Prisma.MeetingAnalysisRunGetPayload<Record<string, never>>;
+    mockRunFindUnique
+      .mockResolvedValueOnce(failedRun)
+      .mockResolvedValueOnce(failedRun);
+    mockRunUpdateMany.mockResolvedValue({ count: 0 });
+
+    const res = await app.request("/internal/analysis-runs/run-1/result", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+      body: JSON.stringify({ status: "completed", summary: "上書き試み" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      summary: null;
+      errorMessage: string;
+    };
+    expect(body.status).toBe("failed");
+    expect(body.errorMessage).toBe("元のエラー");
+    expect(body.summary).toBeNull(); // リクエストの値で上書きされていない
+    expect(mockRunUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "run-1", status: { notIn: ["completed", "failed"] } },
+      }),
+    );
+  });
+
   it("不正な status は 400", async () => {
     const res = await app.request("/internal/analysis-runs/run-1/result", {
       method: "PATCH",
@@ -269,7 +340,7 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
       body: JSON.stringify({ status: "queued" }),
     });
     expect(res.status).toBe(400);
-    expect(mockRunUpdate).not.toHaveBeenCalled();
+    expect(mockRunUpdateMany).not.toHaveBeenCalled();
   });
 
   it("存在しない解析ランは 404", async () => {
@@ -280,7 +351,7 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
       body: JSON.stringify({ status: "completed" }),
     });
     expect(res.status).toBe(404);
-    expect(mockRunUpdate).not.toHaveBeenCalled();
+    expect(mockRunUpdateMany).not.toHaveBeenCalled();
   });
 
   it("認証ヘッダなしは 401", async () => {
@@ -290,6 +361,6 @@ describe("PATCH /internal/analysis-runs/:id/result", () => {
       body: JSON.stringify({ status: "completed" }),
     });
     expect(res.status).toBe(401);
-    expect(mockRunUpdate).not.toHaveBeenCalled();
+    expect(mockRunUpdateMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #292

## 概要・目的
* `PATCH /internal/analysis-runs/:id/result` に終端状態ガードを追加し、`completed` 状態のrunが `failed` に上書きされる問題を修正する
* Service Busの再配送や並行競合が発生した場合でも、一度終端状態に達したrunは変更されないことを保証する

## 背景
* `complete_analysis_run()` が成功してDBが `completed` になった後、`update_analysis_run_result()` が失敗するとService Busが再配送する
* 再配送時に `analyze_meeting()` が失敗すると `status="failed"` をPATCHし、`completed` なrunが `failed` に上書きされる
* この状態不整合により、成果物（`reportJson` 等）は存在するのにステータスが `failed` になるケースが生じていた

## 変更内容
* `apps/api/src/routes/analysis-runs.ts`：`prisma.update` を `prisma.updateMany` に変更し、`where` に `status: { notIn: ["completed", "failed"] }` を追加するCAS方式を採用。更新後は `findUnique` で最新状態を取得して返す（更新件数0＝終端状態の場合も冪等にそのまま返す）
* `apps/api/test/analysis-runs.test.ts`：モックを `updateMany` に差し替え、終端状態テスト2件を追加（既存フィールドが保持されリクエスト値で上書きされないことを検証）

## 動作確認手順
1. `apps/api` でテストを実行し全件パスすることを確認する
```bash
cd apps/api && npx vitest run test/analysis-runs.test.ts
```
2. `completed` 状態のrunに対して `PATCH /internal/analysis-runs/:id/result` を送信し、ステータスが変わらないことを確認する
3. `failed` 状態のrunに対して同様に確認する

## スクリーンショット
`completed` → `failed` 上書き試みのレスポンス例（変更前は `failed` に書き換わっていた）

```
PATCH /internal/analysis-runs/run-1/result
{ "status": "failed", "error_message": "再配送エラー" }

→ 200 OK
{ "id": "run-1", "status": "completed", ... }  # 変更されない
```