### PR TITLE
refactor: decisions/open_issues のフィールド名を topic/content から title/body に統一する

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,9 @@
       "Bash(node *)",
       "Bash(npx prisma *)",
       "Bash(npx vitest *)",
-      "Bash(gh issue *)"
+      "Bash(gh issue *)",
+      "Bash(.venv/bin/python -m pytest tests/test_analyze_pipeline.py tests/test_handle_message.py -v)",
+      "Bash(.venv/bin/python *)"
     ]
   }
 }

--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -1,4 +1,5 @@
 """メイン会議解析パイプライン（Call 1〜6）。"""
+
 import hashlib
 import json
 import logging
@@ -76,9 +77,9 @@ def _calc_input_hash(job: AnalysisJobInput) -> str:
         "transcript": job.transcript,
         "meeting_date": job.meeting_date,
     }
-    return hashlib.sha256(
-        json.dumps(payload, ensure_ascii=False).encode()
-    ).hexdigest()[:16]
+    return hashlib.sha256(json.dumps(payload, ensure_ascii=False).encode()).hexdigest()[
+        :16
+    ]
 
 
 def _assemble(
@@ -99,12 +100,8 @@ def _assemble(
     alert_level = calc_alert_level(estimation)
 
     # 次回持ち越し対象を handover セクションにまとめる
-    handover_open_issues = [
-        o for o in open_issues if o.get("status") == "open"
-    ]
-    handover_tasks = [
-        t for t in tasks if t.get("status") not in {"done", "rejected"}
-    ]
+    handover_open_issues = [o for o in open_issues if o.get("status") == "open"]
+    handover_tasks = [t for t in tasks if t.get("status") not in {"done", "rejected"}]
 
     return {
         "meta": {
@@ -178,9 +175,7 @@ async def analyze_meeting(
         logger.info("[call1] キーワード抽出完了: %d件", len(keywords))
 
         # ── RAG検索① ──────────────────────────────────────────
-        rag_retrieval = build_mock_rag_retrieval(
-            job.recurring_meeting_id, keywords
-        )
+        rag_retrieval = build_mock_rag_retrieval(job.recurring_meeting_id, keywords)
         rag_context = rag_retrieval["rag_context_for_prompt"]
 
         # ── Call 2: 決定事項・未決事項抽出 ───────────────────────
@@ -314,16 +309,12 @@ async def analyze_meeting(
         rag_retrieval["used_in_calls"] = list(
             rag_retrieval.get("used_in_calls", [])
         ) + ["call6"]
-        suggested_participants = build_suggested_participants_context(
-            rag_retrieval
-        )
+        suggested_participants = build_suggested_participants_context(rag_retrieval)
 
         # ── Call 6: サマリー・推奨アジェンダ生成 ─────────────────
         change_summary: str | None = None
         if job.previous_report_json:
-            change_summary = prepare_change_summary_for_call6(
-                job.previous_report_json
-            )
+            change_summary = prepare_change_summary_for_call6(job.previous_report_json)
 
         prompt6 = build_call6_prompt(
             prompts,
@@ -450,18 +441,19 @@ def _fmt_estimation_note(estimation: dict) -> str:
     return "\n".join(lines)
 
 
-def _inherit_recurrence_counts(
-    new_issues: list[dict], prev_issues: list[dict]
-) -> None:
+def _inherit_recurrence_counts(new_issues: list[dict], prev_issues: list[dict]) -> None:
     """前回の未決事項と一致するものに recurrence_count を引き継ぐ。"""
     from .postprocess import normalize_for_similarity
 
     for ni in new_issues:
-        norm_new = normalize_for_similarity(ni.get("topic", ""))
+        norm_new = normalize_for_similarity(ni.get("title", ""))
         for pi in prev_issues:
-            norm_prev = normalize_for_similarity(pi.get("topic", ""))
-            if norm_new and norm_prev and (
-                norm_new in norm_prev or norm_prev in norm_new
+            # 旧DB形式（topic）との後方互換のためフォールバックを保持
+            norm_prev = normalize_for_similarity(pi.get("title") or pi.get("topic", ""))
+            if (
+                norm_new
+                and norm_prev
+                and (norm_new in norm_prev or norm_prev in norm_new)
             ):
                 prev_count = pi.get("recurrence_count", 1)
                 ni["recurrence_count"] = prev_count + 1
@@ -470,9 +462,7 @@ def _inherit_recurrence_counts(
             ni.setdefault("recurrence_count", 1)
 
 
-def _inherit_carried_over_counts(
-    new_tasks: list[dict], prev_tasks: list[dict]
-) -> None:
+def _inherit_carried_over_counts(new_tasks: list[dict], prev_tasks: list[dict]) -> None:
     """前回のタスクと一致するものに carried_over_count を引き継ぐ。"""
     from .postprocess import normalize_for_similarity
 
@@ -480,8 +470,10 @@ def _inherit_carried_over_counts(
         norm_new = normalize_for_similarity(nt.get("title", ""))
         for pt in prev_tasks:
             norm_prev = normalize_for_similarity(pt.get("title", ""))
-            if norm_new and norm_prev and (
-                norm_new in norm_prev or norm_prev in norm_new
+            if (
+                norm_new
+                and norm_prev
+                and (norm_new in norm_prev or norm_prev in norm_new)
             ):
                 prev_count = pt.get("carried_over_count", 0)
                 nt["carried_over_count"] = prev_count + 1

--- a/services/ai/pipeline/complete_payload.py
+++ b/services/ai/pipeline/complete_payload.py
@@ -9,8 +9,8 @@ def build_complete_payload(result: AnalysisRunResult) -> dict:
 
     decision_items = [
         {
-            "title": d.get("topic", ""),
-            "body": d.get("content") or d.get("body"),
+            "title": d.get("title", ""),
+            "body": d.get("body"),
             "source_quote": d.get("source_quote"),
             "source_context": d.get("source_context"),
             "decision_state": d.get("decision_state"),
@@ -19,8 +19,8 @@ def build_complete_payload(result: AnalysisRunResult) -> dict:
         for d in report_json.get("decisions", [])
     ] + [
         {
-            "title": o.get("topic", ""),
-            "body": o.get("body") or o.get("content"),
+            "title": o.get("title", ""),
+            "body": o.get("body"),
             "source_quote": o.get("source_quote"),
             "source_context": o.get("source_context"),
             "decision_state": "open",

--- a/services/ai/pipeline/continuity.py
+++ b/services/ai/pipeline/continuity.py
@@ -6,9 +6,7 @@ def prepare_prev_open_issues_for_call2(previous_report_json: dict) -> list:
     resolved_aiは人間未確認のため持ち越しを継続する。
     """
     open_issues = previous_report_json.get("open_issues", [])
-    return [
-        o for o in open_issues if o.get("status") != "resolved_human"
-    ]
+    return [o for o in open_issues if o.get("status") != "resolved_human"]
 
 
 def prepare_prev_tasks_for_call3(previous_report_json: dict) -> list:
@@ -16,9 +14,7 @@ def prepare_prev_tasks_for_call3(previous_report_json: dict) -> list:
     各タスクにn番号を付与してから返す。
     """
     tasks = previous_report_json.get("tasks", [])
-    incomplete = [
-        t for t in tasks if t.get("status") not in {"done", "rejected"}
-    ]
+    incomplete = [t for t in tasks if t.get("status") not in {"done", "rejected"}]
     for i, t in enumerate(incomplete, 1):
         t["n"] = i
     return incomplete
@@ -34,9 +30,7 @@ def fmt_change_summary(
     """Call 6に渡す「前回からの変化サマリー」テキストを生成する。"""
     parts = []
     if completed_tasks:
-        titles = "、".join(
-            t.get("title", "") for t in completed_tasks[:3]
-        )
+        titles = "、".join(t.get("title", "") for t in completed_tasks[:3])
         suffix = (
             f"（他{len(completed_tasks) - 3}件）" if len(completed_tasks) > 3 else ""
         )
@@ -44,13 +38,17 @@ def fmt_change_summary(
     if carried_over_tasks:
         parts.append(f"⏩ 持ち越しタスク: {len(carried_over_tasks)}件")
     if resolved_issues:
-        topics = "、".join(o.get("topic", "") for o in resolved_issues[:3])
+        # 旧DB形式（topic）との後方互換のためフォールバックを保持
+        topics = "、".join(
+            o.get("title") or o.get("topic", "") for o in resolved_issues[:3]
+        )
         parts.append(f"✅ 解決した未決事項: {topics}")
     if carried_over_issues:
         parts.append(f"⏩ 持ち越し未決事項: {len(carried_over_issues)}件")
     if high_recurrence_issues:
+        # 旧DB形式（topic）との後方互換のためフォールバックを保持
         topics = "、".join(
-            o.get("topic", "") for o in high_recurrence_issues
+            o.get("title") or o.get("topic", "") for o in high_recurrence_issues
         )
         parts.append(f"⚠️ 3回以上継続している未決事項: {topics}")
     return "\n".join(parts) if parts else "(前回との変化なし)"
@@ -61,15 +59,11 @@ def prepare_change_summary_for_call6(previous_report_json: dict) -> str:
     tasks = previous_report_json.get("tasks", [])
     open_issues = previous_report_json.get("open_issues", [])
 
-    completed_tasks = [
-        t for t in tasks if t.get("status") in {"done", "rejected"}
-    ]
+    completed_tasks = [t for t in tasks if t.get("status") in {"done", "rejected"}]
     carried_over_tasks = [
         t for t in tasks if t.get("status") not in {"done", "rejected"}
     ]
-    resolved_issues = [
-        o for o in open_issues if o.get("status") == "resolved_human"
-    ]
+    resolved_issues = [o for o in open_issues if o.get("status") == "resolved_human"]
     carried_over_issues = [
         o for o in open_issues if o.get("status") != "resolved_human"
     ]

--- a/services/ai/pipeline/estimation.py
+++ b/services/ai/pipeline/estimation.py
@@ -21,9 +21,7 @@ def calc_estimation(
 
     # 新規未決事項の議論（5分/件）、再発未決事項（8分/件）
     new_issues = [o for o in open_issues if o.get("recurrence_count", 1) == 1]
-    recurring_issues = [
-        o for o in open_issues if o.get("recurrence_count", 1) >= 2
-    ]
+    recurring_issues = [o for o in open_issues if o.get("recurrence_count", 1) >= 2]
     if new_issues:
         breakdown["open_issue_new"] = {
             "count": len(new_issues),
@@ -44,9 +42,7 @@ def calc_estimation(
         }
 
     # 仮決定の再確認（5分/件）
-    tentative = [
-        d for d in decisions if d.get("decision_state") == "tentative"
-    ]
+    tentative = [d for d in decisions if d.get("decision_state") == "tentative"]
     if tentative:
         breakdown["tentative_reconfirm"] = {
             "count": len(tentative),

--- a/services/ai/pipeline/postprocess.py
+++ b/services/ai/pipeline/postprocess.py
@@ -1,20 +1,21 @@
 """後処理関数群。絵文字除去・担当者解決・ID採番など。"""
+
 import re
 import unicodedata
 
 _EMOJI_PATTERN = re.compile(
     "["
-    "\U0001F600-\U0001F64F"   # Emoticons
-    "\U0001F300-\U0001F5FF"   # Misc Symbols and Pictographs
-    "\U0001F680-\U0001F6FF"   # Transport and Map
-    "\U0001F1E0-\U0001F1FF"   # Flags
-    "\U0001F900-\U0001F9FF"   # Supplemental Symbols and Pictographs
-    "\U0001FA00-\U0001FA6F"   # Chess Symbols
-    "\U0001FA70-\U0001FAFF"   # Symbols and Pictographs Extended-A
-    "☀-⛿"           # Miscellaneous Symbols
-    "✀-➿"           # Dingbats
-    "︀-️"           # Variation Selectors
-    "‍"                   # Zero Width Joiner
+    "\U0001f600-\U0001f64f"  # Emoticons
+    "\U0001f300-\U0001f5ff"  # Misc Symbols and Pictographs
+    "\U0001f680-\U0001f6ff"  # Transport and Map
+    "\U0001f1e0-\U0001f1ff"  # Flags
+    "\U0001f900-\U0001f9ff"  # Supplemental Symbols and Pictographs
+    "\U0001fa00-\U0001fa6f"  # Chess Symbols
+    "\U0001fa70-\U0001faff"  # Symbols and Pictographs Extended-A
+    "☀-⛿"  # Miscellaneous Symbols
+    "✀-➿"  # Dingbats
+    "︀-️"  # Variation Selectors
+    "‍"  # Zero Width Joiner
     "]+",
     flags=re.UNICODE,
 )
@@ -105,9 +106,7 @@ def apply_due_date_conversions(
 ) -> list[dict]:
     """Call 5の変換結果をタスクのdue_dateフィールドに適用する。"""
     conversion_map = {
-        c["original"]: c.get("resolved")
-        for c in conversions
-        if c.get("original")
+        c["original"]: c.get("resolved") for c in conversions if c.get("original")
     }
     for task in tasks:
         raw = task.get("due_date_raw")

--- a/services/ai/pipeline/prompt_builders.py
+++ b/services/ai/pipeline/prompt_builders.py
@@ -1,4 +1,5 @@
 """プロンプト構築関数群。各Callに渡すプロンプトを組み立てる。"""
+
 from string import Template
 
 
@@ -30,10 +31,10 @@ def fmt_open_issues(open_issues: list[dict]) -> str:
         return "(なし)"
     lines = []
     for i, issue in enumerate(open_issues, 1):
-        topic = issue.get("topic", "")
+        title = issue.get("title", "")
         reason = issue.get("reason", "")
         status = issue.get("status", "open")
-        lines.append(f"{i}. [{status}] {topic}（理由: {reason}）")
+        lines.append(f"{i}. [{status}] {title}（理由: {reason}）")
     return "\n".join(lines)
 
 
@@ -48,17 +49,17 @@ def fmt_context_all(
     if decisions:
         parts.append("【決定事項】")
         for i, d in enumerate(decisions, 1):
-            topic = d.get("topic", "")
+            title = d.get("title", "")
             state = d.get("decision_state", "")
-            content = d.get("content", "")
-            parts.append(f"  D{i}. [{state}] {topic}: {content}")
+            body = d.get("body", "")
+            parts.append(f"  D{i}. [{state}] {title}: {body}")
 
     if open_issues:
         parts.append("【未決事項】")
         for i, o in enumerate(open_issues, 1):
-            topic = o.get("topic", "")
+            title = o.get("title", "")
             reason = o.get("reason", "")
-            parts.append(f"  OI{i}. {topic}（{reason}）")
+            parts.append(f"  OI{i}. {title}（{reason}）")
 
     if tasks:
         parts.append("【タスク】")
@@ -87,12 +88,11 @@ def fmt_prev_open_issues(prev_open_issues: list[dict]) -> str:
         return "(なし)"
     lines = []
     for i, issue in enumerate(prev_open_issues, 1):
-        topic = issue.get("topic", "")
+        # 旧DB形式（topic）との後方互換のためフォールバックを保持
+        title = issue.get("title") or issue.get("topic", "")
         reason = issue.get("reason", "")
         rc = issue.get("recurrence_count", 1)
-        lines.append(
-            f"{i}. {topic}（理由: {reason}、継続回数: {rc}回）"
-        )
+        lines.append(f"{i}. {title}（理由: {reason}、継続回数: {rc}回）")
     return "\n".join(lines)
 
 
@@ -119,11 +119,11 @@ def fmt_decisions_for_call6(decisions: list[dict]) -> str:
         return "(なし)"
     lines = []
     for d in decisions:
-        topic = d.get("topic", "")
+        title = d.get("title", "")
         state = d.get("decision_state", "")
-        content = d.get("content", "")
+        body = d.get("body", "")
         item_id = d.get("id", "")
-        lines.append(f"- [{item_id}][{state}] {topic}: {content}")
+        lines.append(f"- [{item_id}][{state}] {title}: {body}")
     return "\n".join(lines)
 
 
@@ -133,14 +133,12 @@ def fmt_open_issues_for_call6(open_issues: list[dict]) -> str:
         return "(なし)"
     lines = []
     for o in open_issues:
-        topic = o.get("topic", "")
+        title = o.get("title", "")
         reason = o.get("reason", "")
         status = o.get("status", "open")
         item_id = o.get("id", "")
         rc = o.get("recurrence_count", 1)
-        lines.append(
-            f"- [{item_id}][{status}] {topic}（{reason}、{rc}回目）"
-        )
+        lines.append(f"- [{item_id}][{status}] {title}（{reason}、{rc}回目）")
     return "\n".join(lines)
 
 

--- a/services/ai/pipeline/validation.py
+++ b/services/ai/pipeline/validation.py
@@ -1,4 +1,5 @@
 """出力バリデーション関数群。"""
+
 import logging
 
 from .postprocess import normalize_for_similarity
@@ -7,8 +8,21 @@ logger = logging.getLogger(__name__)
 
 # タスクのdue_date_rawに含まれていると日付混入の疑いがある相対表現キーワード
 DATE_KEYWORDS = [
-    "月曜", "火曜", "水曜", "木曜", "金曜", "土曜", "日曜",
-    "来週", "今週", "先週", "来月", "今月", "今日", "明日", "明後日",
+    "月曜",
+    "火曜",
+    "水曜",
+    "木曜",
+    "金曜",
+    "土曜",
+    "日曜",
+    "来週",
+    "今週",
+    "先週",
+    "来月",
+    "今月",
+    "今日",
+    "明日",
+    "明後日",
 ]
 
 
@@ -37,9 +51,7 @@ def validate_outputs(
     for task in tasks:
         due_raw = task.get("due_date_raw") or ""
         if any(kw in due_raw for kw in DATE_KEYWORDS) and not task.get("due_date"):
-            logger.warning(
-                "期限変換漏れの疑い: %s -> %s", task.get("id", ""), due_raw
-            )
+            logger.warning("期限変換漏れの疑い: %s -> %s", task.get("id", ""), due_raw)
             warnings.append(
                 make_warning(
                     "unresolved_due_date",
@@ -60,16 +72,16 @@ def validate_outputs(
                 )
             )
 
-    # 決定事項のトピック重複を検出する
+    # 決定事項のタイトル重複を検出する
     seen_decisions: list[str] = []
     for d in decisions:
-        norm = normalize_for_similarity(d.get("topic", ""))
+        norm = normalize_for_similarity(d.get("title", ""))
         for seen in seen_decisions:
             if norm and seen and (norm in seen or seen in norm):
                 warnings.append(
                     make_warning(
                         "duplicate_decision",
-                        f"類似した決定事項が複数あります: '{d.get('topic', '')}'",
+                        f"類似した決定事項が複数あります: '{d.get('title', '')}'",
                         [d.get("id", "")],
                     )
                 )

--- a/services/ai/prompts/meeting_analysis_prompts.toml
+++ b/services/ai/prompts/meeting_analysis_prompts.toml
@@ -44,9 +44,9 @@ $transcript
 {
   "decisions": [
     {
-      "topic": "決定事項のトピック（30字以内）",
+      "title": "決定事項のタイトル（30字以内）",
       "decision_state": "confirmed",
-      "content": "決定内容の詳細",
+      "body": "決定内容の詳細",
       "source_quote": "書き起こしからの引用文（原文ママ）",
       "source_context": "前後の文脈説明",
       "status": "draft"
@@ -54,7 +54,7 @@ $transcript
   ],
   "open_issues": [
     {
-      "topic": "未決事項のトピック（30字以内）",
+      "title": "未決事項のタイトル（30字以内）",
       "reason": "no_consensus",
       "status": "open",
       "source_quote": "書き起こしからの引用文（原文ママ）",

--- a/services/ai/rag/indexer.py
+++ b/services/ai/rag/indexer.py
@@ -1,4 +1,5 @@
 """RAGインデックス登録インターフェース。初期実装はモック。"""
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -15,20 +16,14 @@ def build_rag_document(
     confirmed かつ rejected でない決定事項のテキストのみを含める。
     """
     confirmed_decision_texts = [
-        d.get("content", "")
+        d.get("body", "")
         for d in decisions
         if d.get("decision_state") == "confirmed" and d.get("status") != "rejected"
     ]
     open_issue_texts = [
-        o.get("topic", "")
-        for o in open_issues
-        if o.get("status") == "open"
+        o.get("title", "") for o in open_issues if o.get("status") == "open"
     ]
-    participant_names = [
-        s.get("name", "")
-        for s in speakers
-        if s.get("name")
-    ]
+    participant_names = [s.get("name", "") for s in speakers if s.get("name")]
 
     return {
         "theme_keywords": keywords,

--- a/services/ai/rag/search.py
+++ b/services/ai/rag/search.py
@@ -1,4 +1,5 @@
 """RAG検索インターフェース。初期実装はモック。"""
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/services/ai/tests/test_analyze_pipeline.py
+++ b/services/ai/tests/test_analyze_pipeline.py
@@ -1,4 +1,5 @@
 """パイプラインのユニットテスト。FakeLLMClientを使い、Azure OpenAI不要で動作する。"""
+
 import json
 
 import pytest
@@ -26,91 +27,98 @@ from schemas.analysis import AnalysisJobInput, SpeakerInfo
 
 # ──────────────────────── FakeLLMClient用フィクスチャ ─────────────────────────
 
+
 def _make_fake_responses() -> dict[str, str]:
     """各Callに対応するFakeレスポンスを返す。
     キーはFakeLLMClientが prompt に対して部分一致するユニーク文字列。
     各プロンプトテンプレートにある識別文字列を選ぶ。
     """
     call1_resp = json.dumps(["プロジェクトA", "予算", "期限", "設計書"])
-    call2_resp = json.dumps({
-        "decisions": [
-            {
-                "topic": "予算の増額",
-                "decision_state": "confirmed",
-                "content": "来期予算を10%増額する",
-                "source_quote": "予算は10%増やしましょう",
-                "source_context": "予算議題の後半",
-                "status": "draft",
-            }
-        ],
-        "open_issues": [
-            {
-                "topic": "設計書のレビュー担当",
-                "reason": "no_consensus",
-                "status": "open",
-                "source_quote": "設計書のレビューは誰がやる？",
-                "source_context": "タスク分担の議論",
-                "expected_resolution_date": None,
-                "responsible_raw": None,
-            }
-        ],
-    })
-    call3_resp = json.dumps({
-        "tasks": [
-            {
-                "title": "設計書の更新",
-                "body": "最新仕様を反映する",
-                "assignee_raw": "田中",
-                "due_date_raw": "来週金曜",
-                "priority": "required",
-                "assignee_source": "explicit_mention",
-                "source_quote": "田中さん、設計書お願いします",
-                "source_context": "タスク分担",
-                "status": "draft",
-            }
-        ],
-        "progress_notes": [],
-    })
+    call2_resp = json.dumps(
+        {
+            "decisions": [
+                {
+                    "title": "予算の増額",
+                    "decision_state": "confirmed",
+                    "body": "来期予算を10%増額する",
+                    "source_quote": "予算は10%増やしましょう",
+                    "source_context": "予算議題の後半",
+                    "status": "draft",
+                }
+            ],
+            "open_issues": [
+                {
+                    "title": "設計書のレビュー担当",
+                    "reason": "no_consensus",
+                    "status": "open",
+                    "source_quote": "設計書のレビューは誰がやる？",
+                    "source_context": "タスク分担の議論",
+                    "expected_resolution_date": None,
+                    "responsible_raw": None,
+                }
+            ],
+        }
+    )
+    call3_resp = json.dumps(
+        {
+            "tasks": [
+                {
+                    "title": "設計書の更新",
+                    "body": "最新仕様を反映する",
+                    "assignee_raw": "田中",
+                    "due_date_raw": "来週金曜",
+                    "priority": "required",
+                    "assignee_source": "explicit_mention",
+                    "source_quote": "田中さん、設計書お願いします",
+                    "source_context": "タスク分担",
+                    "status": "draft",
+                }
+            ],
+            "progress_notes": [],
+        }
+    )
     call4a_resp = json.dumps({"ambiguities_quality": []})
-    call4b_resp = json.dumps({
-        "ambiguities_content": [
-            {
-                "ambiguity_type": "no_deadline_absolute",
-                "severity": "medium",
-                "body": "設計書更新の期限が相対表現のみ",
-                "source_quote": None,
-                "source_context": "タスク分担",
-                "inference_basis": "due_date_rawが相対表現",
-                "affected_item_ids": [],
-            }
-        ]
-    })
-    call5_resp = json.dumps({
-        "conversions": [
-            {"original": "来週金曜", "resolved": "2026-05-22"}
-        ]
-    })
-    call6_resp = json.dumps({
-        "summary": "予算増額が確定し、設計書更新タスクが発生した",
-        "recommended_agenda": [
-            {
-                "title": "設計書レビュー担当の確定",
-                "estimated_minutes": 5,
-                "reason": "未決事項の解消",
-            }
-        ],
-        "estimation_note": "次回会議の想定所要時間: 約20分",
-    })
+    call4b_resp = json.dumps(
+        {
+            "ambiguities_content": [
+                {
+                    "ambiguity_type": "no_deadline_absolute",
+                    "severity": "medium",
+                    "body": "設計書更新の期限が相対表現のみ",
+                    "source_quote": None,
+                    "source_context": "タスク分担",
+                    "inference_basis": "due_date_rawが相対表現",
+                    "affected_item_ids": [],
+                }
+            ]
+        }
+    )
+    call5_resp = json.dumps(
+        {"conversions": [{"original": "来週金曜", "resolved": "2026-05-22"}]}
+    )
+    call6_resp = json.dumps(
+        {
+            "summary": "予算増額が確定し、設計書更新タスクが発生した",
+            "recommended_agenda": [
+                {
+                    "title": "設計書レビュー担当の確定",
+                    "estimated_minutes": 5,
+                    "reason": "未決事項の解消",
+                }
+            ],
+            "estimation_note": "次回会議の想定所要時間: 約20分",
+        }
+    )
 
     # キーはプロンプトテンプレート内のユニークな部分文字列
     return {
-        "キーワードを抽出": call1_resp,            # call1
-        "決定事項と未決事項を抽出": call2_resp,   # call2
-        "タスクを抽出してください": call3_resp,   # call3
-        "書き起こし品質に起因する曖昧情報": call4a_resp,   # call4a
-        "会議内容に起因する曖昧情報": call4b_resp, # call4b
-        "絶対日付（YYYY-MM-DD）に変換": call5_resp,        # call5
-        "サマリーと推奨アジェンダを生成": call6_resp,      # call6
+        "キーワードを抽出": call1_resp,  # call1
+        "決定事項と未決事項を抽出": call2_resp,  # call2
+        "タスクを抽出してください": call3_resp,  # call3
+        "書き起こし品質に起因する曖昧情報": call4a_resp,  # call4a
+        "会議内容に起因する曖昧情報": call4b_resp,  # call4b
+        "絶対日付（YYYY-MM-DD）に変換": call5_resp,  # call5
+        "サマリーと推奨アジェンダを生成": call6_resp,  # call6
     }
 
 
@@ -139,6 +147,7 @@ def _make_job() -> AnalysisJobInput:
 
 # ──────────────────────── パイプライン縦断テスト ──────────────────────────────
 
+
 @pytest.mark.asyncio
 async def test_analyze_meeting_completed():
     """FakeLLMClientを使ったCall 1〜6の縦断テスト。"""
@@ -157,7 +166,7 @@ async def test_analyze_meeting_completed():
     assert report is not None
     assert "decisions" in report
     assert len(report["decisions"]) == 1
-    assert report["decisions"][0]["topic"] == "予算の増額"
+    assert report["decisions"][0]["title"] == "予算の増額"
 
     assert "tasks" in report
     assert len(report["tasks"]) == 1
@@ -285,16 +294,16 @@ def test_validate_outputs_no_warnings():
 def test_prepare_prev_open_issues_excludes_resolved_human():
     prev_json = {
         "open_issues": [
-            {"topic": "A", "status": "open"},
-            {"topic": "B", "status": "resolved_human"},
-            {"topic": "C", "status": "resolved_ai"},
+            {"title": "A", "status": "open"},
+            {"title": "B", "status": "resolved_human"},
+            {"title": "C", "status": "resolved_ai"},
         ]
     }
     result = prepare_prev_open_issues_for_call2(prev_json)
-    topics = [o["topic"] for o in result]
-    assert "A" in topics
-    assert "C" in topics
-    assert "B" not in topics
+    titles = [o["title"] for o in result]
+    assert "A" in titles
+    assert "C" in titles
+    assert "B" not in titles
 
 
 def test_prepare_prev_tasks_excludes_done_rejected():
@@ -321,8 +330,8 @@ def test_prepare_change_summary_for_call6():
             {"title": "継続タスク", "status": "todo"},
         ],
         "open_issues": [
-            {"topic": "解決済み", "status": "resolved_human", "recurrence_count": 1},
-            {"topic": "継続中", "status": "open", "recurrence_count": 4},
+            {"title": "解決済み", "status": "resolved_human", "recurrence_count": 1},
+            {"title": "継続中", "status": "open", "recurrence_count": 4},
         ],
     }
     summary = prepare_change_summary_for_call6(prev_json)

--- a/services/ai/tests/test_handle_message.py
+++ b/services/ai/tests/test_handle_message.py
@@ -26,8 +26,8 @@ _COMPLETED_RESULT = AnalysisRunResult(
     report_json={
         "decisions": [
             {
-                "topic": "決定事項A",
-                "content": "本文A",
+                "title": "決定事項A",
+                "body": "本文A",
                 "source_quote": "引用A",
                 "source_context": "文脈A",
                 "decision_state": "confirmed",
@@ -35,7 +35,7 @@ _COMPLETED_RESULT = AnalysisRunResult(
         ],
         "open_issues": [
             {
-                "topic": "未決事項B",
+                "title": "未決事項B",
                 "body": "詳細B",
                 "reason": "no_consensus",
                 "recurrence_count": 2,
@@ -205,11 +205,11 @@ def test_build_complete_payload_decision_items():
         status="completed",
         report_json={
             "decisions": [
-                {"topic": "決定A", "content": "本文A", "decision_state": "confirmed"}
+                {"title": "決定A", "body": "本文A", "decision_state": "confirmed"}
             ],
             "open_issues": [
                 {
-                    "topic": "未決B",
+                    "title": "未決B",
                     "reason": "no_consensus",
                     "recurrence_count": 1,
                     "expected_resolution_date": "2026-06-01",

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -53,9 +53,7 @@ async def test_lifespan_starts_consumer_when_env_set():
         _ENDPOINT_KEY: _ENDPOINT_VAL,
     }
     with patch.dict(os.environ, env):
-        with patch(
-            "main.ServiceBusConsumer", return_value=mock_consumer
-        ) as mock_cls:
+        with patch("main.ServiceBusConsumer", return_value=mock_consumer) as mock_cls:
             async with main.lifespan(main.app):
                 await asyncio.wait_for(started.wait(), timeout=1.0)
 


### PR DESCRIPTION
## 関連Issue
  Closes #296

  ## 概要・目的
  AIサービスの decisions / open_issues が LLM 出力として `topic` / `content` を返しており、`complete_payload.py` で
  `title` / `body` に変換する処理が挟まっていた。
  このバッファ変換を不要にするため、LLM へのプロンプト指示とパイプライン全体のフィールド名を `title` / `body`
  に統一した。

  ## 背景
  * PR #281 のレビューコメントで `topic`/`content` と `title`/`body` の混在が指摘されており、Issue #296
  としてトラッキングされていた
  * tasks / ambiguities はすでに `title` / `body` を使用しており、decisions / open_issues だけが旧形式のままだった

  ## 変更内容
  * `prompts/meeting_analysis_prompts.toml` — Call 2 の出力スキーマを `topic`→`title`、`content`→`body` に変更
  * `pipeline/complete_payload.py` — `topic`/`content` からの変換コードを削除し `title`/`body` を直読みに
  * `pipeline/prompt_builders.py` — 5関数の `topic`/`content` 参照を修正（`fmt_prev_open_issues`
  は旧DB形式との後方互換フォールバックあり）
  * `pipeline/analyze_meeting.py` — `_inherit_recurrence_counts` の新LLMデータは `title`
  に変更、前回DBデータはフォールバック付き
  * `pipeline/validation.py` — 重複検出の `topic` → `title`
  * `pipeline/continuity.py` — `fmt_change_summary` の2箇所を旧DB形式フォールバック付きで `title` に変更
  * `rag/indexer.py` — `content`→`body`、`topic`→`title`
  * `tests/test_analyze_pipeline.py`, `tests/test_handle_message.py` — フィクスチャ・アサーションを新形式に更新

  ## 動作確認手順
  1. `services/ai` ディレクトリで `uv run pytest` を実行し 59 件全パスを確認
  2. （任意）AIサービスをローカル起動し、`POST /analyze` を dry-run モードで呼び出して `report_json.decisions[*]` に
  `title` / `body` が含まれることを確認

  ## スクリーンショット
  API変更なし・UI変更なし。変換レイヤーの削除のみのため、`POST /internal/analysis-runs/:id/complete`
  のリクエスト／レスポンス形式に変化なし。