### PR TITLE
fix(web): スクロール時にサイドバーとトップバーを viewport 内に固定する

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -96,7 +96,7 @@ export function Sidebar() {
   return (
     <aside
       aria-label="サイドバー"
-      className="w-52 border-r border-border/50 bg-muted/30 flex flex-col shrink-0"
+      className="w-52 border-r border-border/50 bg-muted/30 flex flex-col shrink-0 overflow-y-auto"
     >
       <OrganizationSelector
         isLoading={isLoading}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -35,7 +35,7 @@ function RootLayout() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="h-screen flex flex-col bg-background">
       <Topbar />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />


### PR DESCRIPTION
## 関連Issue
Closes #307 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* ページコンテンツが長い場合にサイドバーとトップバーが一緒にスクロールしてしまう問題を修正する。
* スクロール時もサイドバー・トップバーを viewport 内に固定し、メインコンテンツ領域のみスクロールさせる。

## 背景
* ルートレイアウトのコンテナが `min-h-screen` のため、コンテンツ量に応じて高さが伸び、サイドバーも一緒にスクロールしていた
* サイドバー内のナビ項目が増えた場合に独立したスクロールができなかった

## 変更内容
* `__root.tsx`: `min-h-screen` → `h-screen` に変更し、コンテナを viewport 高さに固定
* `Sidebar.tsx`: `<aside>` に `overflow-y-auto` を追加してサイドバー内を独立スクロール可能に

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
1. `make dev` で起動
2. 定例やタスクを多数作成してメインコンテンツが画面外に伸びる状態にする
3. ページを下にスクロールし、トップバー・サイドバーが固定されたままであることを確認する
4. サイドバーのナビ項目が viewport を超える場合、サイドバー内だけで縦スクロールできることを確認する

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
 <img width="1470" height="739" alt="スクリーンショット 2026-05-26 13 52 25" src="https://github.com/user-attachments/assets/24c7f831-4d00-4031-8c9a-a3cca338c1e8" />
<img width="1470" height="738" alt="スクリーンショット 2026-05-26 13 52 42" src="https://github.com/user-attachments/assets/1aacb58d-fe85-4f62-92d2-2d632ce8b1d5" />

