### PR TITLE
fix(web): ダッシュボード次回会議の表示件数修正と一部デザイン修正

### DIFF
--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl border border-border/70 py-6 shadow-sm",
         className,
       )}
       {...props}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,8 +9,7 @@ import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ChevronRight } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Dashboard,
@@ -109,28 +108,6 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
   const isLoading = isRmLoading || meetingQueries.some((q) => q.isLoading);
   const isMeetingsError = meetingQueries.some((q) => q.isError);
 
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-  };
-
-  useEffect(() => {
-    updateScrollState();
-  });
-
-  const scroll = (dir: "left" | "right") => {
-    scrollRef.current?.scrollBy({
-      left: dir === "left" ? -272 : 272,
-      behavior: "smooth",
-    });
-  };
-
   if (isLoading) {
     return (
       <div
@@ -178,36 +155,8 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-muted-foreground">
-          次回会議
-        </h2>
-        <div className="flex gap-1">
-          <button
-            type="button"
-            onClick={() => scroll("left")}
-            disabled={!canScrollLeft}
-            aria-label="前へ"
-            className="p-1 rounded-md border text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:pointer-events-none transition-colors"
-          >
-            <ChevronLeft size={16} />
-          </button>
-          <button
-            type="button"
-            onClick={() => scroll("right")}
-            disabled={!canScrollRight}
-            aria-label="次へ"
-            className="p-1 rounded-md border text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:pointer-events-none transition-colors"
-          >
-            <ChevronRight size={16} />
-          </button>
-        </div>
-      </div>
-      <div
-        ref={scrollRef}
-        onScroll={updateScrollState}
-        className="flex gap-3 overflow-x-auto pb-1 snap-x snap-mandatory scrollbar-hide"
-      >
+      <h2 className="text-sm font-semibold text-muted-foreground">次回会議</h2>
+      <div className="flex gap-3 overflow-x-auto pb-1 snap-x snap-mandatory scrollbar-hide">
         {candidates.map((c) => (
           <NextMeetingCard
             key={c.recurringMeetingId}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,7 +9,7 @@ import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
-import { ChevronRight } from "lucide-react";
+import { ArrowRight, ChevronRight } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Dashboard,
@@ -182,17 +182,23 @@ const MOCK_REVIEW_ROWS: ReviewRow[] = [
 ];
 
 function ReviewPendingCard() {
+  const total = MOCK_REVIEW_ROWS.reduce((sum, r) => sum + r.count, 0);
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle>レビュー待ち</CardTitle>
-          <span className="text-sm text-muted-foreground font-normal">
-            {MOCK_REVIEW_ROWS.reduce((sum, r) => sum + r.count, 0)} 件
-          </span>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-0">
+    <Card className="gap-0 py-0 overflow-hidden">
+      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50">
+        <span className="text-sm font-semibold flex-1">レビュー待ち</span>
+        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+          {total}
+        </span>
+        {/* TODO: レビュー画面が実装されたらリンクに変更する */}
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowRight size={15} />
+        </button>
+      </div>
+      <div className="px-5 py-1">
         {MOCK_REVIEW_ROWS.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <p className="text-sm text-muted-foreground">
@@ -203,27 +209,16 @@ function ReviewPendingCard() {
           MOCK_REVIEW_ROWS.map((row) => (
             <div
               key={row.label}
-              className="flex items-center justify-between py-3 border-b border-border/80"
+              className="flex items-center justify-between py-3 border-b border-border/50 last:border-0"
             >
               <span className="text-sm">{row.label}</span>
-              <span className="flex items-center gap-1 text-sm text-destructive font-medium">
+              <span className="text-sm text-destructive font-medium">
                 {row.count} 件
-                <ChevronRight size={14} />
               </span>
             </div>
           ))
         )}
-        {/* TODO: レビュー画面が実装されたらリンクに変更する */}
-        <div className="flex justify-end pt-3">
-          <button
-            type="button"
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            レビューする
-            <ChevronRight size={14} />
-          </button>
-        </div>
-      </CardContent>
+      </div>
     </Card>
   );
 }
@@ -292,60 +287,55 @@ const URGENCY_STYLE: Record<
 
 function IncompleteTasksCard() {
   return (
-    <Card className="flex flex-col h-[470px]">
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle>未完了タスク</CardTitle>
-          <span className="text-sm text-muted-foreground font-normal">
-            {MOCK_TASKS.length} 件
-          </span>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col flex-1 overflow-hidden pb-3">
-        <div className="flex flex-col flex-1 overflow-y-auto divide-y divide-border/80">
-          {MOCK_TASKS.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center">
-              <p className="text-sm text-muted-foreground">
-                未完了のタスクはありません
-              </p>
-            </div>
-          ) : (
-            MOCK_TASKS.slice(0, 5).map((item, i) => {
-              const style = URGENCY_STYLE[item.urgency];
-              return (
-                // biome-ignore lint/suspicious/noArrayIndexKey: モックデータのため index で代替
-                <div key={i} className="py-2">
-                  <div
-                    className={`flex items-center gap-3 border-l-2 pl-3 py-2 rounded-r-md hover:bg-muted/40 transition-colors ${style.border}`}
-                  >
-                    <div className="flex flex-col min-w-0 flex-1">
-                      <span className="text-sm font-medium truncate">
-                        {item.name}
-                      </span>
-                      <span className="text-xs text-muted-foreground truncate">
-                        {item.meeting}
-                      </span>
-                    </div>
-                    <span className={`text-xs shrink-0 ${style.deadline}`}>
-                      {item.deadline}
+    <Card className="gap-0 py-0 overflow-hidden">
+      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50">
+        <span className="text-sm font-semibold flex-1">未完了タスク</span>
+        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+          {MOCK_TASKS.length}
+        </span>
+        {/* TODO: タスク一覧が実装されたらリンクに変更する */}
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowRight size={15} />
+        </button>
+      </div>
+      <div className="px-5 py-2 overflow-y-auto max-h-96">
+        {MOCK_TASKS.length === 0 ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">
+              未完了のタスクはありません
+            </p>
+          </div>
+        ) : (
+          MOCK_TASKS.slice(0, 5).map((item) => {
+            const style = URGENCY_STYLE[item.urgency];
+            return (
+              <div
+                key={item.name}
+                className="py-2 border-b border-border/50 last:border-b-0"
+              >
+                <div
+                  className={`flex items-center gap-3 border-l-2 pl-3 py-2.5 ${style.border}`}
+                >
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <span className="text-sm font-medium truncate">
+                      {item.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground truncate">
+                      {item.meeting}
                     </span>
                   </div>
+                  <span className={`text-xs shrink-0 ${style.deadline}`}>
+                    {item.deadline}
+                  </span>
                 </div>
-              );
-            })
-          )}
-        </div>
-        {/* TODO: タスク一覧画面が実装されたらリンクに変更する */}
-        <div className="flex justify-end pt-2">
-          <button
-            type="button"
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            全て見る
-            <ChevronRight size={14} />
-          </button>
-        </div>
-      </CardContent>
+              </div>
+            );
+          })
+        )}
+      </div>
     </Card>
   );
 }
@@ -376,7 +366,7 @@ export function Dashboard() {
           <NextMeetingsSection orgId={orgId} />
 
           {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4">
             <ReviewPendingCard />
             <IncompleteTasksCard />
           </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,7 +9,8 @@ import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
-import { ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 export const Route = createFileRoute("/")({
   component: Dashboard,
@@ -54,14 +55,13 @@ function NextMeetingCard({
   next: MeetingListItem;
 }) {
   return (
-    <Card>
+    <Card className="w-64 shrink-0 snap-start">
       <CardHeader className="pb-2">
-        <CardTitle>次回会議</CardTitle>
+        <CardTitle className="text-sm font-medium truncate">
+          {recurringMeetingName}
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-1">
-        <p className="text-sm font-medium text-muted-foreground truncate">
-          {recurringMeetingName}
-        </p>
         <p className="text-xs text-muted-foreground tabular-nums">
           {formatMeetingTime(next.heldAt, next.estimatedDurationMinutes)}
         </p>
@@ -87,8 +87,7 @@ function NextMeetingCard({
 }
 
 // ===== 次回会議セクション =====
-// 全定例の会議を並列取得し、最も直近の upcoming 会議を1件だけ表示する。
-// TODO: 表示件数（直近N件・当日・今週など）は別 Issue で検討・対応する。
+// 定例ごとに最も直近の upcoming 会議を1件取得し、日付順で横スクロール表示する。
 
 type Candidate = {
   recurringMeetingId: string;
@@ -103,13 +102,34 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
     isError: isRmError,
   } = useOrganizationMeetings(orgId);
 
-  // 全定例の会議を並列取得
   const meetingQueries = useQueries({
     queries: recurringMeetings.map((rm) => meetingListQueryOptions(rm.id)),
   });
 
   const isLoading = isRmLoading || meetingQueries.some((q) => q.isLoading);
   const isMeetingsError = meetingQueries.some((q) => q.isError);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  };
+
+  useEffect(() => {
+    updateScrollState();
+  });
+
+  const scroll = (dir: "left" | "right") => {
+    scrollRef.current?.scrollBy({
+      left: dir === "left" ? -272 : 272,
+      behavior: "smooth",
+    });
+  };
 
   if (isLoading) {
     return (
@@ -124,7 +144,6 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
     return <p className="text-sm text-destructive">定例の取得に失敗しました</p>;
   }
 
-  // 全定例から最も直近の upcoming 会議を1件選ぶ
   const candidates: Candidate[] = [];
   for (const [i, rm] of recurringMeetings.entries()) {
     const meetings = meetingQueries[i]?.data ?? [];
@@ -137,13 +156,12 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
       });
     }
   }
+  candidates.sort(
+    (a, b) =>
+      new Date(a.next.heldAt).getTime() - new Date(b.next.heldAt).getTime(),
+  );
 
-  const nearest = candidates.reduce<Candidate | null>((min, c) => {
-    if (!min) return c;
-    return new Date(c.next.heldAt) < new Date(min.next.heldAt) ? c : min;
-  }, null);
-
-  if (!nearest) {
+  if (candidates.length === 0) {
     return (
       <Card>
         <CardHeader>
@@ -159,11 +177,47 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
   }
 
   return (
-    <NextMeetingCard
-      recurringMeetingId={nearest.recurringMeetingId}
-      recurringMeetingName={nearest.recurringMeetingName}
-      next={nearest.next}
-    />
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          次回会議
+        </h2>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => scroll("left")}
+            disabled={!canScrollLeft}
+            aria-label="前へ"
+            className="p-1 rounded-md border text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:pointer-events-none transition-colors"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={() => scroll("right")}
+            disabled={!canScrollRight}
+            aria-label="次へ"
+            className="p-1 rounded-md border text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:pointer-events-none transition-colors"
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={updateScrollState}
+        className="flex gap-3 overflow-x-auto pb-1 snap-x snap-mandatory scrollbar-hide"
+      >
+        {candidates.map((c) => (
+          <NextMeetingCard
+            key={c.recurringMeetingId}
+            recurringMeetingId={c.recurringMeetingId}
+            recurringMeetingName={c.recurringMeetingName}
+            next={c.next}
+          />
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -368,15 +422,15 @@ export function Dashboard() {
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4 items-start">
-          {/* 左列：次回会議 + レビュー待ち */}
-          <div className="flex flex-col gap-4">
-            <NextMeetingsSection orgId={orgId} />
-            <ReviewPendingCard />
-          </div>
+        <div className="flex flex-col gap-4">
+          {/* 上段：次回会議（横スクロール） */}
+          <NextMeetingsSection orgId={orgId} />
 
-          {/* 右列：未完了タスク */}
-          <IncompleteTasksCard />
+          {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <ReviewPendingCard />
+            <IncompleteTasksCard />
+          </div>
         </div>
       )}
     </section>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -60,3 +60,11 @@ body {
   background-color: var(--background);
   color: var(--foreground);
 }
+
+.scrollbar-hide {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -139,11 +139,10 @@ describe("Dashboard - NextMeetingsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("複数定例のうち heldAt が最も近い upcoming 会議の定例名が表示される", async () => {
+  it("複数定例がある場合、すべての定例名が表示される", async () => {
     vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
       mockJson([RM_1, RM_2]),
     );
-    // rm-1 は遠い未来、rm-2 は近い未来 → rm-2 が選ばれる
     vi.mocked(api["recurring-meetings"][":id"].meetings.$get)
       .mockResolvedValueOnce(
         mockJson([
@@ -168,7 +167,43 @@ describe("Dashboard - NextMeetingsSection", () => {
         ]),
       );
     render();
-    expect(await screen.findByText("月次レビュー")).toBeInTheDocument();
+    expect(await screen.findByText("週次定例")).toBeInTheDocument();
+    expect(screen.getByText("月次レビュー")).toBeInTheDocument();
+  });
+
+  it("複数定例の会議カードが heldAt の昇順（近い順）で並ぶ", async () => {
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([RM_1, RM_2]),
+    );
+    // rm-1 は遠い未来、rm-2 は近い未来 → rm-2 が先に表示される
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get)
+      .mockResolvedValueOnce(
+        mockJson([
+          {
+            id: "mtg-rm1",
+            title: "週次定例 会議",
+            heldAt: FAR_FUTURE,
+            estimatedDurationMinutes: 60,
+            recurringMeetingId: "rm-1",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        mockJson([
+          {
+            id: "mtg-rm2",
+            title: "月次レビュー 会議",
+            heldAt: NEAR_FUTURE,
+            estimatedDurationMinutes: 60,
+            recurringMeetingId: "rm-2",
+          },
+        ]),
+      );
+    render();
+    await screen.findByText("週次定例");
+    const cards = screen.getAllByRole("link", { name: /詳細/ });
+    expect(cards[0]).toHaveAttribute("href", "/recurring-meetings/rm-2");
+    expect(cards[1]).toHaveAttribute("href", "/recurring-meetings/rm-1");
   });
 
   it("定例取得が失敗したとき「定例の取得に失敗しました」が表示される", async () => {
@@ -223,7 +258,7 @@ describe("Dashboard - NextMeetingsSection", () => {
         ]),
       );
     render();
-    const link = await screen.findByRole("link", { name: /詳細/ });
-    expect(link).toHaveAttribute("href", "/recurring-meetings/rm-2");
+    const links = await screen.findAllByRole("link", { name: /詳細/ });
+    expect(links[0]).toHaveAttribute("href", "/recurring-meetings/rm-2");
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #220 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* 定例ごとに最も直近の会議を1件取得し、昇順（近い順）で横スクロール表示するセクションを追加
* レビュー待ち・未完了タスクカードのデザインを一部修正

## 背景
* 現在のダッシュボードは全定例から最も直近の upcoming 会議を1件だけ表示している
* 「直近N件・当日の会議・今週の会議など、もう少し見たい」という指摘があった

## 変更内容
  - `routes/index.tsx`: `NextMeetingsSection`（横スクロールカルーセル）・`Re
  viewPendingCard`・`IncompleteTasksCard` を実装
  - `components/ui/card.tsx`: ボーダーを `border-border/70`に調整
  - `styles/globals.css`: `scrollbar-hide` ユーティリティを追加
  - `test/index.test.tsx`: 次回会議セクションのテストを追加（空・過去のみ・複数定例の表示・昇順ソート・エラー）

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
1. make devで起動
2. ダッシュボードで定例が横スクロールで表示されること

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1470" height="734" alt="スクリーンショット 2026-05-26 15 50 16" src="https://github.com/user-attachments/assets/77e9a925-cff9-48f9-ba74-6f505e9d3e5f" />
<img width="1470" height="736" alt="スクリーンショット 2026-05-26 15 50 58" src="https://github.com/user-attachments/assets/ebc8e557-d545-4011-b8e6-142499f1ee75" />

