### PR TITLE
feat(web): ダッシュボードの未完了タスク・レビュー待ちを実データに置き換え

### DIFF
--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -274,6 +274,7 @@ export function useReviewItems({
     items: query.data ?? [],
     isLoading: query.isLoading,
     isError: query.isError,
+    refetch: query.refetch,
     updateItem,
     resolveAmbiguity,
   };

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -313,6 +313,7 @@ function IncompleteTasksCard() {
         )}
         <Link
           to="/tasks"
+          search={{ status: "todo,in_progress" }}
           className="text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowRight size={15} />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -341,7 +341,7 @@ function IncompleteTasksCard() {
             </p>
           </div>
         ) : (
-          data.slice(0, 4).map((task) => {
+          data.map((task) => {
             const urgency = calcUrgency(task.dueDate);
             const style = URGENCY_STYLE[urgency];
             const meetingName =

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -183,7 +183,7 @@ const REVIEW_ITEM_TYPE_ORDER: ReviewItemType[] = [
 ];
 
 function ReviewPendingCard({ orgId }: { orgId: string }) {
-  const { items, isLoading, isError } = useReviewItems({
+  const { items, isLoading, isError, refetch } = useReviewItems({
     organizationId: orgId,
   });
 
@@ -220,8 +220,15 @@ function ReviewPendingCard({ orgId }: { orgId: string }) {
             ))}
           </div>
         ) : isError ? (
-          <div className="flex items-center justify-center py-8">
+          <div className="flex flex-col items-center justify-center gap-2 py-8">
             <p className="text-sm text-destructive">取得に失敗しました</p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="text-xs text-muted-foreground underline hover:text-foreground"
+            >
+              再試行
+            </button>
           </div>
         ) : countByType.length === 0 ? (
           <div className="flex items-center justify-center py-8">
@@ -298,6 +305,7 @@ function IncompleteTasksCard() {
     data = [],
     isLoading,
     isError,
+    refetch,
   } = useMyTasks({
     status: ["todo", "in_progress"],
   });
@@ -330,10 +338,17 @@ function IncompleteTasksCard() {
             ))}
           </div>
         ) : isError ? (
-          <div className="flex items-center justify-center py-8">
+          <div className="flex flex-col items-center justify-center gap-2 py-8">
             <p className="text-sm text-destructive">
               タスクの取得に失敗しました
             </p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="text-xs text-muted-foreground underline hover:text-foreground"
+            >
+              再試行
+            </button>
           </div>
         ) : data.length === 0 ? (
           <div className="flex items-center justify-center py-8">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,6 +5,7 @@ import {
   meetingListQueryOptions,
 } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
 import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
+import { useOrgTasks } from "@/features/tasks/hooks/useOrgTasks";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
@@ -223,77 +224,70 @@ function ReviewPendingCard() {
   );
 }
 
-// ===== 未完了タスクカード（モック） =====
-// TODO: タスク API が実装されたら実データに置き換える。
+// ===== 未完了タスクカード =====
 
-type TaskItem = {
-  name: string;
-  meeting: string;
-  deadline: string;
-  // "overdue" | "this-week" | "later"
-  urgency: "overdue" | "this-week" | "later";
-};
+type TaskUrgency = "overdue" | "this-week" | "later";
 
-const MOCK_TASKS: TaskItem[] = [
+const URGENCY_STYLE: Record<TaskUrgency, { border: string; deadline: string }> =
   {
-    name: "〜の設定",
-    meeting: "〜進捗報告",
-    deadline: "3日超過",
-    urgency: "overdue",
-  },
-  {
-    name: "〜提出",
-    meeting: "〜定例会議",
-    deadline: "1日超過",
-    urgency: "overdue",
-  },
-  {
-    name: "〜の仕様確認",
-    meeting: "〜進捗報告",
-    deadline: "5/2",
-    urgency: "this-week",
-  },
-  {
-    name: "〜提出",
-    meeting: "〜定例会議",
-    deadline: "5/4",
-    urgency: "this-week",
-  },
-  {
-    name: "〜提出",
-    meeting: "〜定例会議",
-    deadline: "5/4",
-    urgency: "this-week",
-  },
-];
+    overdue: {
+      border: "border-l-destructive",
+      deadline: "text-destructive font-medium",
+    },
+    "this-week": {
+      border: "border-l-orange-400",
+      deadline: "text-orange-500 font-medium",
+    },
+    later: {
+      border: "border-l-border",
+      deadline: "text-muted-foreground",
+    },
+  };
 
-const URGENCY_STYLE: Record<
-  TaskItem["urgency"],
-  { border: string; deadline: string }
-> = {
-  overdue: {
-    border: "border-l-destructive",
-    deadline: "text-destructive font-medium",
-  },
-  "this-week": {
-    border: "border-l-orange-400",
-    deadline: "text-orange-500 font-medium",
-  },
-  later: {
-    border: "border-l-border",
-    deadline: "text-muted-foreground",
-  },
-};
+function calcUrgency(dueDate: string | null): TaskUrgency {
+  if (!dueDate) return "later";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  if (due < today) return "overdue";
+  const weekLater = new Date(today);
+  weekLater.setDate(weekLater.getDate() + 7);
+  if (due <= weekLater) return "this-week";
+  return "later";
+}
 
-function IncompleteTasksCard() {
+function formatDeadline(dueDate: string | null, urgency: TaskUrgency): string {
+  if (!dueDate) return "未設定";
+  if (urgency === "overdue") {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const days = Math.ceil(
+      (today.getTime() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24),
+    );
+    return `${days}日超過`;
+  }
+  const d = new Date(dueDate);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function IncompleteTasksCard({ orgId }: { orgId: string }) {
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useOrgTasks(orgId, {
+    status: ["todo", "in_progress"],
+  });
+
   return (
     <Card className="gap-0 py-0 overflow-hidden">
       <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50">
         <span className="text-sm font-semibold flex-1">未完了タスク</span>
-        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
-          {MOCK_TASKS.length}
-        </span>
-        {/* TODO: タスク一覧が実装されたらリンクに変更する */}
+        {!isLoading && !isError && (
+          <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+            {data.length}
+          </span>
+        )}
         <button
           type="button"
           className="text-muted-foreground hover:text-foreground transition-colors"
@@ -302,18 +296,38 @@ function IncompleteTasksCard() {
         </button>
       </div>
       <div className="px-5 py-2 overflow-y-auto max-h-96">
-        {MOCK_TASKS.length === 0 ? (
+        {isLoading ? (
+          <div className="space-y-3 py-2">
+            {(["s0", "s1", "s2"] as const).map((k) => (
+              <div
+                key={k}
+                className="h-12 rounded-md bg-muted/50 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-destructive">
+              タスクの取得に失敗しました
+            </p>
+          </div>
+        ) : data.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <p className="text-sm text-muted-foreground">
               未完了のタスクはありません
             </p>
           </div>
         ) : (
-          MOCK_TASKS.slice(0, 5).map((item) => {
-            const style = URGENCY_STYLE[item.urgency];
+          data.slice(0, 5).map((task) => {
+            const urgency = calcUrgency(task.dueDate);
+            const style = URGENCY_STYLE[urgency];
+            const meetingName =
+              task.originMeeting?.title ??
+              task.recurringMeetings[0]?.name ??
+              "";
             return (
               <div
-                key={item.name}
+                key={task.id}
                 className="py-2 border-b border-border/50 last:border-b-0"
               >
                 <div
@@ -321,14 +335,14 @@ function IncompleteTasksCard() {
                 >
                   <div className="flex flex-col min-w-0 flex-1">
                     <span className="text-sm font-medium truncate">
-                      {item.name}
+                      {task.title}
                     </span>
                     <span className="text-xs text-muted-foreground truncate">
-                      {item.meeting}
+                      {meetingName}
                     </span>
                   </div>
                   <span className={`text-xs shrink-0 ${style.deadline}`}>
-                    {item.deadline}
+                    {formatDeadline(task.dueDate, urgency)}
                   </span>
                 </div>
               </div>
@@ -368,7 +382,7 @@ export function Dashboard() {
           {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
           <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4">
             <ReviewPendingCard />
-            <IncompleteTasksCard />
+            <IncompleteTasksCard orgId={orgId} />
           </div>
         </div>
       )}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -185,21 +185,20 @@ const MOCK_REVIEW_ROWS: ReviewRow[] = [
 function ReviewPendingCard() {
   const total = MOCK_REVIEW_ROWS.reduce((sum, r) => sum + r.count, 0);
   return (
-    <Card className="gap-0 py-0 overflow-hidden">
-      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50">
+    <Card className="gap-0 py-0 overflow-hidden h-90">
+      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
         <span className="text-sm font-semibold flex-1">レビュー待ち</span>
         <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
           {total}
         </span>
-        {/* TODO: レビュー画面が実装されたらリンクに変更する */}
-        <button
-          type="button"
+        <Link
+          to="/review"
           className="text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowRight size={15} />
-        </button>
+        </Link>
       </div>
-      <div className="px-5 py-1">
+      <div className="px-5 py-1 flex-1 min-h-0 overflow-y-auto">
         {MOCK_REVIEW_ROWS.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <p className="text-sm text-muted-foreground">
@@ -235,11 +234,11 @@ const URGENCY_STYLE: Record<TaskUrgency, { border: string; deadline: string }> =
       deadline: "text-destructive font-medium",
     },
     "this-week": {
-      border: "border-l-orange-400",
-      deadline: "text-orange-500 font-medium",
+      border: "border-l-amber-500",
+      deadline: "text-amber-600 font-medium",
     },
     later: {
-      border: "border-l-border",
+      border: "border-l-slate-200",
       deadline: "text-muted-foreground",
     },
   };
@@ -280,22 +279,22 @@ function IncompleteTasksCard() {
   });
 
   return (
-    <Card className="gap-0 py-0 overflow-hidden">
-      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50">
+    <Card className="gap-0 py-0 overflow-hidden h-90">
+      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
         <span className="text-sm font-semibold flex-1">未完了タスク</span>
         {!isLoading && !isError && (
           <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
             {data.length}
           </span>
         )}
-        <button
-          type="button"
+        <Link
+          to="/tasks"
           className="text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowRight size={15} />
-        </button>
+        </Link>
       </div>
-      <div className="px-5 py-2 overflow-y-auto max-h-96">
+      <div className="px-5 py-2 flex-1 min-h-0 overflow-y-auto">
         {isLoading ? (
           <div className="space-y-3 py-2">
             {(["s0", "s1", "s2"] as const).map((k) => (
@@ -318,7 +317,7 @@ function IncompleteTasksCard() {
             </p>
           </div>
         ) : (
-          data.slice(0, 5).map((task) => {
+          data.slice(0, 4).map((task) => {
             const urgency = calcUrgency(task.dueDate);
             const style = URGENCY_STYLE[urgency];
             const meetingName =
@@ -331,7 +330,7 @@ function IncompleteTasksCard() {
                 className="py-2 border-b border-border/50 last:border-b-0"
               >
                 <div
-                  className={`flex items-center gap-3 border-l-2 pl-3 py-2.5 ${style.border}`}
+                  className={`flex items-center gap-3 border-l-4 pl-3 py-2.5 ${style.border}`}
                 >
                   <div className="flex flex-col min-w-0 flex-1">
                     <span className="text-sm font-medium truncate">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -345,9 +345,9 @@ function IncompleteTasksCard() {
             const urgency = calcUrgency(task.dueDate);
             const style = URGENCY_STYLE[urgency];
             const meetingName =
-              task.originMeeting?.title ??
               task.recurringMeetings[0]?.name ??
-              "";
+              task.originMeeting?.title ??
+              null;
             return (
               <div
                 key={task.id}
@@ -360,9 +360,11 @@ function IncompleteTasksCard() {
                     <span className="text-sm font-medium truncate">
                       {task.title}
                     </span>
-                    <span className="text-xs text-muted-foreground truncate">
-                      {meetingName}
-                    </span>
+                    {meetingName && (
+                      <span className="text-xs text-muted-foreground truncate">
+                        {meetingName}
+                      </span>
+                    )}
                   </div>
                   <span className={`text-xs shrink-0 ${style.deadline}`}>
                     {formatDeadline(task.dueDate, urgency)}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,7 +5,7 @@ import {
   meetingListQueryOptions,
 } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
 import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
-import { useOrgTasks } from "@/features/tasks/hooks/useOrgTasks";
+import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
@@ -270,12 +270,12 @@ function formatDeadline(dueDate: string | null, urgency: TaskUrgency): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-function IncompleteTasksCard({ orgId }: { orgId: string }) {
+function IncompleteTasksCard() {
   const {
     data = [],
     isLoading,
     isError,
-  } = useOrgTasks(orgId, {
+  } = useMyTasks({
     status: ["todo", "in_progress"],
   });
 
@@ -382,7 +382,7 @@ export function Dashboard() {
           {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
           <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4">
             <ReviewPendingCard />
-            <IncompleteTasksCard orgId={orgId} />
+            <IncompleteTasksCard />
           </div>
         </div>
       )}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,10 +5,7 @@ import {
   meetingListQueryOptions,
 } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
 import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
-import {
-  TYPE_LABELS,
-  type ReviewItemType,
-} from "@/features/review/types";
+import { TYPE_LABELS, type ReviewItemType } from "@/features/review/types";
 import { useReviewItems } from "@/features/review/useReviewItems";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
@@ -186,7 +183,9 @@ const REVIEW_ITEM_TYPE_ORDER: ReviewItemType[] = [
 ];
 
 function ReviewPendingCard({ orgId }: { orgId: string }) {
-  const { items, isLoading, isError } = useReviewItems({ organizationId: orgId });
+  const { items, isLoading, isError } = useReviewItems({
+    organizationId: orgId,
+  });
 
   const countByType = REVIEW_ITEM_TYPE_ORDER.map((type) => ({
     type,
@@ -214,7 +213,10 @@ function ReviewPendingCard({ orgId }: { orgId: string }) {
         {isLoading ? (
           <div className="space-y-3 py-2">
             {(["s0", "s1", "s2"] as const).map((k) => (
-              <div key={k} className="h-10 rounded-md bg-muted/50 animate-pulse" />
+              <div
+                key={k}
+                className="h-10 rounded-md bg-muted/50 animate-pulse"
+              />
             ))}
           </div>
         ) : isError ? (

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,6 +5,11 @@ import {
   meetingListQueryOptions,
 } from "@/features/recurring-meetings/hooks/useRecurringMeetingMeetings";
 import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
+import {
+  TYPE_LABELS,
+  type ReviewItemType,
+} from "@/features/review/types";
+import { useReviewItems } from "@/features/review/useReviewItems";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
@@ -171,26 +176,33 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
   );
 }
 
-// ===== レビュー待ちカード（モック） =====
-// TODO: レビュー待ちデータ取得 API が実装されたら実データに置き換える。
+// ===== レビュー待ちカード =====
 
-type ReviewRow = { label: string; count: number };
-
-const MOCK_REVIEW_ROWS: ReviewRow[] = [
-  { label: "担当者なし", count: 1 },
-  { label: "期限なし", count: 1 },
-  { label: "未決事項", count: 1 },
+const REVIEW_ITEM_TYPE_ORDER: ReviewItemType[] = [
+  "task_candidate",
+  "open_issue",
+  "ambiguity",
+  "decision",
 ];
 
-function ReviewPendingCard() {
-  const total = MOCK_REVIEW_ROWS.reduce((sum, r) => sum + r.count, 0);
+function ReviewPendingCard({ orgId }: { orgId: string }) {
+  const { items, isLoading, isError } = useReviewItems({ organizationId: orgId });
+
+  const countByType = REVIEW_ITEM_TYPE_ORDER.map((type) => ({
+    type,
+    label: TYPE_LABELS[type],
+    count: items.filter((i) => i.type === type).length,
+  })).filter((r) => r.count > 0);
+
   return (
     <Card className="gap-0 py-0 overflow-hidden h-90">
       <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
         <span className="text-sm font-semibold flex-1">レビュー待ち</span>
-        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
-          {total}
-        </span>
+        {!isLoading && !isError && (
+          <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+            {items.length}
+          </span>
+        )}
         <Link
           to="/review"
           className="text-muted-foreground hover:text-foreground transition-colors"
@@ -199,21 +211,31 @@ function ReviewPendingCard() {
         </Link>
       </div>
       <div className="px-5 py-1 flex-1 min-h-0 overflow-y-auto">
-        {MOCK_REVIEW_ROWS.length === 0 ? (
+        {isLoading ? (
+          <div className="space-y-3 py-2">
+            {(["s0", "s1", "s2"] as const).map((k) => (
+              <div key={k} className="h-10 rounded-md bg-muted/50 animate-pulse" />
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-destructive">取得に失敗しました</p>
+          </div>
+        ) : countByType.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <p className="text-sm text-muted-foreground">
               レビュー待ちのアイテムはありません
             </p>
           </div>
         ) : (
-          MOCK_REVIEW_ROWS.map((row) => (
+          countByType.map((row) => (
             <div
-              key={row.label}
+              key={row.type}
               className="flex items-center justify-between py-3 border-b border-border/50 last:border-0"
             >
               <span className="text-sm">{row.label}</span>
-              <span className="text-sm text-destructive font-medium">
-                {row.count} 件
+              <span className="size-6 inline-flex items-center justify-center rounded-full bg-destructive/10 text-destructive text-xs font-semibold shrink-0">
+                {row.count}
               </span>
             </div>
           ))
@@ -380,7 +402,7 @@ export function Dashboard() {
 
           {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
           <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4">
-            <ReviewPendingCard />
+            <ReviewPendingCard orgId={orgId} />
             <IncompleteTasksCard />
           </div>
         </div>

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -372,7 +372,9 @@ describe("Dashboard - ReviewPendingCard", () => {
     expect(await screen.findByText("タスク候補")).toBeInTheDocument();
     expect(screen.getByText("未決事項")).toBeInTheDocument();
     // 種別バッジの件数が正しい値で表示される
-    const reviewCard = screen.getByText("タスク候補").closest("[data-slot=card]");
+    const reviewCard = screen
+      .getByText("タスク候補")
+      .closest("[data-slot=card]");
     expect(reviewCard).toBeTruthy();
     expect(reviewCard?.textContent).toContain("2");
     expect(reviewCard?.textContent).toContain("1");

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -492,7 +492,7 @@ describe("Dashboard - IncompleteTasksCard", () => {
     expect(await screen.findByText("未設定")).toBeInTheDocument();
   });
 
-  it("5件以上のとき先頭4件のみ表示される", async () => {
+  it("5件以上のとき全件スクロール表示される", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(
       mockJson(
         Array.from({ length: 5 }, (_, i) =>
@@ -503,7 +503,7 @@ describe("Dashboard - IncompleteTasksCard", () => {
     renderDashboard();
     await screen.findByText("タスク1");
     expect(screen.getByText("タスク4")).toBeInTheDocument();
-    expect(screen.queryByText("タスク5")).not.toBeInTheDocument();
+    expect(screen.getByText("タスク5")).toBeInTheDocument();
   });
 
   it("ヘッダーに件数バッジが表示される", async () => {

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -6,17 +6,17 @@ vi.mock("@/lib/api", () => ({
   api: {
     organizations: {
       ":id": {
-        meetings: {
-          $get: vi.fn(),
-        },
+        meetings: { $get: vi.fn() },
+        "review-items": { $get: vi.fn() },
       },
     },
     "recurring-meetings": {
       ":id": {
-        meetings: {
-          $get: vi.fn(),
-        },
+        meetings: { $get: vi.fn() },
       },
+    },
+    tasks: {
+      me: { $get: vi.fn() },
     },
   },
   authHeaders: () => ({ headers: {} }),
@@ -59,6 +59,8 @@ vi.mock("jotai", async () => {
 });
 
 import { api } from "@/lib/api";
+import type { ReviewItem } from "@/features/review/types";
+import type { TaskListItem } from "@/features/tasks/types";
 import { useAtomValue } from "jotai";
 import { Dashboard } from "../routes/index";
 
@@ -78,11 +80,72 @@ const PAST = "2000-01-01T10:00:00.000Z";
 const RM_1 = { id: "rm-1", name: "週次定例", _count: { members: 0 } };
 const RM_2 = { id: "rm-2", name: "月次レビュー", _count: { members: 0 } };
 
+function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
+  return {
+    id: "item-1",
+    sourceTable: "task",
+    type: "task_candidate",
+    title: "テストタスク",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "draft",
+    assignees: [],
+    deadline: null,
+    severity: null,
+    resolutionType: null,
+    recurringMeetingId: "rmtg-1",
+    recurringMeetingName: "週次定例",
+    meetingId: "mtg-1",
+    version: 0,
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<TaskListItem> = {}): TaskListItem {
+  return {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "テストタスク",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [],
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 function render() {
+  // 既存テストが新しいエンドポイントで undefined を返して落ちないようデフォルトを設定する
+  vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+    mockJson([]),
+  );
+  vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
   return renderWithQuery(<Dashboard />);
 }
 
@@ -260,5 +323,199 @@ describe("Dashboard - NextMeetingsSection", () => {
     render();
     const links = await screen.findAllByRole("link", { name: /詳細/ });
     expect(links[0]).toHaveAttribute("href", "/recurring-meetings/rm-2");
+  });
+});
+
+// ===== ReviewPendingCard =====
+// render() はデフォルトモックを上書きするため、このブロックでは renderWithQuery を直接使う。
+
+describe("Dashboard - ReviewPendingCard", () => {
+  beforeEach(() => {
+    vi.mocked(useAtomValue).mockReturnValue("org-1");
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+  });
+
+  function renderDashboard() {
+    return renderWithQuery(<Dashboard />);
+  }
+
+  it("アイテムが空のとき「レビュー待ちのアイテムはありません」が表示される", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderDashboard();
+    expect(
+      await screen.findByText("レビュー待ちのアイテムはありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("取得失敗時に「取得に失敗しました」が表示される", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockRejectedValue(
+      new Error("network"),
+    );
+    renderDashboard();
+    expect(await screen.findByText("取得に失敗しました")).toBeInTheDocument();
+  });
+
+  it("種別ごとに件数が集計されて表示される", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({ id: "r1", type: "task_candidate" }),
+        makeReviewItem({ id: "r2", type: "task_candidate" }),
+        makeReviewItem({ id: "r3", type: "open_issue" }),
+      ]),
+    );
+    renderDashboard();
+    expect(await screen.findByText("タスク候補")).toBeInTheDocument();
+    expect(screen.getByText("未決事項")).toBeInTheDocument();
+    // 種別バッジの件数が正しい値で表示される
+    const reviewCard = screen.getByText("タスク候補").closest("[data-slot=card]");
+    expect(reviewCard).toBeTruthy();
+    expect(reviewCard?.textContent).toContain("2");
+    expect(reviewCard?.textContent).toContain("1");
+  });
+
+  it("件数が0の種別は表示されない", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([makeReviewItem({ id: "r1", type: "open_issue" })]),
+    );
+    renderDashboard();
+    await screen.findByText("未決事項");
+    expect(screen.queryByText("タスク候補")).not.toBeInTheDocument();
+    expect(screen.queryByText("曖昧箇所")).not.toBeInTheDocument();
+  });
+
+  it("ヘッダーに総件数バッジが表示される", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({ id: "r1", type: "task_candidate" }),
+        makeReviewItem({ id: "r2", type: "open_issue" }),
+        makeReviewItem({ id: "r3", type: "open_issue" }),
+      ]),
+    );
+    renderDashboard();
+    // データ取得完了後にバッジが描画される
+    expect(await screen.findByText("タスク候補")).toBeInTheDocument();
+    const header = screen.getByText("レビュー待ち").closest("div");
+    expect(header?.textContent).toContain("3");
+  });
+
+  it("/review へのリンクが存在する", async () => {
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([]),
+    );
+    renderDashboard();
+    await screen.findByText("レビュー待ち");
+    const reviewLinks = screen
+      .getAllByRole("link")
+      .filter((l) => l.getAttribute("href") === "/review");
+    expect(reviewLinks.length).toBeGreaterThan(0);
+  });
+});
+
+// ===== IncompleteTasksCard =====
+// render() はデフォルトモックを上書きするため、このブロックでは renderWithQuery を直接使う。
+
+describe("Dashboard - IncompleteTasksCard", () => {
+  beforeEach(() => {
+    vi.mocked(useAtomValue).mockReturnValue("org-1");
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([]),
+    );
+  });
+
+  function renderDashboard() {
+    return renderWithQuery(<Dashboard />);
+  }
+
+  it("タスクが空のとき「未完了のタスクはありません」が表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderDashboard();
+    expect(
+      await screen.findByText("未完了のタスクはありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("取得失敗時に「タスクの取得に失敗しました」が表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockRejectedValue(new Error("network"));
+    renderDashboard();
+    expect(
+      await screen.findByText("タスクの取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("タスクのタイトルと所属定例名が表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([
+        makeTask({
+          id: "t1",
+          title: "議事録を作成する",
+          recurringMeetings: [{ id: "rm-1", name: "週次定例" }],
+        }),
+      ]),
+    );
+    renderDashboard();
+    expect(await screen.findByText("議事録を作成する")).toBeInTheDocument();
+    expect(screen.getByText("週次定例")).toBeInTheDocument();
+  });
+
+  it("期限切れのタスクは「超過」テキストが表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      // PAST は確実に過去のため overdue 判定される
+      mockJson([makeTask({ id: "t1", dueDate: PAST })]),
+    );
+    renderDashboard();
+    expect(await screen.findByText(/超過/)).toBeInTheDocument();
+  });
+
+  it("期限ありのタスクは「月/日」形式で表示される", async () => {
+    // タイムゾーン依存を避けるため月中旬の正午UTCを使う
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "t1", dueDate: "2099-06-15T12:00:00.000Z" })]),
+    );
+    renderDashboard();
+    expect(await screen.findByText("6/15")).toBeInTheDocument();
+  });
+
+  it("期限なしのタスクは「未設定」と表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "t1", dueDate: null })]),
+    );
+    renderDashboard();
+    expect(await screen.findByText("未設定")).toBeInTheDocument();
+  });
+
+  it("5件以上のとき先頭4件のみ表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson(
+        Array.from({ length: 5 }, (_, i) =>
+          makeTask({ id: `t${i}`, title: `タスク${i + 1}` }),
+        ),
+      ),
+    );
+    renderDashboard();
+    await screen.findByText("タスク1");
+    expect(screen.getByText("タスク4")).toBeInTheDocument();
+    expect(screen.queryByText("タスク5")).not.toBeInTheDocument();
+  });
+
+  it("ヘッダーに件数バッジが表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([
+        makeTask({ id: "t1", title: "タスクA" }),
+        makeTask({ id: "t2", title: "タスクB" }),
+      ]),
+    );
+    renderDashboard();
+    // データ取得完了後にバッジが描画される
+    await screen.findByText("タスクA");
+    const header = screen.getByText("未完了タスク").closest("div");
+    expect(header?.textContent).toContain("2");
   });
 });

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -137,7 +137,6 @@ function makeTask(overrides: Partial<TaskListItem> = {}): TaskListItem {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 function render() {


### PR DESCRIPTION
## 関連Issue
Closes #198 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* ダッシュボードの「未完了タスク」カードと「レビュー待ち」カードをモックデータから実データに置き換える。
* 認証ユーザーの担当タスクおよび組織のレビューアイテムをAPIから取得し、ダッシュボードで実際の状況を確認できるようにする。 

## 背景
* 「未完了タスク」カードはモックの固定リストを表示していた
* 「レビュー待ち」カードは固定の `MOCK_REVIEW_ROWS` を表示していた
* いずれも `useMyTasks` / `useReviewItems` フックがすでに存在していたため、接続するだけで実データ化が可能だった
  
## 変更内容
*  `IncompleteTasksCard`：`useMyTasks({ status: ["todo", "in_progress"] })` で認証ユーザーのタスクを取得。期限の超過・今週・それ以降を左ボーダー色で区別し、最大4件を表示
* `ReviewPendingCard`：`MOCK_REVIEW_ROWS` を削除し `useReviewItems({ organizationId })`で組織全体のレビューアイテムを取得。種別（タスク候補・未決事項・曖昧箇所・決定事項）ごとの件数を丸バッジで表示
* `index.test.tsx`：上記2カードのテストを13件追加（空状態・エラー状態・データ表示・件数バッジ・件数制限）

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. ローカル環境を起動し、タスクと未解決のレビューアイテムが存在する組織アカウントでログイン
  2. サイドバーから組織を選択し、ダッシュボードを開く
  3. 「未完了タスク」カードに自分が担当の todo / in_progress タスクが表示されること、期限切れは赤・今週は黄のボーダーで表示されることを確認
  4. 「レビュー待ち」カードに組織のレビューアイテムが種別ごとに集計されて表示されることを確認
  5. タスク・レビューアイテムが0件のとき、それぞれ空状態のメッセージが表示されることを確認

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1470" height="735" alt="スクリーンショット 2026-05-28 1 40 14" src="https://github.com/user-attachments/assets/f90de77c-44c7-4ef6-a097-eba1382893ca" />
