### PR TITLE
feat: AI抽出結果のレビュー待ち戻し機能とキャッシュ整合性の修正

### DIFF
--- a/apps/api/src/lib/review-item-serialization.ts
+++ b/apps/api/src/lib/review-item-serialization.ts
@@ -36,8 +36,10 @@ type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
 }>;
 
 export function serializeDecisionItem(item: DecisionItemWithReview) {
+  // status:"open" は未決確定済み → decisionState によらず open_issue のまま
   const type =
-    item.decisionState === "confirmed" || item.decisionState === "tentative"
+    item.status !== "open" &&
+    (item.decisionState === "confirmed" || item.decisionState === "tentative")
       ? ("decision" as const)
       : ("open_issue" as const);
   return {

--- a/apps/api/src/lib/schemas/review-item.ts
+++ b/apps/api/src/lib/schemas/review-item.ts
@@ -38,7 +38,7 @@ export const recurringMeetingReviewItemQuerySchema =
 export const decisionItemPatchSchema = z
   .object({
     version: z.number().int().nonnegative(),
-    status: z.enum(["open", "decided", "cancelled"]).optional(),
+    status: z.enum(["draft", "open", "decided", "cancelled"]).optional(),
     decisionState: z
       .enum(["confirmed", "tentative", "open"])
       .nullable()

--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
-// 手動経路で受け付ける status 値（draft / reviewing は AI 専用なので除外）。
+// 手動経路で受け付ける status 値。draft はレビュー待ち戻し操作のみで使用。
 // POST では指定不可（サーバ側で todo 固定）、PATCH でのみ変更可能。
 const manualTaskStatusSchema = z.enum([
+  "draft",
   "todo",
   "in_progress",
   "done",

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -59,6 +59,8 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
     }
 
     // 一般編集 UI からの誤用防止。draft へは decided/open/cancelled からのみ遷移可。
+    // draft/reviewing（AI処理中）からは戻せない。task と異なり in_progress/done 相当の
+    // 概念がないため、決定済み・未決・却下済みの3状態を対象にしている。
     if (input.status === "draft") {
       const current = access.item.status;
       if (

--- a/apps/api/src/routes/decision-items.ts
+++ b/apps/api/src/routes/decision-items.ts
@@ -58,6 +58,21 @@ export const decisionItemsRoute = new Hono<{ Variables: AuthVariables }>()
       }
     }
 
+    // 一般編集 UI からの誤用防止。draft へは decided/open/cancelled からのみ遷移可。
+    if (input.status === "draft") {
+      const current = access.item.status;
+      if (
+        current !== "decided" &&
+        current !== "open" &&
+        current !== "cancelled"
+      ) {
+        return c.json(
+          { error: "この状態からレビュー待ちに戻すことはできません" },
+          400,
+        );
+      }
+    }
+
     // status が "decided" になったら decidedBy / decidedAt を自動設定。
     // "decided" 以外のステータスへ変わったら decidedBy / decidedAt をクリア。
     const prevStatus = access.item.status;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -192,6 +192,7 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     const organizationId = guard.task.organizationId;
 
     // 一般編集 UI からの誤用防止。draft へは todo/rejected からのみ遷移可。
+    // in_progress/done は作業・完了履歴が混乱するため再レビュー対象にしない。
     if (input.status === "draft") {
       const current = guard.task.status;
       if (current !== "todo" && current !== "rejected") {

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -191,6 +191,17 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
 
     const organizationId = guard.task.organizationId;
 
+    // 一般編集 UI からの誤用防止。draft へは todo/rejected からのみ遷移可。
+    if (input.status === "draft") {
+      const current = guard.task.status;
+      if (current !== "todo" && current !== "rejected") {
+        return c.json(
+          { error: "この状態からレビュー待ちに戻すことはできません" },
+          400,
+        );
+      }
+    }
+
     // assignees / recurringMeetings の置換が指定されたら、クロス組織を再検証する。
     // 作成時と同じ整合性ルール（同一組織内のみ許可）。
     if (input.assigneeUserIds !== undefined) {

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -330,13 +330,13 @@ describe("PATCH /decision-items/:id", () => {
     expect(capturedData?.decidedAt).toBeNull();
   });
 
-  it("status=draft は 400（AI 専用なので手動 PATCH で受け付けない）", async () => {
+  it("status=draft は 200（レビュー待ちに戻す操作で使用）", async () => {
     const res = await app.request("/decision-items/di-1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ version: 0, status: "draft" }),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
   });
 
   it("全フィールド未指定の更新は 400", async () => {

--- a/apps/api/test/decision-items.test.ts
+++ b/apps/api/test/decision-items.test.ts
@@ -339,6 +339,32 @@ describe("PATCH /decision-items/:id", () => {
     expect(res.status).toBe(200);
   });
 
+  it("status=draft のとき現在が draft なら 400", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw({ status: "draft" }) as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("status=draft のとき現在が reviewing なら 400", async () => {
+    mockDecisionItemFindUnique.mockResolvedValue(
+      mockDecisionItemRaw({ status: "reviewing" }) as never,
+    );
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const res = await app.request("/decision-items/di-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("全フィールド未指定の更新は 400", async () => {
     const res = await app.request("/decision-items/di-1", {
       method: "PATCH",

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -545,13 +545,13 @@ describe("PATCH /tasks/:id", () => {
     expect(res.status).toBe(200);
   });
 
-  it("status=draft は 400（AI 専用なので手動 PATCH で受け付けない）", async () => {
+  it("status=draft は 200（レビュー待ちに戻す操作で使用）", async () => {
     const res = await app.request("/tasks/task-1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ version: 0, status: "draft" }),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
   });
 
   it("全フィールド未指定の更新は 400", async () => {

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -554,6 +554,34 @@ describe("PATCH /tasks/:id", () => {
     expect(res.status).toBe(200);
   });
 
+  it("status=draft のとき現在が in_progress なら 400", async () => {
+    mockTaskFindUnique.mockResolvedValue({
+      ...sampleTask,
+      status: "in_progress",
+    } as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("status=draft のとき現在が done なら 400", async () => {
+    mockTaskFindUnique.mockResolvedValue({
+      ...sampleTask,
+      status: "done",
+    } as never);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: 0, status: "draft" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("全フィールド未指定の更新は 400", async () => {
     const res = await app.request("/tasks/task-1", {
       method: "PATCH",

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -14,7 +14,7 @@ export type AmbiguityResolution =
 
 type ReviewItemStatus = "pending" | "all" | "decided";
 
-// ステータスを含まない基底キー。全バリアントをまとめて invalidate するときに使う。
+// "pending"/"all" など全バリアントをまとめて invalidate するために status を含まない。
 function reviewItemsBaseQueryKey(params: {
   meetingId?: string;
   recurringMeetingId?: string;

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -14,6 +14,9 @@ export type AmbiguityResolution =
 
 type ReviewItemStatus = "pending" | "all" | "decided";
 
+const isReviewPending = (status: string) =>
+  status === "draft" || status === "reviewing";
+
 // "pending"/"all" など全バリアントをまとめて invalidate するために status を含まない。
 function reviewItemsBaseQueryKey(params: {
   meetingId?: string;
@@ -151,10 +154,8 @@ export function useReviewItems({
       }
 
       const updated = (await res.json()) as ReviewItem;
-      const isPending =
-        updated.status === "draft" || updated.status === "reviewing";
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-        isPending
+        isReviewPending(updated.status)
           ? (prev ?? []).map((i) => (i.id === id ? updated : i))
           : (prev ?? []).filter((i) => i.id !== id),
       );
@@ -218,14 +219,12 @@ export function useReviewItems({
       const reviewStatus: ReviewItem["status"] =
         task.status === "rejected"
           ? "rejected"
-          : task.status === "draft" || task.status === "reviewing"
+          : isReviewPending(task.status)
             ? item.status
             : "decided";
 
-      const isTaskPending =
-        reviewStatus === "draft" || reviewStatus === "reviewing";
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-        isTaskPending
+        isReviewPending(reviewStatus)
           ? (prev ?? []).map((i) =>
               i.id === id
                 ? {
@@ -299,10 +298,8 @@ export function useReviewItems({
     }
 
     const updated = (await res.json()) as ReviewItem;
-    const isAmbigPending =
-      updated.status === "draft" || updated.status === "reviewing";
     queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-      isAmbigPending
+      isReviewPending(updated.status)
         ? (prev ?? []).map((i) => (i.id === id ? updated : i))
         : (prev ?? []).filter((i) => i.id !== id),
     );
@@ -314,18 +311,16 @@ export function useReviewItems({
     if (!item) throw new Error(`resetToPending: id="${id}" が見つかりません`);
 
     if (item.sourceTable === "decision_item") {
-      const body: Record<string, unknown> = {
-        version: item.version,
-        status: "draft",
-      };
-      if (item.type === "open_issue") body.decisionState = "open";
-
       const res = await api["decision-items"][":id"].$patch(
         {
           param: { id },
-          json: body as Parameters<
-            (typeof api)["decision-items"][":id"]["$patch"]
-          >[0]["json"],
+          json: {
+            version: item.version,
+            status: "draft" as const,
+            ...(item.type === "open_issue" && {
+              decisionState: "open" as const,
+            }),
+          },
         },
         authHeaders(),
       );
@@ -338,9 +333,7 @@ export function useReviewItems({
       const res = await api.tasks[":id"].$patch(
         {
           param: { id },
-          json: { version: item.version, status: "draft" } as Parameters<
-            (typeof api.tasks)[":id"]["$patch"]
-          >[0]["json"],
+          json: { version: item.version, status: "draft" as const },
         },
         authHeaders(),
       );

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -154,6 +154,8 @@ export function useReviewItems({
       }
 
       const updated = (await res.json()) as ReviewItem;
+      // queryKey は status: "pending" 前提。pending でなくなった項目はリストから除く。
+      // status: "all" 文脈で呼ぶと approved 項目が一瞬消えて refetch で戻るチラツキが起きる。
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
         isReviewPending(updated.status)
           ? (prev ?? []).map((i) => (i.id === id ? updated : i))
@@ -223,6 +225,7 @@ export function useReviewItems({
             ? item.status
             : "decided";
 
+      // queryKey は status: "pending" 前提。pending でなくなった項目はリストから除く。
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
         isReviewPending(reviewStatus)
           ? (prev ?? []).map((i) =>
@@ -298,6 +301,7 @@ export function useReviewItems({
     }
 
     const updated = (await res.json()) as ReviewItem;
+    // queryKey は status: "pending" 前提。pending でなくなった項目はリストから除く。
     queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
       isReviewPending(updated.status)
         ? (prev ?? []).map((i) => (i.id === id ? updated : i))

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -14,7 +14,7 @@ export type AmbiguityResolution =
 
 type ReviewItemStatus = "pending" | "all" | "decided";
 
-const isReviewPending = (status: string) =>
+export const isReviewPending = (status: string) =>
   status === "draft" || status === "reviewing";
 
 // "pending"/"all" など全バリアントをまとめて invalidate するために status を含まない。

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -294,11 +294,57 @@ export function useReviewItems({
     );
   };
 
+  const resetToPending = async (id: string): Promise<void> => {
+    const item = (query.data ?? []).find((i) => i.id === id);
+    if (!item) throw new Error(`resetToPending: id="${id}" が見つかりません`);
+
+    if (item.sourceTable === "decision_item") {
+      const body: Record<string, unknown> = {
+        version: item.version,
+        status: "draft",
+      };
+      if (item.type === "open_issue") body.decisionState = "open";
+
+      const res = await api["decision-items"][":id"].$patch(
+        {
+          param: { id },
+          json: body as Parameters<
+            (typeof api)["decision-items"][":id"]["$patch"]
+          >[0]["json"],
+        },
+        authHeaders(),
+      );
+      if (!res.ok) throw new Error(`更新に失敗しました (${res.status})`);
+      await queryClient.invalidateQueries({ queryKey });
+      return;
+    }
+
+    if (item.sourceTable === "task") {
+      const res = await api.tasks[":id"].$patch(
+        {
+          param: { id },
+          json: { version: item.version, status: "draft" } as Parameters<
+            (typeof api.tasks)[":id"]["$patch"]
+          >[0]["json"],
+        },
+        authHeaders(),
+      );
+      if (!res.ok) throw new Error(`更新に失敗しました (${res.status})`);
+      await queryClient.invalidateQueries({ queryKey });
+      return;
+    }
+
+    throw new Error(
+      `resetToPending: 未対応の sourceTable="${item.sourceTable}"`,
+    );
+  };
+
   return {
     items: query.data ?? [],
     isLoading: query.isLoading,
     isError: query.isError,
     updateItem,
     resolveAmbiguity,
+    resetToPending,
   };
 }

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -12,25 +12,31 @@ export type AmbiguityResolution =
   | { resolution: "decision_item" }
   | { resolution: "rejected" };
 
+type ReviewItemStatus = "pending" | "all" | "decided";
+
 export function reviewItemsQueryKey(params: {
   meetingId?: string;
   recurringMeetingId?: string;
   organizationId?: string;
+  status?: ReviewItemStatus;
 }) {
+  const status = params.status ?? "pending";
   if (params.meetingId) {
-    return ["meetings", params.meetingId, "review-items"] as const;
+    return ["meetings", params.meetingId, "review-items", status] as const;
   }
   if (params.recurringMeetingId) {
     return [
       "recurring-meetings",
       params.recurringMeetingId,
       "review-items",
+      status,
     ] as const;
   }
   return [
     "organizations",
     params.organizationId ?? "_none",
     "review-items",
+    status,
   ] as const;
 }
 
@@ -38,17 +44,21 @@ export function useReviewItems({
   meetingId,
   recurringMeetingId,
   organizationId,
+  status,
 }: {
   meetingId?: string;
   recurringMeetingId?: string;
   organizationId?: string;
+  status?: ReviewItemStatus;
 }) {
   const queryClient = useQueryClient();
   const queryKey = reviewItemsQueryKey({
     meetingId,
     recurringMeetingId,
     organizationId,
+    status,
   });
+  const statusQuery = status && status !== "pending" ? { status } : {};
 
   const query = useQuery<ReviewItem[]>({
     queryKey,
@@ -56,17 +66,17 @@ export function useReviewItems({
       let res: Response;
       if (meetingId) {
         res = await api.meetings[":id"]["review-items"].$get(
-          { param: { id: meetingId }, query: {} },
+          { param: { id: meetingId }, query: statusQuery },
           authHeaders(),
         );
       } else if (recurringMeetingId) {
         res = await api["recurring-meetings"][":id"]["review-items"].$get(
-          { param: { id: recurringMeetingId }, query: {} },
+          { param: { id: recurringMeetingId }, query: statusQuery },
           authHeaders(),
         );
       } else {
         res = await api.organizations[":id"]["review-items"].$get(
-          { param: { id: organizationId ?? "" }, query: {} },
+          { param: { id: organizationId ?? "" }, query: statusQuery },
           authHeaders(),
         );
       }
@@ -87,12 +97,14 @@ export function useReviewItems({
     if (item?.sourceTable === "decision_item") {
       const body: Record<string, unknown> = { version: item.version };
       if (updates.status !== undefined) {
-        // DecisionItem は "rejected" を持たず "cancelled" が対応する
-        body.status =
-          updates.status === "rejected" ? "cancelled" : updates.status;
-        // open_issue 承認時は AI の次回持ち越しを防ぐため confirmed に昇格する
-        if (updates.status === "decided" && item.type === "open_issue") {
+        if (updates.status === "rejected") {
+          body.status = "cancelled";
+        } else if (updates.status === "decided" && item.type === "open_issue") {
+          // 未決事項の承認は "open"（未決確定）に対応する
+          body.status = "open";
           body.decisionState = "confirmed";
+        } else {
+          body.status = updates.status;
         }
       }
       if (updates.title !== undefined) body.title = updates.title;
@@ -127,8 +139,12 @@ export function useReviewItems({
       }
 
       const updated = (await res.json()) as ReviewItem;
+      const isPending =
+        updated.status === "draft" || updated.status === "reviewing";
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-        (prev ?? []).map((i) => (i.id === id ? updated : i)),
+        isPending
+          ? (prev ?? []).map((i) => (i.id === id ? updated : i))
+          : (prev ?? []).filter((i) => i.id !== id),
       );
       return;
     }
@@ -193,19 +209,23 @@ export function useReviewItems({
             ? item.status
             : "decided";
 
+      const isTaskPending =
+        reviewStatus === "draft" || reviewStatus === "reviewing";
       queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-        (prev ?? []).map((i) =>
-          i.id === id
-            ? {
-                ...i,
-                title: task.title,
-                assignees: task.assignees,
-                deadline: task.dueDate,
-                version: task.version,
-                status: reviewStatus,
-              }
-            : i,
-        ),
+        isTaskPending
+          ? (prev ?? []).map((i) =>
+              i.id === id
+                ? {
+                    ...i,
+                    title: task.title,
+                    assignees: task.assignees,
+                    deadline: task.dueDate,
+                    version: task.version,
+                    status: reviewStatus,
+                  }
+                : i,
+            )
+          : (prev ?? []).filter((i) => i.id !== id),
       );
       return;
     }
@@ -265,8 +285,12 @@ export function useReviewItems({
     }
 
     const updated = (await res.json()) as ReviewItem;
+    const isAmbigPending =
+      updated.status === "draft" || updated.status === "reviewing";
     queryClient.setQueryData<ReviewItem[]>(queryKey, (prev) =>
-      (prev ?? []).map((i) => (i.id === id ? updated : i)),
+      isAmbigPending
+        ? (prev ?? []).map((i) => (i.id === id ? updated : i))
+        : (prev ?? []).filter((i) => i.id !== id),
     );
   };
 

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -14,6 +14,29 @@ export type AmbiguityResolution =
 
 type ReviewItemStatus = "pending" | "all" | "decided";
 
+// ステータスを含まない基底キー。全バリアントをまとめて invalidate するときに使う。
+function reviewItemsBaseQueryKey(params: {
+  meetingId?: string;
+  recurringMeetingId?: string;
+  organizationId?: string;
+}) {
+  if (params.meetingId) {
+    return ["meetings", params.meetingId, "review-items"] as const;
+  }
+  if (params.recurringMeetingId) {
+    return [
+      "recurring-meetings",
+      params.recurringMeetingId,
+      "review-items",
+    ] as const;
+  }
+  return [
+    "organizations",
+    params.organizationId ?? "_none",
+    "review-items",
+  ] as const;
+}
+
 export function reviewItemsQueryKey(params: {
   meetingId?: string;
   recurringMeetingId?: string;
@@ -21,23 +44,7 @@ export function reviewItemsQueryKey(params: {
   status?: ReviewItemStatus;
 }) {
   const status = params.status ?? "pending";
-  if (params.meetingId) {
-    return ["meetings", params.meetingId, "review-items", status] as const;
-  }
-  if (params.recurringMeetingId) {
-    return [
-      "recurring-meetings",
-      params.recurringMeetingId,
-      "review-items",
-      status,
-    ] as const;
-  }
-  return [
-    "organizations",
-    params.organizationId ?? "_none",
-    "review-items",
-    status,
-  ] as const;
+  return [...reviewItemsBaseQueryKey(params), status] as const;
 }
 
 export function useReviewItems({
@@ -52,6 +59,11 @@ export function useReviewItems({
   status?: ReviewItemStatus;
 }) {
   const queryClient = useQueryClient();
+  const baseQueryKey = reviewItemsBaseQueryKey({
+    meetingId,
+    recurringMeetingId,
+    organizationId,
+  });
   const queryKey = reviewItemsQueryKey({
     meetingId,
     recurringMeetingId,
@@ -315,7 +327,7 @@ export function useReviewItems({
         authHeaders(),
       );
       if (!res.ok) throw new Error(`更新に失敗しました (${res.status})`);
-      await queryClient.invalidateQueries({ queryKey });
+      await queryClient.invalidateQueries({ queryKey: baseQueryKey });
       return;
     }
 
@@ -330,7 +342,7 @@ export function useReviewItems({
         authHeaders(),
       );
       if (!res.ok) throw new Error(`更新に失敗しました (${res.status})`);
-      await queryClient.invalidateQueries({ queryKey });
+      await queryClient.invalidateQueries({ queryKey: baseQueryKey });
       return;
     }
 

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -141,7 +141,7 @@ export function useReviewItems({
       );
 
       if (res.status === 409) {
-        await queryClient.invalidateQueries({ queryKey });
+        await queryClient.invalidateQueries({ queryKey: baseQueryKey });
         throw new Error(
           "他のユーザーが先に更新しました。最新の状態を取得しました。",
         );
@@ -158,6 +158,7 @@ export function useReviewItems({
           ? (prev ?? []).map((i) => (i.id === id ? updated : i))
           : (prev ?? []).filter((i) => i.id !== id),
       );
+      await queryClient.invalidateQueries({ queryKey: baseQueryKey });
       return;
     }
 
@@ -191,7 +192,7 @@ export function useReviewItems({
       );
 
       if (res.status === 409) {
-        await queryClient.invalidateQueries({ queryKey });
+        await queryClient.invalidateQueries({ queryKey: baseQueryKey });
         throw new Error(
           "他のユーザーが先に更新しました。最新の状態を取得しました。",
         );
@@ -239,6 +240,7 @@ export function useReviewItems({
             )
           : (prev ?? []).filter((i) => i.id !== id),
       );
+      await queryClient.invalidateQueries({ queryKey: baseQueryKey });
       return;
     }
 
@@ -287,7 +289,7 @@ export function useReviewItems({
     );
 
     if (res.status === 409) {
-      await queryClient.invalidateQueries({ queryKey });
+      await queryClient.invalidateQueries({ queryKey: baseQueryKey });
       throw new Error(
         "他のユーザーが先に更新しました。最新の状態を取得しました。",
       );
@@ -304,6 +306,7 @@ export function useReviewItems({
         ? (prev ?? []).map((i) => (i.id === id ? updated : i))
         : (prev ?? []).filter((i) => i.id !== id),
     );
+    await queryClient.invalidateQueries({ queryKey: baseQueryKey });
   };
 
   const resetToPending = async (id: string): Promise<void> => {

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -475,6 +475,8 @@ function ReviewAccordionItem({
           <ul className="border-t divide-y">
             {items.map((item) => {
               const isPending = isReviewPending(item.status);
+              // TODO: task の in_progress/done は API が 400 を返すが UI はボタンを出す。
+              // ReviewItem に元の task.status を持たせて除外するか、API ガードを緩めるか要検討。
               const canReset =
                 !isPending && item.sourceTable !== "ambiguous_info";
               return (

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -102,7 +102,7 @@ export function MeetingDetailView({
 }) {
   const detailQuery = useMeetingDetail(id);
   const { items: meetingReviewItems, isError: reviewItemsError } =
-    useReviewItems({ meetingId: id });
+    useReviewItems({ meetingId: id, status: "all" });
   const pendingCount = meetingReviewItems.filter(
     (i) => i.status === "draft" || i.status === "reviewing",
   ).length;

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -12,7 +12,10 @@ import {
   TYPE_LABELS,
   type ReviewItem,
 } from "@/features/review/types";
-import { useReviewItems } from "@/features/review/useReviewItems";
+import {
+  isReviewPending,
+  useReviewItems,
+} from "@/features/review/useReviewItems";
 import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
@@ -112,8 +115,8 @@ export function MeetingDetailView({
     isError: reviewItemsError,
     resetToPending,
   } = useReviewItems({ meetingId: id, status: "all" });
-  const pendingCount = meetingReviewItems.filter(
-    (i) => i.status === "draft" || i.status === "reviewing",
+  const pendingCount = meetingReviewItems.filter((i) =>
+    isReviewPending(i.status),
   ).length;
 
   const statusArr = parseStatusParam(search.status);
@@ -418,9 +421,7 @@ function ReviewAccordionItem({
 }) {
   const [open, setOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
-  const pendingCount = items.filter(
-    (i) => i.status === "draft" || i.status === "reviewing",
-  ).length;
+  const pendingCount = items.filter((i) => isReviewPending(i.status)).length;
 
   const handleResetToPending = async (id: string) => {
     setResetError(null);
@@ -473,8 +474,7 @@ function ReviewAccordionItem({
           )}
           <ul className="border-t divide-y">
             {items.map((item) => {
-              const isPending =
-                item.status === "draft" || item.status === "reviewing";
+              const isPending = isReviewPending(item.status);
               const canReset =
                 !isPending && item.sourceTable !== "ambiguous_info";
               return (

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -107,8 +107,11 @@ export function MeetingDetailView({
   now?: Date;
 }) {
   const detailQuery = useMeetingDetail(id);
-  const { items: meetingReviewItems, isError: reviewItemsError, resetToPending } =
-    useReviewItems({ meetingId: id, status: "all" });
+  const {
+    items: meetingReviewItems,
+    isError: reviewItemsError,
+    resetToPending,
+  } = useReviewItems({ meetingId: id, status: "all" });
   const pendingCount = meetingReviewItems.filter(
     (i) => i.status === "draft" || i.status === "reviewing",
   ).length;
@@ -347,7 +350,12 @@ export function MeetingDetailView({
               );
               if (typeItems.length === 0) return null;
               return (
-                <ReviewAccordionItem key={type} type={type} items={typeItems} onResetToPending={resetToPending} />
+                <ReviewAccordionItem
+                  key={type}
+                  type={type}
+                  items={typeItems}
+                  onResetToPending={resetToPending}
+                />
               );
             })}
           </div>

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -472,52 +472,52 @@ function ReviewAccordionItem({
             </p>
           )}
           <ul className="border-t divide-y">
-          {items.map((item) => {
-            const isPending =
-              item.status === "draft" || item.status === "reviewing";
-            const canReset =
-              !isPending && item.sourceTable !== "ambiguous_info";
-            return (
-              <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
-                <div className="flex items-start justify-between gap-2">
-                  <p className="text-sm">{item.title}</p>
-                  <div className="flex items-center gap-1 shrink-0">
-                    <ResolutionBadge
-                      type={type}
-                      status={item.status}
-                      resolutionType={item.resolutionType}
-                    />
-                    {canReset && onResetToPending && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            className="p-0.5 rounded hover:bg-muted text-muted-foreground"
-                            aria-label="メニュー"
-                          >
-                            <MoreHorizontal size={14} />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            className="text-xs"
-                            onClick={() => handleResetToPending(item.id)}
-                          >
-                            レビュー待ちに戻す
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
+            {items.map((item) => {
+              const isPending =
+                item.status === "draft" || item.status === "reviewing";
+              const canReset =
+                !isPending && item.sourceTable !== "ambiguous_info";
+              return (
+                <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="text-sm">{item.title}</p>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <ResolutionBadge
+                        type={type}
+                        status={item.status}
+                        resolutionType={item.resolutionType}
+                      />
+                      {canReset && onResetToPending && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              className="p-0.5 rounded hover:bg-muted text-muted-foreground"
+                              aria-label="メニュー"
+                            >
+                              <MoreHorizontal size={14} />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              className="text-xs"
+                              onClick={() => handleResetToPending(item.id)}
+                            >
+                              レビュー待ちに戻す
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
                   </div>
-                </div>
-                {item.sourceContext && (
-                  <p className="text-xs text-amber-900 bg-amber-50 px-2 py-1 rounded border border-amber-100">
-                    {item.sourceContext}
-                  </p>
-                )}
-              </li>
-            );
-          })}
+                  {item.sourceContext && (
+                    <p className="text-xs text-amber-900 bg-amber-50 px-2 py-1 rounded border border-amber-100">
+                      {item.sourceContext}
+                    </p>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </>
       )}

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -417,9 +417,19 @@ function ReviewAccordionItem({
   onResetToPending?: (id: string) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
   const pendingCount = items.filter(
     (i) => i.status === "draft" || i.status === "reviewing",
   ).length;
+
+  const handleResetToPending = async (id: string) => {
+    setResetError(null);
+    try {
+      await onResetToPending?.(id);
+    } catch (e) {
+      setResetError(e instanceof Error ? e.message : "更新に失敗しました");
+    }
+  };
 
   return (
     <div className="border rounded-lg overflow-hidden">
@@ -455,14 +465,18 @@ function ReviewAccordionItem({
         />
       </button>
       {open && (
-        <ul className="border-t divide-y">
+        <>
+          {resetError && (
+            <p className="px-4 py-2 text-xs text-destructive border-t">
+              {resetError}
+            </p>
+          )}
+          <ul className="border-t divide-y">
           {items.map((item) => {
             const isPending =
               item.status === "draft" || item.status === "reviewing";
             const canReset =
-              !isPending &&
-              onResetToPending &&
-              item.sourceTable !== "ambiguous_info";
+              !isPending && item.sourceTable !== "ambiguous_info";
             return (
               <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
                 <div className="flex items-start justify-between gap-2">
@@ -473,7 +487,7 @@ function ReviewAccordionItem({
                       status={item.status}
                       resolutionType={item.resolutionType}
                     />
-                    {canReset && (
+                    {canReset && onResetToPending && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <button
@@ -486,7 +500,8 @@ function ReviewAccordionItem({
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem
-                            onClick={() => onResetToPending(item.id)}
+                            className="text-xs"
+                            onClick={() => handleResetToPending(item.id)}
                           >
                             レビュー待ちに戻す
                           </DropdownMenuItem>
@@ -503,7 +518,8 @@ function ReviewAccordionItem({
               </li>
             );
           })}
-        </ul>
+          </ul>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,4 +1,10 @@
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import {
   REVIEW_ITEM_TYPES,
@@ -24,7 +30,7 @@ import { authAtom } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, MoreHorizontal } from "lucide-react";
 import { useState } from "react";
 import { z } from "zod";
 
@@ -101,7 +107,7 @@ export function MeetingDetailView({
   now?: Date;
 }) {
   const detailQuery = useMeetingDetail(id);
-  const { items: meetingReviewItems, isError: reviewItemsError } =
+  const { items: meetingReviewItems, isError: reviewItemsError, resetToPending } =
     useReviewItems({ meetingId: id, status: "all" });
   const pendingCount = meetingReviewItems.filter(
     (i) => i.status === "draft" || i.status === "reviewing",
@@ -341,7 +347,7 @@ export function MeetingDetailView({
               );
               if (typeItems.length === 0) return null;
               return (
-                <ReviewAccordionItem key={type} type={type} items={typeItems} />
+                <ReviewAccordionItem key={type} type={type} items={typeItems} onResetToPending={resetToPending} />
               );
             })}
           </div>
@@ -396,9 +402,11 @@ function ResolutionBadge({
 function ReviewAccordionItem({
   type,
   items,
+  onResetToPending,
 }: {
   type: (typeof REVIEW_ITEM_TYPES)[number];
   items: ReviewItem[];
+  onResetToPending?: (id: string) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const pendingCount = items.filter(
@@ -440,23 +448,53 @@ function ReviewAccordionItem({
       </button>
       {open && (
         <ul className="border-t divide-y">
-          {items.map((item) => (
-            <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
-              <div className="flex items-start justify-between gap-2">
-                <p className="text-sm">{item.title}</p>
-                <ResolutionBadge
-                  type={type}
-                  status={item.status}
-                  resolutionType={item.resolutionType}
-                />
-              </div>
-              {item.sourceContext && (
-                <p className="text-xs text-amber-900 bg-amber-50 px-2 py-1 rounded border border-amber-100">
-                  {item.sourceContext}
-                </p>
-              )}
-            </li>
-          ))}
+          {items.map((item) => {
+            const isPending =
+              item.status === "draft" || item.status === "reviewing";
+            const canReset =
+              !isPending &&
+              onResetToPending &&
+              item.sourceTable !== "ambiguous_info";
+            return (
+              <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm">{item.title}</p>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <ResolutionBadge
+                      type={type}
+                      status={item.status}
+                      resolutionType={item.resolutionType}
+                    />
+                    {canReset && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-0.5 rounded hover:bg-muted text-muted-foreground"
+                            aria-label="メニュー"
+                          >
+                            <MoreHorizontal size={14} />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => onResetToPending(item.id)}
+                          >
+                            レビュー待ちに戻す
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </div>
+                </div>
+                {item.sourceContext && (
+                  <p className="text-xs text-amber-900 bg-amber-50 px-2 py-1 rounded border border-amber-100">
+                    {item.sourceContext}
+                  </p>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/api", () => ({
       ":id": {
         $get: vi.fn(),
         tasks: { $get: vi.fn() },
+        "review-items": { $get: vi.fn() },
       },
     },
     organizations: {
@@ -20,6 +21,10 @@ vi.mock("@/lib/api", () => ({
     },
     tasks: {
       $post: vi.fn(),
+      ":id": { $patch: vi.fn() },
+    },
+    "decision-items": {
+      ":id": { $patch: vi.fn() },
     },
   },
   authHeaders: () => ({ headers: {} }),
@@ -33,7 +38,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { api } from "@/lib/api";
 import { MeetingDetailView } from "../routes/meetings.$id";
-
+import type { ReviewItem } from "@/features/review/types";
 import { mockJson } from "./helpers/mockJson";
 
 const detail: MeetingDetail = {
@@ -91,6 +96,9 @@ const sampleTask = {
 beforeEach(() => {
   vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detail));
   vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(mockJson([]));
+  vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+    mockJson([]),
+  );
   // AssigneeFilter のメンバー取得はデフォルトで空配列。個別テストで上書きしない想定。
   vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
     mockJson([]),
@@ -243,5 +251,99 @@ describe("MeetingDetailView", () => {
     expect(
       (call[0] as { query: { assigneeId?: string } }).query.assigneeId,
     ).toBe("user-42");
+  });
+});
+
+// AI抽出結果の3点メニューテスト用ヘルパー
+function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
+  return {
+    id: "ri-1",
+    sourceTable: "decision_item",
+    type: "decision",
+    title: "テスト決定事項",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "decided",
+    assignees: [],
+    deadline: null,
+    severity: null,
+    resolutionType: null,
+    recurringMeetingId: "rmtg-1",
+    recurringMeetingName: "週次定例",
+    meetingId: "mtg-1",
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
+  it("確定済みアイテムに ⋯ メニューボタンが表示される", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([makeReviewItem({ status: "decided" })]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    // アコーディオンを開く
+    const accordion = await screen.findByRole("button", { name: /決定事項/ });
+    await userEvent.click(accordion);
+    expect(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
+  });
+
+  it("レビュー待ち（draft）アイテムには ⋯ メニューボタンが表示されない", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([makeReviewItem({ status: "draft" })]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /決定事項/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.queryByRole("button", { name: "メニュー" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("ambiguous_info には ⋯ メニューボタンが表示されない", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({
+          sourceTable: "ambiguous_info",
+          type: "ambiguity",
+          status: "resolved",
+        }),
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /曖昧箇所/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.queryByRole("button", { name: "メニュー" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("「レビュー待ちに戻す」クリックで decision-items PATCH が呼ばれる", async () => {
+    const item = makeReviewItem({ id: "di-1", status: "decided", version: 2 });
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([item]),
+    );
+    vi.mocked(api["decision-items"][":id"].$patch).mockResolvedValue(
+      mockJson({ ...item, status: "draft" }),
+    );
+
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /決定事項/ });
+    await userEvent.click(accordion);
+    await userEvent.click(screen.getByRole("button", { name: "メニュー" }));
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "レビュー待ちに戻す" }),
+    );
+
+    expect(
+      vi.mocked(api["decision-items"][":id"].$patch),
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        param: { id: "di-1" },
+        json: expect.objectContaining({ status: "draft" }),
+      }),
+      expect.anything(),
+    );
   });
 });

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -309,7 +309,7 @@ describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
         makeReviewItem({
           sourceTable: "ambiguous_info",
           type: "ambiguity",
-          status: "resolved",
+          status: "decided",
         }),
       ]),
     );

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -286,7 +286,9 @@ describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
     // アコーディオンを開く
     const accordion = await screen.findByRole("button", { name: /決定事項/ });
     await userEvent.click(accordion);
-    expect(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "メニュー" }),
+    ).toBeInTheDocument();
   });
 
   it("レビュー待ち（draft）アイテムには ⋯ メニューボタンが表示されない", async () => {
@@ -336,9 +338,7 @@ describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
       screen.getByRole("menuitem", { name: "レビュー待ちに戻す" }),
     );
 
-    expect(
-      vi.mocked(api["decision-items"][":id"].$patch),
-    ).toHaveBeenCalledWith(
+    expect(vi.mocked(api["decision-items"][":id"].$patch)).toHaveBeenCalledWith(
       expect.objectContaining({
         param: { id: "di-1" },
         json: expect.objectContaining({ status: "draft" }),

--- a/apps/web/src/test/review.test.tsx
+++ b/apps/web/src/test/review.test.tsx
@@ -539,6 +539,111 @@ describe("useReviewItems — updateItem", () => {
   });
 });
 
+describe("useReviewItems — resetToPending", () => {
+  it("decision_item の レビュー待ちに戻す で PATCH に status:draft が含まれる", async () => {
+    const item = makeItem({
+      id: "di-reset",
+      sourceTable: "decision_item",
+      type: "decision",
+      status: "decided",
+      version: 3,
+    });
+    vi.mocked(api["decision-items"][":id"].$patch).mockResolvedValue(
+      mockJson({ ...item, status: "draft" as const }),
+    );
+    const { result } = renderHook(
+      () => useReviewItems({ meetingId: "mtg-reset" }),
+      {
+        wrapper: makeWrapper(
+          ["meetings", "mtg-reset", "review-items", "pending"],
+          [item],
+        ),
+      },
+    );
+    await act(async () => {
+      await result.current.resetToPending("di-reset");
+    });
+    expect(vi.mocked(api["decision-items"][":id"].$patch)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({ status: "draft" }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("open_issue の レビュー待ちに戻す で PATCH に status:draft と decisionState:open が含まれる", async () => {
+    const item = makeItem({
+      id: "oi-reset",
+      sourceTable: "decision_item",
+      type: "open_issue",
+      status: "open",
+      version: 2,
+    });
+    vi.mocked(api["decision-items"][":id"].$patch).mockResolvedValue(
+      mockJson({ ...item, status: "draft" as const }),
+    );
+    const { result } = renderHook(
+      () => useReviewItems({ meetingId: "mtg-oi-reset" }),
+      {
+        wrapper: makeWrapper(
+          ["meetings", "mtg-oi-reset", "review-items", "pending"],
+          [item],
+        ),
+      },
+    );
+    await act(async () => {
+      await result.current.resetToPending("oi-reset");
+    });
+    expect(vi.mocked(api["decision-items"][":id"].$patch)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          status: "draft",
+          decisionState: "open",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("task_candidate の レビュー待ちに戻す で PATCH に status:draft が含まれる", async () => {
+    const item = makeItem({
+      id: "t-reset",
+      sourceTable: "task",
+      type: "task_candidate",
+      status: "decided",
+      version: 1,
+    });
+    vi.mocked(api.tasks[":id"].$patch).mockResolvedValue(
+      mockJson({
+        id: "t-reset",
+        title: item.title,
+        status: "draft",
+        assignees: [],
+        dueDate: null,
+        version: 2,
+      }),
+    );
+    const { result } = renderHook(
+      () => useReviewItems({ meetingId: "mtg-t-reset" }),
+      {
+        wrapper: makeWrapper(
+          ["meetings", "mtg-t-reset", "review-items", "pending"],
+          [item],
+        ),
+      },
+    );
+    await act(async () => {
+      await result.current.resetToPending("t-reset");
+    });
+    expect(vi.mocked(api.tasks[":id"].$patch)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({ status: "draft" }),
+      }),
+      expect.anything(),
+    );
+  });
+});
+
 describe("useReviewItems — resolveAmbiguity", () => {
   const ambigItem = makeItem({
     id: "amb-1",

--- a/apps/web/src/test/review.test.tsx
+++ b/apps/web/src/test/review.test.tsx
@@ -451,7 +451,12 @@ describe("useReviewItems — updateItem", () => {
 
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-di" }),
-      { wrapper: makeWrapper(["meetings", "mtg-di", "review-items", "pending"], [item]) },
+      {
+        wrapper: makeWrapper(
+          ["meetings", "mtg-di", "review-items", "pending"],
+          [item],
+        ),
+      },
     );
 
     await act(async () => {
@@ -479,7 +484,12 @@ describe("useReviewItems — updateItem", () => {
 
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-oi" }),
-      { wrapper: makeWrapper(["meetings", "mtg-oi", "review-items", "pending"], [item]) },
+      {
+        wrapper: makeWrapper(
+          ["meetings", "mtg-oi", "review-items", "pending"],
+          [item],
+        ),
+      },
     );
 
     await act(async () => {
@@ -519,7 +529,10 @@ describe("useReviewItems — updateItem", () => {
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-task" }),
       {
-        wrapper: makeWrapper(["meetings", "mtg-task", "review-items", "pending"], [item]),
+        wrapper: makeWrapper(
+          ["meetings", "mtg-task", "review-items", "pending"],
+          [item],
+        ),
       },
     );
 

--- a/apps/web/src/test/review.test.tsx
+++ b/apps/web/src/test/review.test.tsx
@@ -451,7 +451,7 @@ describe("useReviewItems — updateItem", () => {
 
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-di" }),
-      { wrapper: makeWrapper(["meetings", "mtg-di", "review-items"], [item]) },
+      { wrapper: makeWrapper(["meetings", "mtg-di", "review-items", "pending"], [item]) },
     );
 
     await act(async () => {
@@ -466,7 +466,7 @@ describe("useReviewItems — updateItem", () => {
     );
   });
 
-  it("open_issue 承認で PATCH に decisionState:confirmed が含まれる", async () => {
+  it("open_issue 承認で PATCH に status:open と decisionState:confirmed が含まれる", async () => {
     const item = makeItem({
       id: "di-2",
       sourceTable: "decision_item",
@@ -474,12 +474,12 @@ describe("useReviewItems — updateItem", () => {
       version: 1,
     });
     vi.mocked(api["decision-items"][":id"].$patch).mockResolvedValue(
-      mockJson({ ...item, status: "decided" as const }),
+      mockJson({ ...item, status: "open" as const }),
     );
 
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-oi" }),
-      { wrapper: makeWrapper(["meetings", "mtg-oi", "review-items"], [item]) },
+      { wrapper: makeWrapper(["meetings", "mtg-oi", "review-items", "pending"], [item]) },
     );
 
     await act(async () => {
@@ -489,7 +489,7 @@ describe("useReviewItems — updateItem", () => {
     expect(vi.mocked(api["decision-items"][":id"].$patch)).toHaveBeenCalledWith(
       expect.objectContaining({
         json: expect.objectContaining({
-          status: "decided",
+          status: "open",
           decisionState: "confirmed",
         }),
       }),
@@ -519,7 +519,7 @@ describe("useReviewItems — updateItem", () => {
     const { result } = renderHook(
       () => useReviewItems({ meetingId: "mtg-task" }),
       {
-        wrapper: makeWrapper(["meetings", "mtg-task", "review-items"], [item]),
+        wrapper: makeWrapper(["meetings", "mtg-task", "review-items", "pending"], [item]),
       },
     );
 
@@ -546,7 +546,7 @@ describe("useReviewItems — resolveAmbiguity", () => {
     type: "ambiguity",
     version: 0,
   });
-  const ambigKey = ["meetings", "mtg-amb", "review-items"] as const;
+  const ambigKey = ["meetings", "mtg-amb", "review-items", "pending"] as const;
 
   it("resolution:task で PATCH に resolutionType:task が含まれる", async () => {
     vi.mocked(api["ambiguous-infos"][":id"].$patch).mockResolvedValue(


### PR DESCRIPTION
## 関連Issue
Closes #311 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* 会議詳細画面のAI抽出結果に「レビュー待ちに戻す」操作を追加し、承認・却下済みアイテムを再レビュー対象に戻せるようにした
* あわせてレビュー操作後のキャッシュ整合性バグと未決事項の承認挙動を修正した

## 背景
  - 承認・却下したAI抽出結果が会議詳細画面から消えてしまい、確認できなくなるバグがあった
  - 未決事項を承認すると「未決確定」ではなく「決定事項」として扱われるバグがあった
  - レビュー待ちに戻す操作が "pending" キャッシュを無効化できず、レビュー画面に反映されないバグがあった

## 変更内容
  - feat: 会議詳細のAI抽出結果アコーディオンに3点メニュー（「レビュー待ちに戻す」）を追加
  - fix(web): 未決事項の承認を status: "open" + decisionState: "confirmed" に修正
  - fix(web): resetToPending / updateItem / resolveAmbiguity が全キャッシュバリアント（"pending"/"all"）を同期するよう修正
  - fix(api): status: "draft" への遷移を確定済み状態からのみ許可するサーバーサイドガードを追加
  - fix(api): serializeDecisionItem で status: "open" は decisionState によらず open_issue に固定
  - refactor: isReviewPending ヘルパーに集約し3箇所の重複判定を解消、型キャストを除去

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. make devでアプリを開き会議詳細画面にいき「AI抽出結果」セクションでレビューを行う（承認・却下）
  2. 承認・却下後もアイテムが画面上に残り、ステータスバッジが更新されることを確認
  3. 確定済みアイテムの右端に ⋯ メニューが表示されることを確認
  4. ⋯ → 「レビュー待ちに戻す」を押し、レビュー画面に再表示されることを確認
  5. 未決事項を承認し、「未決確定」として表示される（「決定事項」にならない）ことを確認

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1918" height="873" alt="スクリーンショット 2026-05-28 19 01 03" src="https://github.com/user-attachments/assets/e9a322e2-a719-4233-b7e8-735fd97ece9e" />

