### PR TITLE
feat: 会議詳細に会議要約・参加者を追加、ダッシュボード次回定例に参加者を追加

### DIFF
--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -75,8 +75,10 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         recurringMeeting: {
           include: {
             organization: { select: { id: true, name: true } },
+            _count: { select: { members: true } },
             members: {
               take: 4,
+              orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
               include: {
                 user: { select: { id: true, name: true, displayName: true } },
               },
@@ -105,6 +107,7 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         name: recurringMeeting.name,
       },
       organization: recurringMeeting.organization,
+      memberCount: recurringMeeting._count.members,
       members: recurringMeeting.members.map((m) => ({
         userId: m.userId,
         role: m.role,

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -107,7 +107,11 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       members: recurringMeeting.members.map((m) => ({
         userId: m.userId,
         role: m.role,
-        user: { id: m.user.id, name: m.user.name, displayName: m.user.displayName },
+        user: {
+          id: m.user.id,
+          name: m.user.name,
+          displayName: m.user.displayName,
+        },
       })),
       latestAnalysisRun: latestRun
         ? {

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -76,6 +76,7 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
           include: {
             organization: { select: { id: true, name: true } },
             members: {
+              take: 4,
               include: {
                 user: { select: { id: true, name: true, displayName: true } },
               },

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -75,6 +75,11 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         recurringMeeting: {
           include: {
             organization: { select: { id: true, name: true } },
+            members: {
+              include: {
+                user: { select: { id: true, name: true, displayName: true } },
+              },
+            },
           },
         },
         // 解析ラン最新 1 件をポーリング用に含める
@@ -99,6 +104,11 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
         name: recurringMeeting.name,
       },
       organization: recurringMeeting.organization,
+      members: recurringMeeting.members.map((m) => ({
+        userId: m.userId,
+        role: m.role,
+        user: { id: m.user.id, name: m.user.name, displayName: m.user.displayName },
+      })),
       latestAnalysisRun: latestRun
         ? {
             id: latestRun.id,

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -290,7 +290,9 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
         _count: { select: { members: true } },
         members: {
           take: 4,
-          include: { user: { select: { id: true, name: true, displayName: true } } },
+          include: {
+            user: { select: { id: true, name: true, displayName: true } },
+          },
         },
       },
     });

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -281,14 +281,15 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
-    // _count.members はバッジ表示用、members は先頭5件をアバター表示用に含める。
+    // _count.members はバッジ表示用、members は先頭4件をアバター表示用に含める。
+    // AvatarStack のデフォルト max=4 と合わせる。
     const meetings = await prisma.recurringMeeting.findMany({
       where: { organizationId: id },
       orderBy: { createdAt: "desc" },
       include: {
         _count: { select: { members: true } },
         members: {
-          take: 5,
+          take: 4,
           include: { user: { select: { id: true, name: true, displayName: true } } },
         },
       },

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -290,6 +290,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
         _count: { select: { members: true } },
         members: {
           take: 4,
+          orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
           include: {
             user: { select: { id: true, name: true, displayName: true } },
           },

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -281,12 +281,17 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
     const guard = await requireOrgMembership(c, id);
     if (!guard.ok) return guard.res;
 
-    // 一覧画面でメンバー数バッジを出せるよう _count.members を併せて取得する。
-    // メンバー詳細は重いので別エンドポイント（GET /recurring-meetings/:id）で返す。
+    // _count.members はバッジ表示用、members は先頭5件をアバター表示用に含める。
     const meetings = await prisma.recurringMeeting.findMany({
       where: { organizationId: id },
       orderBy: { createdAt: "desc" },
-      include: { _count: { select: { members: true } } },
+      include: {
+        _count: { select: { members: true } },
+        members: {
+          take: 5,
+          include: { user: { select: { id: true, name: true, displayName: true } } },
+        },
+      },
     });
     return c.json(meetings);
   })

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -285,6 +285,54 @@ describe("GET /meetings/:id", () => {
     expect(body.latestAnalysisRun).toBeNull();
   });
 
+  it("members がある場合 レスポンスに整形して含む", async () => {
+    mockFindUnique.mockResolvedValue({
+      ...detailMeeting,
+      recurringMeeting: {
+        ...detailMeeting.recurringMeeting,
+        members: [
+          {
+            userId: "u-1",
+            role: "owner",
+            user: { id: "u-1", name: "Alice", displayName: "Alice" },
+          },
+          {
+            userId: "u-2",
+            role: "member",
+            user: { id: "u-2", name: "Bob", displayName: "Bob" },
+          },
+        ],
+      },
+    } as MeetingDetail);
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+
+    const res = await app.request("/meetings/mtg-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      members: Array<{
+        userId: string;
+        role: string;
+        user: { id: string; name: string; displayName: string };
+      }>;
+    };
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0]).toEqual({
+      userId: "u-1",
+      role: "owner",
+      user: { id: "u-1", name: "Alice", displayName: "Alice" },
+    });
+    expect(body.members[1]).toEqual({
+      userId: "u-2",
+      role: "member",
+      user: { id: "u-2", name: "Bob", displayName: "Bob" },
+    });
+  });
+
   it("解析ランがある場合 latestAnalysisRun を含む", async () => {
     const run = {
       id: "run-1",

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -72,11 +72,18 @@ import type { TaskWithList } from "../src/lib/task-serialization.js";
 type MeetingWithRecurringOrgId = Prisma.MeetingGetPayload<{
   include: { recurringMeeting: { select: { organizationId: true } } };
 }>;
-// GET /meetings/:id ハンドラ用: recurringMeeting に organization (id/name) と analysisRuns を含む
+// GET /meetings/:id ハンドラ用: recurringMeeting に organization・members と analysisRuns を含む
 type MeetingDetail = Prisma.MeetingGetPayload<{
   include: {
     recurringMeeting: {
-      include: { organization: { select: { id: true; name: true } } };
+      include: {
+        organization: { select: { id: true; name: true } };
+        members: {
+          include: {
+            user: { select: { id: true; name: true; displayName: true } };
+          };
+        };
+      };
     };
     analysisRuns: { orderBy: { createdAt: "desc" }; take: 1 };
   };
@@ -248,6 +255,7 @@ describe("GET /meetings/:id", () => {
       name: "週次定例",
       organizationId: "org-1",
       organization: { id: "org-1", name: "ACME" },
+      members: [],
     },
     analysisRuns: [],
   } satisfies Partial<MeetingDetail>;

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -78,6 +78,7 @@ type MeetingDetail = Prisma.MeetingGetPayload<{
     recurringMeeting: {
       include: {
         organization: { select: { id: true; name: true } };
+        _count: { select: { members: true } };
         members: {
           include: {
             user: { select: { id: true; name: true; displayName: true } };
@@ -255,6 +256,7 @@ describe("GET /meetings/:id", () => {
       name: "週次定例",
       organizationId: "org-1",
       organization: { id: "org-1", name: "ACME" },
+      _count: { members: 0 },
       members: [],
     },
     analysisRuns: [],
@@ -290,6 +292,7 @@ describe("GET /meetings/:id", () => {
       ...detailMeeting,
       recurringMeeting: {
         ...detailMeeting.recurringMeeting,
+        _count: { members: 5 },
         members: [
           {
             userId: "u-1",
@@ -314,12 +317,14 @@ describe("GET /meetings/:id", () => {
     const res = await app.request("/meetings/mtg-1");
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
+      memberCount: number;
       members: Array<{
         userId: string;
         role: string;
         user: { id: string; name: string; displayName: string };
       }>;
     };
+    expect(body.memberCount).toBe(5);
     expect(body.members).toHaveLength(2);
     expect(body.members[0]).toEqual({
       userId: "u-1",

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -362,6 +362,7 @@ describe("GET /organizations/:id/meetings", () => {
         _count: { select: { members: true } },
         members: {
           take: 4,
+          orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
           include: {
             user: { select: { id: true, name: true, displayName: true } },
           },

--- a/apps/api/test/recurring-meetings.test.ts
+++ b/apps/api/test/recurring-meetings.test.ts
@@ -358,7 +358,15 @@ describe("GET /organizations/:id/meetings", () => {
     expect(mockRecurringFindMany).toHaveBeenCalledWith({
       where: { organizationId: "org-1" },
       orderBy: { createdAt: "desc" },
-      include: { _count: { select: { members: true } } },
+      include: {
+        _count: { select: { members: true } },
+        members: {
+          take: 4,
+          include: {
+            user: { select: { id: true, name: true, displayName: true } },
+          },
+        },
+      },
     });
   });
 

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -24,6 +24,11 @@ export type MeetingDetail = {
     alertLevel: string | null;
     completedAt: string | null;
   } | null;
+  members?: {
+    userId: string;
+    role: string;
+    user: { id: string; name: string; displayName: string };
+  }[];
 };
 
 // 会議詳細を取得する hook。クエリキーは ["meetings", id, "detail"]。

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -2,7 +2,6 @@ import { api, authHeaders } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 
 // 会議詳細レスポンス。API 側 (apps/api/src/routes/meetings.ts) の整形に揃える。
-// 議事録メタ・解析結果などは別 Issue で拡張予定なので、ここでは最小限に絞っている。
 export type MeetingDetail = {
   id: string;
   title: string;
@@ -18,6 +17,13 @@ export type MeetingDetail = {
   createdAt: string;
   recurringMeeting: { id: string; name: string };
   organization: { id: string; name: string };
+  latestAnalysisRun: {
+    id: string;
+    status: string;
+    summary: string | null;
+    alertLevel: string | null;
+    completedAt: string | null;
+  } | null;
 };
 
 // 会議詳細を取得する hook。クエリキーは ["meetings", id, "detail"]。

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -24,7 +24,7 @@ export type MeetingDetail = {
     alertLevel: string | null;
     completedAt: string | null;
   } | null;
-  members?: {
+  members: {
     userId: string;
     role: string;
     user: { id: string; name: string; displayName: string };

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -24,6 +24,7 @@ export type MeetingDetail = {
     alertLevel: string | null;
     completedAt: string | null;
   } | null;
+  memberCount: number;
   members: {
     userId: string;
     role: string;

--- a/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
@@ -2,9 +2,14 @@ import type { RecurringMeeting } from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 
-// 一覧 API は _count.members を付与して返すため、UI 用に型を拡張する。
+// 一覧 API は _count.members とアバター用の先頭5件 members を返す。
 export type RecurringMeetingListItem = RecurringMeeting & {
   _count: { members: number };
+  members: {
+    userId: string;
+    role: string;
+    user: { id: string; name: string; displayName: string };
+  }[];
 };
 
 // 組織配下の定例一覧を取得する hook。

--- a/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useOrganizationMeetings.ts
@@ -2,7 +2,7 @@ import type { RecurringMeeting } from "@/features/organizations/types";
 import { api, authHeaders } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 
-// 一覧 API は _count.members とアバター用の先頭5件 members を返す。
+// 一覧 API は _count.members とアバター用の先頭4件 members を返す。
 export type RecurringMeetingListItem = RecurringMeeting & {
   _count: { members: number };
   members: {

--- a/apps/web/src/features/tasks/components/AvatarStack.tsx
+++ b/apps/web/src/features/tasks/components/AvatarStack.tsx
@@ -41,17 +41,20 @@ export function AvatarStack({
   users,
   max = 4,
   size = "sm",
+  extraCount = 0,
 }: {
   users: AvatarUser[];
   max?: number;
   size?: "sm" | "md";
+  // API 側で件数を絞って渡す場合に、実際の残り人数を上書きするための補正値。
+  extraCount?: number;
 }) {
   if (users.length === 0) {
     return <span className="text-xs text-muted-foreground">担当者未指定</span>;
   }
 
   const shown = users.slice(0, max);
-  const remaining = users.length - shown.length;
+  const remaining = users.length - shown.length + extraCount;
   const sizeClass = size === "sm" ? "h-6 w-6 text-[10px]" : "h-7 w-7 text-xs";
 
   return (

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -56,11 +56,13 @@ function NextMeetingCard({
   recurringMeetingName,
   next,
   members,
+  memberCount,
 }: {
   recurringMeetingId: string;
   recurringMeetingName: string;
   next: MeetingListItem;
   members: AvatarUser[];
+  memberCount: number;
 }) {
   return (
     <Card className="w-64 shrink-0 snap-start">
@@ -74,7 +76,13 @@ function NextMeetingCard({
           {formatMeetingTime(next.heldAt, next.estimatedDurationMinutes)}
         </p>
         <div className="flex items-center justify-between mt-1">
-          {members.length > 0 && <AvatarStack users={members} size="sm" />}
+          {memberCount > 0 && (
+            <AvatarStack
+              users={members}
+              size="sm"
+              extraCount={memberCount - members.length}
+            />
+          )}
           <Link
             to="/recurring-meetings/$id"
             params={{ id: recurringMeetingId }}
@@ -97,6 +105,7 @@ type Candidate = {
   recurringMeetingName: string;
   next: MeetingListItem;
   members: AvatarUser[];
+  memberCount: number;
 };
 
 function NextMeetingsSection({ orgId }: { orgId: string }) {
@@ -139,6 +148,7 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
           id: m.user.id,
           displayName: m.user.displayName || m.user.name,
         })),
+        memberCount: rm._count.members,
       });
     }
   }
@@ -173,6 +183,7 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
             recurringMeetingName={c.recurringMeetingName}
             next={c.next}
             members={c.members}
+            memberCount={c.memberCount}
           />
         ))}
       </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -12,6 +12,10 @@ import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
+import {
+  AvatarStack,
+  type AvatarUser,
+} from "@/features/tasks/components/AvatarStack";
 import { ArrowRight, ChevronRight } from "lucide-react";
 
 export const Route = createFileRoute("/")({
@@ -51,10 +55,12 @@ function NextMeetingCard({
   recurringMeetingId,
   recurringMeetingName,
   next,
+  members,
 }: {
   recurringMeetingId: string;
   recurringMeetingName: string;
   next: MeetingListItem;
+  members: AvatarUser[];
 }) {
   return (
     <Card className="w-64 shrink-0 snap-start">
@@ -67,13 +73,8 @@ function NextMeetingCard({
         <p className="text-xs text-muted-foreground tabular-nums">
           {formatMeetingTime(next.heldAt, next.estimatedDurationMinutes)}
         </p>
-        {/* TODO: 参加者一覧 API が実装されたらアバターを表示する */}
         <div className="flex items-center justify-between mt-1">
-          <div className="flex items-center gap-1">
-            <div className="size-5 rounded-full bg-muted-foreground/20" />
-            <div className="size-5 rounded-full bg-muted-foreground/20" />
-            <div className="size-5 rounded-full bg-muted-foreground/20" />
-          </div>
+          <AvatarStack users={members} size="sm" />
           <Link
             to="/recurring-meetings/$id"
             params={{ id: recurringMeetingId }}
@@ -95,6 +96,7 @@ type Candidate = {
   recurringMeetingId: string;
   recurringMeetingName: string;
   next: MeetingListItem;
+  members: AvatarUser[];
 };
 
 function NextMeetingsSection({ orgId }: { orgId: string }) {
@@ -133,6 +135,10 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
         recurringMeetingId: rm.id,
         recurringMeetingName: rm.name,
         next,
+        members: rm.members.map((m) => ({
+          id: m.user.id,
+          displayName: m.user.displayName || m.user.name,
+        })),
       });
     }
   }
@@ -166,6 +172,7 @@ function NextMeetingsSection({ orgId }: { orgId: string }) {
             recurringMeetingId={c.recurringMeetingId}
             recurringMeetingName={c.recurringMeetingName}
             next={c.next}
+            members={c.members}
           />
         ))}
       </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -74,7 +74,7 @@ function NextMeetingCard({
           {formatMeetingTime(next.heldAt, next.estimatedDurationMinutes)}
         </p>
         <div className="flex items-center justify-between mt-1">
-          <AvatarStack users={members} size="sm" />
+          {members.length > 0 && <AvatarStack users={members} size="sm" />}
           <Link
             to="/recurring-meetings/$id"
             params={{ id: recurringMeetingId }}

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -25,6 +25,10 @@ import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import {
+  AvatarStack,
+  type AvatarUser,
+} from "@/features/tasks/components/AvatarStack";
 import { useState } from "react";
 import { z } from "zod";
 
@@ -174,16 +178,25 @@ export function MeetingDetailView({
         <h1 id="meeting-title" className="text-2xl font-bold">
           {detail.title}
         </h1>
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
           <span>{formatDateTime(detail.heldAt)}</span>
           {detail.estimatedDurationMinutes !== null && (
             <span>{detail.estimatedDurationMinutes} 分</span>
           )}
+          {(detail.members?.length ?? 0) > 0 && (
+            <AvatarStack
+              users={(detail.members ?? []).map<AvatarUser>((m) => ({
+                id: m.user.id,
+                displayName: m.user.displayName || m.user.name,
+              }))}
+            />
+          )}
         </div>
       </header>
 
-      {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる（過去の会議のみ） */}
+      {new Date(detail.heldAt) <= new Date() && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
           <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
             <span className="text-sm font-semibold flex-1">会議要約</span>
@@ -258,7 +271,8 @@ export function MeetingDetailView({
             )}
           </div>
         </Card>
-      </div>
+        </div>
+      )}
 
       {/* 下段: タスク（フルwidth） */}
       <section aria-label="タスク" className="space-y-3">

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -195,7 +195,7 @@ export function MeetingDetailView({
       </header>
 
       {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる（過去の会議のみ） */}
-      {new Date(detail.heldAt) <= new Date() && (
+      {new Date(detail.heldAt) <= (now ?? new Date()) && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
           <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -197,7 +197,7 @@ export function MeetingDetailView({
       </header>
 
       {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる（過去の会議のみ） */}
-      {new Date(detail.heldAt) <= (now ?? new Date()) && (
+      {isPastMeeting && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           <Card
             aria-label="会議要約"

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -112,9 +112,6 @@ export function MeetingDetailView({
     : false;
   const { items: meetingReviewItems, isError: reviewItemsError } =
     useReviewItems({ meetingId: isPastMeeting ? id : undefined });
-  const pendingCount = meetingReviewItems.filter(
-    (i) => i.status === "draft" || i.status === "reviewing",
-  ).length;
 
   const statusArr = parseStatusParam(search.status);
   // Kanban view では status は列として可視化されるため、フィルタ UI も API への
@@ -202,7 +199,10 @@ export function MeetingDetailView({
       {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる（過去の会議のみ） */}
       {new Date(detail.heldAt) <= (now ?? new Date()) && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
+          <Card
+            aria-label="会議要約"
+            className="gap-0 py-0 overflow-hidden h-75"
+          >
             <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
               <span className="text-sm font-semibold flex-1">会議要約</span>
             </div>
@@ -214,7 +214,10 @@ export function MeetingDetailView({
           </Card>
 
           {/* AI抽出結果セクション（読み取り専用・アコーディオン） */}
-          <Card aria-label="AI抽出結果" className="gap-0 py-0 overflow-hidden h-75">
+          <Card
+            aria-label="AI抽出結果"
+            className="gap-0 py-0 overflow-hidden h-75"
+          >
             <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
               <span className="text-sm font-semibold flex-1">AI抽出結果</span>
               {meetingReviewItems.length > 0 && (

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import {
   REVIEW_ITEM_TYPES,
@@ -182,6 +182,85 @@ export function MeetingDetailView({
         </div>
       </header>
 
+      {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
+          <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
+            <span className="text-sm font-semibold flex-1">会議要約</span>
+          </div>
+          <div className="px-5 py-4 flex-1 overflow-y-auto">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {detail.latestAnalysisRun?.summary ?? "要約はまだありません"}
+            </p>
+          </div>
+        </Card>
+
+        {/* AI抽出結果セクション（読み取り専用・アコーディオン） */}
+        <Card aria-label="AI抽出結果" className="gap-0 py-0 overflow-hidden h-75">
+          <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
+            <span className="text-sm font-semibold flex-1">AI抽出結果</span>
+            {meetingReviewItems.length > 0 && (
+              <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+                {meetingReviewItems.length}
+              </span>
+            )}
+            {pendingCount > 0 ? (
+              <Link
+                to="/review"
+                search={{
+                  recurringMeetingId: detail.recurringMeeting.id,
+                  meetingId: id,
+                  from: "hub",
+                }}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronRight size={15} />
+              </Link>
+            ) : meetingReviewItems.length > 0 ? (
+              <Link
+                to="/review"
+                search={{
+                  recurringMeetingId: detail.recurringMeeting.id,
+                  meetingId: id,
+                  from: "hub",
+                }}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronRight size={15} />
+              </Link>
+            ) : null}
+          </div>
+          <div className="px-5 py-4 flex-1 overflow-y-auto">
+            {reviewItemsError ? (
+              <p className="text-sm text-destructive">
+                AI抽出結果の取得に失敗しました
+              </p>
+            ) : meetingReviewItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                AI抽出結果はまだありません
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {REVIEW_ITEM_TYPES.map((type) => {
+                  const typeItems = meetingReviewItems.filter(
+                    (i) => i.type === type,
+                  );
+                  if (typeItems.length === 0) return null;
+                  return (
+                    <ReviewAccordionItem
+                      key={type}
+                      type={type}
+                      items={typeItems}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      {/* 下段: タスク（フルwidth） */}
       <section aria-label="タスク" className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-semibold">タスク</h2>
@@ -288,63 +367,6 @@ export function MeetingDetailView({
             ariaLabel="会議由来のタスク一覧"
             now={now}
           />
-        )}
-      </section>
-
-      {/* AI抽出結果セクション（読み取り専用・アコーディオン） */}
-      <section aria-label="AI抽出結果" className="space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className="text-lg font-semibold">AI抽出結果</h2>
-          {pendingCount > 0 ? (
-            <Link
-              to="/review"
-              search={{
-                recurringMeetingId: detail.recurringMeeting.id,
-                meetingId: id,
-                from: "hub",
-              }}
-            >
-              <Button size="sm" className="gap-1">
-                レビューして確定する（{pendingCount}件）
-                <ChevronRight size={14} />
-              </Button>
-            </Link>
-          ) : meetingReviewItems.length > 0 ? (
-            <Link
-              to="/review"
-              search={{
-                recurringMeetingId: detail.recurringMeeting.id,
-                meetingId: id,
-                from: "hub",
-              }}
-            >
-              <Button size="sm" variant="outline" className="gap-1">
-                確定済み（レビュー内容を見る）
-                <ChevronRight size={14} />
-              </Button>
-            </Link>
-          ) : null}
-        </div>
-        {reviewItemsError ? (
-          <p className="text-sm text-destructive">
-            AI抽出結果の取得に失敗しました
-          </p>
-        ) : meetingReviewItems.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            AI抽出結果はまだありません
-          </p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {REVIEW_ITEM_TYPES.map((type) => {
-              const typeItems = meetingReviewItems.filter(
-                (i) => i.type === type,
-              );
-              if (typeItems.length === 0) return null;
-              return (
-                <ReviewAccordionItem key={type} type={type} items={typeItems} />
-              );
-            })}
-          </div>
         )}
       </section>
     </section>

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
 import {
@@ -7,6 +8,10 @@ import {
   type ReviewItem,
 } from "@/features/review/types";
 import { useReviewItems } from "@/features/review/useReviewItems";
+import {
+  AvatarStack,
+  type AvatarUser,
+} from "@/features/tasks/components/AvatarStack";
 import { AssigneeFilter } from "@/features/tasks/components/AssigneeFilter";
 import { CreateTaskDialog } from "@/features/tasks/components/CreateTaskDialog";
 import { KanbanBoard } from "@/features/tasks/components/KanbanBoard";
@@ -17,19 +22,14 @@ import {
   type TaskView,
 } from "@/features/tasks/components/ViewToggle";
 import { useMeetingTasks } from "@/features/tasks/hooks/useMeetingTasks";
-import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import { taskStatusLabels } from "@/features/tasks/labels";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import type { TaskListFilters, TaskStatus } from "@/features/tasks/types";
 import { authAtom } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import {
-  AvatarStack,
-  type AvatarUser,
-} from "@/features/tasks/components/AvatarStack";
-import { useState } from "react";
 import { z } from "zod";
 
 // 手動経路で表示する status の選択肢。AI 専用の draft/reviewing は UI から除外。
@@ -105,8 +105,13 @@ export function MeetingDetailView({
   now?: Date;
 }) {
   const detailQuery = useMeetingDetail(id);
+
+  // 過去の会議のみレビューアイテムを取得する。未来の会議は meetingId を渡さず無効化。
+  const isPastMeeting = detailQuery.data
+    ? new Date(detailQuery.data.heldAt) <= (now ?? new Date())
+    : false;
   const { items: meetingReviewItems, isError: reviewItemsError } =
-    useReviewItems({ meetingId: id });
+    useReviewItems({ meetingId: isPastMeeting ? id : undefined });
   const pendingCount = meetingReviewItems.filter(
     (i) => i.status === "draft" || i.status === "reviewing",
   ).length;
@@ -183,9 +188,9 @@ export function MeetingDetailView({
           {detail.estimatedDurationMinutes !== null && (
             <span>{detail.estimatedDurationMinutes} 分</span>
           )}
-          {(detail.members?.length ?? 0) > 0 && (
+          {detail.members.length > 0 && (
             <AvatarStack
-              users={(detail.members ?? []).map<AvatarUser>((m) => ({
+              users={detail.members.map<AvatarUser>((m) => ({
                 id: m.user.id,
                 displayName: m.user.displayName || m.user.name,
               }))}
@@ -197,80 +202,68 @@ export function MeetingDetailView({
       {/* 上段: 会議要約 ＋ AI抽出結果 を2カラムで並べる（過去の会議のみ） */}
       {new Date(detail.heldAt) <= (now ?? new Date()) && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
-          <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
-            <span className="text-sm font-semibold flex-1">会議要約</span>
-          </div>
-          <div className="px-5 py-4 flex-1 overflow-y-auto">
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              {detail.latestAnalysisRun?.summary ?? "要約はまだありません"}
-            </p>
-          </div>
-        </Card>
+          <Card aria-label="会議要約" className="gap-0 py-0 overflow-hidden h-75">
+            <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
+              <span className="text-sm font-semibold flex-1">会議要約</span>
+            </div>
+            <div className="px-5 py-4 flex-1 overflow-y-auto">
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {detail.latestAnalysisRun?.summary ?? "要約はまだありません"}
+              </p>
+            </div>
+          </Card>
 
-        {/* AI抽出結果セクション（読み取り専用・アコーディオン） */}
-        <Card aria-label="AI抽出結果" className="gap-0 py-0 overflow-hidden h-75">
-          <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
-            <span className="text-sm font-semibold flex-1">AI抽出結果</span>
-            {meetingReviewItems.length > 0 && (
-              <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
-                {meetingReviewItems.length}
-              </span>
-            )}
-            {pendingCount > 0 ? (
-              <Link
-                to="/review"
-                search={{
-                  recurringMeetingId: detail.recurringMeeting.id,
-                  meetingId: id,
-                  from: "hub",
-                }}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <ChevronRight size={15} />
-              </Link>
-            ) : meetingReviewItems.length > 0 ? (
-              <Link
-                to="/review"
-                search={{
-                  recurringMeetingId: detail.recurringMeeting.id,
-                  meetingId: id,
-                  from: "hub",
-                }}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <ChevronRight size={15} />
-              </Link>
-            ) : null}
-          </div>
-          <div className="px-5 py-4 flex-1 overflow-y-auto">
-            {reviewItemsError ? (
-              <p className="text-sm text-destructive">
-                AI抽出結果の取得に失敗しました
-              </p>
-            ) : meetingReviewItems.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                AI抽出結果はまだありません
-              </p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                {REVIEW_ITEM_TYPES.map((type) => {
-                  const typeItems = meetingReviewItems.filter(
-                    (i) => i.type === type,
-                  );
-                  if (typeItems.length === 0) return null;
-                  return (
-                    <ReviewAccordionItem
-                      key={type}
-                      type={type}
-                      items={typeItems}
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        </Card>
+          {/* AI抽出結果セクション（読み取り専用・アコーディオン） */}
+          <Card aria-label="AI抽出結果" className="gap-0 py-0 overflow-hidden h-75">
+            <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
+              <span className="text-sm font-semibold flex-1">AI抽出結果</span>
+              {meetingReviewItems.length > 0 && (
+                <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+                  {meetingReviewItems.length}
+                </span>
+              )}
+              {meetingReviewItems.length > 0 && (
+                <Link
+                  to="/review"
+                  search={{
+                    recurringMeetingId: detail.recurringMeeting.id,
+                    meetingId: id,
+                    from: "hub",
+                  }}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ChevronRight size={15} />
+                </Link>
+              )}
+            </div>
+            <div className="px-5 py-4 flex-1 overflow-y-auto">
+              {reviewItemsError ? (
+                <p className="text-sm text-destructive">
+                  AI抽出結果の取得に失敗しました
+                </p>
+              ) : meetingReviewItems.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  AI抽出結果はまだありません
+                </p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {REVIEW_ITEM_TYPES.map((type) => {
+                    const typeItems = meetingReviewItems.filter(
+                      (i) => i.type === type,
+                    );
+                    if (typeItems.length === 0) return null;
+                    return (
+                      <ReviewAccordionItem
+                        key={type}
+                        type={type}
+                        items={typeItems}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </Card>
         </div>
       )}
 

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -200,12 +200,13 @@ export function MeetingDetailView({
           {detail.estimatedDurationMinutes !== null && (
             <span>{detail.estimatedDurationMinutes} 分</span>
           )}
-          {detail.members.length > 0 && (
+          {detail.memberCount > 0 && (
             <AvatarStack
               users={detail.members.map<AvatarUser>((m) => ({
                 id: m.user.id,
                 displayName: m.user.displayName || m.user.name,
               }))}
+              extraCount={detail.memberCount - detail.members.length}
             />
           )}
         </div>

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   DropdownMenu,
@@ -124,7 +123,10 @@ export function MeetingDetailView({
     items: meetingReviewItems,
     isError: reviewItemsError,
     resetToPending,
-  } = useReviewItems({ meetingId: isPastMeeting ? id : undefined, status: "all" });
+  } = useReviewItems({
+    meetingId: isPastMeeting ? id : undefined,
+    status: "all",
+  });
 
   const statusArr = parseStatusParam(search.status);
   // Kanban view では status は列として可視化されるため、フィルタ UI も API への

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -77,8 +77,8 @@ const NEAR_FUTURE = "2099-01-01T10:00:00.000Z";
 const FAR_FUTURE = "2099-06-01T10:00:00.000Z";
 const PAST = "2000-01-01T10:00:00.000Z";
 
-const RM_1 = { id: "rm-1", name: "週次定例", _count: { members: 0 } };
-const RM_2 = { id: "rm-2", name: "月次レビュー", _count: { members: 0 } };
+const RM_1 = { id: "rm-1", name: "週次定例", _count: { members: 0 }, members: [] };
+const RM_2 = { id: "rm-2", name: "月次レビュー", _count: { members: 0 }, members: [] };
 
 function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
   return {
@@ -289,6 +289,56 @@ describe("Dashboard - NextMeetingsSection", () => {
     expect(
       await screen.findByText("定例の取得に失敗しました"),
     ).toBeInTheDocument();
+  });
+
+  it("members があるとき AvatarStack が表示される", async () => {
+    const rmWithMembers = {
+      ...RM_1,
+      members: [
+        { userId: "u-1", role: "owner", user: { id: "u-1", name: "Alice", displayName: "Alice" } },
+      ],
+    };
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([rmWithMembers]),
+    );
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([
+        {
+          id: "mtg-1",
+          title: "週次定例 会議",
+          heldAt: NEAR_FUTURE,
+          estimatedDurationMinutes: 60,
+          recurringMeetingId: "rm-1",
+        },
+      ]),
+    );
+    render();
+    await screen.findByText("週次定例");
+    expect(
+      screen.getByRole("group", { name: /担当者: Alice/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("members が空のとき AvatarStack が表示されない", async () => {
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([RM_1]),
+    );
+    vi.mocked(api["recurring-meetings"][":id"].meetings.$get).mockResolvedValue(
+      mockJson([
+        {
+          id: "mtg-1",
+          title: "週次定例 会議",
+          heldAt: NEAR_FUTURE,
+          estimatedDurationMinutes: 60,
+          recurringMeetingId: "rm-1",
+        },
+      ]),
+    );
+    render();
+    await screen.findByText("週次定例");
+    expect(
+      screen.queryByRole("group", { name: /担当者:/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("「詳細」リンクが最も直近の定例の id のページに向いている", async () => {

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -77,8 +77,18 @@ const NEAR_FUTURE = "2099-01-01T10:00:00.000Z";
 const FAR_FUTURE = "2099-06-01T10:00:00.000Z";
 const PAST = "2000-01-01T10:00:00.000Z";
 
-const RM_1 = { id: "rm-1", name: "週次定例", _count: { members: 0 }, members: [] };
-const RM_2 = { id: "rm-2", name: "月次レビュー", _count: { members: 0 }, members: [] };
+const RM_1 = {
+  id: "rm-1",
+  name: "週次定例",
+  _count: { members: 0 },
+  members: [],
+};
+const RM_2 = {
+  id: "rm-2",
+  name: "月次レビュー",
+  _count: { members: 0 },
+  members: [],
+};
 
 function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
   return {
@@ -295,7 +305,11 @@ describe("Dashboard - NextMeetingsSection", () => {
     const rmWithMembers = {
       ...RM_1,
       members: [
-        { userId: "u-1", role: "owner", user: { id: "u-1", name: "Alice", displayName: "Alice" } },
+        {
+          userId: "u-1",
+          role: "owner",
+          user: { id: "u-1", name: "Alice", displayName: "Alice" },
+        },
       ],
     };
     vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -304,6 +304,7 @@ describe("Dashboard - NextMeetingsSection", () => {
   it("members があるとき AvatarStack が表示される", async () => {
     const rmWithMembers = {
       ...RM_1,
+      _count: { members: 1 },
       members: [
         {
           userId: "u-1",

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -387,6 +387,10 @@ function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
 }
 
 describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
+  beforeEach(() => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detailPast));
+  });
+
   it("確定済みアイテムに ⋯ メニューボタンが表示される", async () => {
     vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
       mockJson([makeReviewItem({ status: "decided" })]),

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/api", () => ({
       ":id": {
         $get: vi.fn(),
         tasks: { $get: vi.fn() },
+        "review-items": { $get: vi.fn() },
       },
     },
     organizations: {
@@ -91,6 +92,9 @@ const sampleTask = {
 beforeEach(() => {
   vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detail));
   vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(mockJson([]));
+  vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+    mockJson([]),
+  );
   // AssigneeFilter のメンバー取得はデフォルトで空配列。個別テストで上書きしない想定。
   vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
     mockJson([]),
@@ -243,5 +247,106 @@ describe("MeetingDetailView", () => {
     expect(
       (call[0] as { query: { assigneeId?: string } }).query.assigneeId,
     ).toBe("user-42");
+  });
+});
+
+// NOW より前の heldAt を持つ過去の会議
+const detailPast: MeetingDetail = {
+  ...detail,
+  heldAt: "2026-05-16T01:00:00.000Z",
+};
+
+describe("MeetingDetailView - 会議要約・AI抽出結果", () => {
+  it("過去の会議では「会議要約」カードが表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detailPast));
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(await screen.findByLabelText("会議要約")).toBeInTheDocument();
+  });
+
+  it("過去の会議では「AI抽出結果」カードが表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detailPast));
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(await screen.findByLabelText("AI抽出結果")).toBeInTheDocument();
+  });
+
+  it("未来の会議では「会議要約」カードが表示されない", async () => {
+    // detail.heldAt (2026-05-17T01:00:00Z) > NOW (2026-05-17T00:00:00Z)
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(screen.queryByLabelText("会議要約")).not.toBeInTheDocument();
+  });
+
+  it("未来の会議では「AI抽出結果」カードが表示されない", async () => {
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(screen.queryByLabelText("AI抽出結果")).not.toBeInTheDocument();
+  });
+
+  it("latestAnalysisRun.summary があればサマリーテキストが表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson({
+        ...detailPast,
+        latestAnalysisRun: {
+          id: "run-1",
+          status: "completed",
+          summary: "今回の会議では予算について合意しました。",
+          alertLevel: null,
+          completedAt: "2026-05-16T02:00:00.000Z",
+        },
+      }),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByText("今回の会議では予算について合意しました。"),
+    ).toBeInTheDocument();
+  });
+
+  it("latestAnalysisRun が null のとき「要約はまだありません」が表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson({ ...detailPast, latestAnalysisRun: null }),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByText("要約はまだありません"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView - 参加者アバター", () => {
+  it("members があればアバターグループが表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson({
+        ...detail,
+        members: [
+          { userId: "u-1", role: "owner", user: { id: "u-1", name: "Alice", displayName: "Alice" } },
+          { userId: "u-2", role: "member", user: { id: "u-2", name: "Bob", displayName: "Bob" } },
+        ],
+      }),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(
+      screen.getByRole("group", { name: /担当者: Alice, Bob/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("members が空のときアバターグループが表示されない", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson({ ...detail, members: [] }),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(
+      screen.queryByRole("group", { name: /担当者:/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("members が未定義のときアバターグループが表示されない", async () => {
+    // latestAnalysisRun なし・members なしの既存 detail を使う
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(
+      screen.queryByRole("group", { name: /担当者:/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -57,6 +57,7 @@ const detail: MeetingDetail = {
   recurringMeeting: { id: "rmtg-1", name: "週次定例" },
   organization: { id: "org-1", name: "ACME" },
   latestAnalysisRun: null,
+  memberCount: 0,
   members: [],
 };
 
@@ -321,6 +322,7 @@ describe("MeetingDetailView - 参加者アバター", () => {
     vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
       mockJson({
         ...detail,
+        memberCount: 2,
         members: [
           {
             userId: "u-1",

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -308,9 +308,7 @@ describe("MeetingDetailView - 会議要約・AI抽出結果", () => {
       mockJson({ ...detailPast, latestAnalysisRun: null }),
     );
     renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
-    expect(
-      await screen.findByText("要約はまだありません"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("要約はまだありません")).toBeInTheDocument();
   });
 });
 
@@ -320,8 +318,16 @@ describe("MeetingDetailView - 参加者アバター", () => {
       mockJson({
         ...detail,
         members: [
-          { userId: "u-1", role: "owner", user: { id: "u-1", name: "Alice", displayName: "Alice" } },
-          { userId: "u-2", role: "member", user: { id: "u-2", name: "Bob", displayName: "Bob" } },
+          {
+            userId: "u-1",
+            role: "owner",
+            user: { id: "u-1", name: "Alice", displayName: "Alice" },
+          },
+          {
+            userId: "u-2",
+            role: "member",
+            user: { id: "u-2", name: "Bob", displayName: "Bob" },
+          },
         ],
       }),
     );

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -52,6 +52,8 @@ const detail: MeetingDetail = {
   createdAt: "2026-05-01T00:00:00.000Z",
   recurringMeeting: { id: "rmtg-1", name: "週次定例" },
   organization: { id: "org-1", name: "ACME" },
+  latestAnalysisRun: null,
+  members: [],
 };
 
 const sampleTask = {


### PR DESCRIPTION
## 関連Issue
Closes #325 #326

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
  * 会議詳細ページのヘッダーに定例メンバーのアバターを表示し、「誰の会議か」を一目で把握できるようにした
  * 過去の会議のみ「会議要約」「AI抽出結果」カードを2カラムで表示し、未来の会議では非表示にした
  * ダッシュボードの次回会議カードにも同様のアバターを追加した

## 背景
  * 会議詳細画面に参加者情報がなく、誰が関係する会議かを確認する手段がなかった
  * 会議要約・AI抽出結果は過去会議のみ意味があるため、未来の会議には表示しないことにした

## 変更内容
  * `GET /meetings/:id` のレスポンスに定例メンバー（先頭4件）を追加
  * `GET /organizations/:id/meetings` のレスポンスにアバター表示用のメンバー（先頭4件）を追加
  * `AvatarStack` に `extraCount` prop を追加し、API 側で件数を絞った場合でも正確な `+n` 表示ができるようにした
  * 会議詳細ヘッダーに `AvatarStack` を追加（メンバーがいる場合のみ表示）
  * 過去会議のみ「会議要約」「AI抽出結果」の2カラムカードを表示。`useReviewItems` も未来会議では無効化
  * ダッシュボードの次回会議カードに `AvatarStack` を追加。`_count.members` を使って残り人数を正確に表示

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. make devでアプリ起動後、定例に複数メンバーが登録された状態で会議詳細ページを開く
  2. ヘッダーの日時・所要時間の横にアバターが表示されること、5人以上なら `+n` が表示されることを確認
  3. 過去の会議（`heldAt` が現在より前）では「会議要約」「AI抽出結果」カードが表示されること、未来の会議では非表示であることを確認
  4. ダッシュボードの次回会議カードにアバターが表示され、定例メンバーが5人以上の場合 `+n` が正しい人数を示すことを確認

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1470" height="733" alt="スクリーンショット 2026-05-29 23 49 30" src="https://github.com/user-attachments/assets/6b581c9f-005c-4c51-b94d-7c54cd08507a" />
<img width="1470" height="735" alt="スクリーンショット 2026-05-29 23 49 21" src="https://github.com/user-attachments/assets/9e12083b-25fb-4f8f-baa3-305a7aa46466" />
ダミーデータ（5人以上）
<img width="1470" height="733" alt="スクリーンショット 2026-05-29 23 46 07" src="https://github.com/user-attachments/assets/2308be6e-abc5-40a1-88f4-77020748ee69" />
<img width="1470" height="736" alt="スクリーンショット 2026-05-29 23 49 06" src="https://github.com/user-attachments/assets/5f7ceab1-c616-4787-85e5-61e0885d4ab2" />

