### PR TITLE
fix: 「レビュー待ちに戻す」ボタンの表示条件と API 遷移ルールの不一致を解消

### DIFF
--- a/apps/api/src/lib/review-item-serialization.ts
+++ b/apps/api/src/lib/review-item-serialization.ts
@@ -71,6 +71,8 @@ function serializeTaskAsReviewItem(task: TaskWithReview) {
     sourceTable: "task" as const,
     type: "task_candidate" as const,
     status: task.status,
+    // PATCH /tasks/:id で in_progress/done → draft は 400 になるため、UI 側の canReset 判定に使う
+    taskStatus: task.status,
     title: task.title,
     body: task.body,
     sourceQuote: task.sourceQuote,

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -945,6 +945,28 @@ describe("GET /meetings/:id/review-items", () => {
     expect(mockAmbiguousInfoFindMany).toHaveBeenCalledTimes(1);
   });
 
+  it("task_candidate レスポンスに taskStatus が含まれる", async () => {
+    setupAccess();
+    const inProgressTask = {
+      ...sampleReviewTask,
+      status: "in_progress",
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: TaskWithReview は TaskWithList と include 形が異なるため
+    mockTaskFindMany.mockResolvedValue([inProgressTask] as any);
+
+    const res = await app.request(
+      "/meetings/mtg-1/review-items?type=task_candidate",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      sourceTable: string;
+      taskStatus?: string;
+    }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].sourceTable).toBe("task");
+    expect(body[0].taskStatus).toBe("in_progress");
+  });
+
   it("?type=decision → confirmed/tentative 制約が where に入り task・ambiguity は呼ばれない", async () => {
     setupAccess();
     mockDecisionItemFindMany.mockResolvedValue([sampleDecisionItem]);

--- a/apps/web/src/features/review/types.ts
+++ b/apps/web/src/features/review/types.ts
@@ -47,6 +47,8 @@ export type ReviewItem = {
   meetingId: string;
   // 楽観ロック用バージョン番号
   version: number;
+  // task_candidate のみ。in_progress/done は draft への遷移が API で禁止されるため canReset 判定に使う
+  taskStatus?: string | null;
 };
 
 export const TYPE_LABELS: Record<ReviewItemType, string> = {

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -478,8 +478,9 @@ function ReviewAccordionItem({
               const canReset =
                 !isPending &&
                 item.sourceTable !== "ambiguous_info" &&
-                item.taskStatus !== "in_progress" &&
-                item.taskStatus !== "done";
+                (item.sourceTable !== "task" ||
+                  item.taskStatus === "todo" ||
+                  item.taskStatus === "rejected");
               return (
                 <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
                   <div className="flex items-start justify-between gap-2">

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -475,10 +475,11 @@ function ReviewAccordionItem({
           <ul className="border-t divide-y">
             {items.map((item) => {
               const isPending = isReviewPending(item.status);
-              // TODO: task の in_progress/done は API が 400 を返すが UI はボタンを出す。
-              // ReviewItem に元の task.status を持たせて除外するか、API ガードを緩めるか要検討。
               const canReset =
-                !isPending && item.sourceTable !== "ambiguous_info";
+                !isPending &&
+                item.sourceTable !== "ambiguous_info" &&
+                item.taskStatus !== "in_progress" &&
+                item.taskStatus !== "done";
               return (
                 <li key={item.id} className="px-4 py-3 flex flex-col gap-1">
                   <div className="flex items-start justify-between gap-2">

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -378,6 +378,25 @@ describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
     ).toBeInTheDocument();
   });
 
+  it("task_candidate で taskStatus=rejected のとき ⋯ メニューボタンが表示される", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({
+          sourceTable: "task",
+          type: "task_candidate",
+          status: "rejected" as ReviewItem["status"],
+          taskStatus: "rejected",
+        }),
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /タスク候補/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.getByRole("button", { name: "メニュー" }),
+    ).toBeInTheDocument();
+  });
+
   it("「レビュー待ちに戻す」クリックで decision-items PATCH が呼ばれる", async () => {
     const item = makeReviewItem({ id: "di-1", status: "decided", version: 2 });
     vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -321,6 +321,63 @@ describe("MeetingDetailView — AI抽出結果 3点メニュー", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("task_candidate で taskStatus=in_progress のとき ⋯ メニューボタンが表示されない", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({
+          sourceTable: "task",
+          type: "task_candidate",
+          status: "in_progress" as ReviewItem["status"],
+          taskStatus: "in_progress",
+        }),
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /タスク候補/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.queryByRole("button", { name: "メニュー" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("task_candidate で taskStatus=done のとき ⋯ メニューボタンが表示されない", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({
+          sourceTable: "task",
+          type: "task_candidate",
+          status: "done" as ReviewItem["status"],
+          taskStatus: "done",
+        }),
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /タスク候補/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.queryByRole("button", { name: "メニュー" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("task_candidate で taskStatus=todo のとき ⋯ メニューボタンが表示される", async () => {
+    vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([
+        makeReviewItem({
+          sourceTable: "task",
+          type: "task_candidate",
+          status: "todo" as ReviewItem["status"],
+          taskStatus: "todo",
+        }),
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const accordion = await screen.findByRole("button", { name: /タスク候補/ });
+    await userEvent.click(accordion);
+    expect(
+      screen.getByRole("button", { name: "メニュー" }),
+    ).toBeInTheDocument();
+  });
+
   it("「レビュー待ちに戻す」クリックで decision-items PATCH が呼ばれる", async () => {
     const item = makeReviewItem({ id: "di-1", status: "decided", version: 2 });
     vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(


### PR DESCRIPTION
## 関連Issue
Closes #324 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* タスク候補アイテムの「レビュー待ちに戻す」ボタンが、APIが拒否する状態（in_progress / done）でも表示されていたため、表示条件をAPIのトランジションルールに合わせて修正した。

## 背景
  * `PATCH /tasks/:id` に `status: "draft"` を送る場合、タスクの現在ステータスが `in_progress` または `done` だと 400 を返す仕様になっている
  * UIの `canReset` 条件はこれを考慮しておらず、押すと必ずエラーになるボタンが表示されていた

## 変更内容
  * API: `serializeTaskAsReviewItem` に `taskStatus` フィールドを追加し、タスクの実作業ステータスをレスポンスに含めるようにした
  * Frontend: `ReviewItem` 型に `taskStatus?: string | null` を追加
  * Frontend: `canReset` 条件に `taskStatus !== "in_progress" && taskStatus !== "done"` を追加

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. make devで起動後、会議詳細画面（過去の会議）を開き、AI抽出結果セクションを表示する
  2. タスク候補のアコーディオンを開く
  3. ステータスが `in_progress` または `done` のタスク候補に ⋯ メニューが表示されないことを確認する
  4. ステータスが `todo` のタスク候補には ⋯ メニューが表示され、「レビュー待ちに戻す」が動作することを確認する

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
* UIの変化なし
