### PR TITLE
auth: Entra External ID トークンに email がない場合のログイン失敗を解消する

### DIFF
--- a/apps/api/prisma/dbml/schema.dbml
+++ b/apps/api/prisma/dbml/schema.dbml
@@ -34,7 +34,7 @@ Table Meeting {
 Table User {
   id String [pk]
   externalId String [unique, not null]
-  email String [unique, not null]
+  email String [unique]
   name String [not null]
   displayName String [not null]
   createdAt DateTime [default: `now()`, not null]

--- a/apps/api/prisma/migrations/20260529173122_email_nullable/migration.sql
+++ b/apps/api/prisma/migrations/20260529173122_email_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "email" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,7 +60,10 @@ model Meeting {
 model User {
   id          String   @id @default(cuid())
   externalId  String   @unique
-  email       String   @unique
+  // Entra External ID は email クレームを返さない設定がある。
+  // nullable にすることで email なしでもログインを通す。
+  // 招待照合（OrganizationInvitation.email との一致）は email がある場合のみ機能する。
+  email       String?  @unique
   name        String
   displayName String
   createdAt   DateTime @default(now())

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -34,15 +34,17 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
     return c.json({ error: "トークンの検証に失敗しました" }, 401);
   }
 
-  // 自動作成に必要な claim が揃っていることを保証する
+  // 自動作成に必要な claim が揃っていることを保証する。
+  // email は Entra External ID が返さない設定があるため任意とする。
+  // 本人特定は sub（externalId）で行うため email は照合に不要。
   const externalId = typeof payload.sub === "string" ? payload.sub : undefined;
   const rawEmail =
     typeof payload.email === "string" ? payload.email : undefined;
   const name = typeof payload.name === "string" ? payload.name : undefined;
 
-  if (!externalId || !rawEmail || !name) {
+  if (!externalId || !name) {
     return c.json(
-      { error: "トークンに必要な claim (sub/email/name) が含まれていません" },
+      { error: "トークンに必要な claim (sub/name) が含まれていません" },
       401,
     );
   }
@@ -50,7 +52,8 @@ export const auth: MiddlewareHandler<{ Variables: AuthVariables }> = async (
   // IdP が返す email は大文字や前後空白を含み得るため、保存前に正規化する。
   // 招待 (`OrganizationInvitation.email`) も同じ normalizeEmail で保存しているため、
   // 比較経路全体で正規化を一貫させる必要がある。
-  const email = normalizeEmail(rawEmail);
+  // email が無い場合は null を保存する（PostgreSQL は NULL 同士を @unique で許容する）。
+  const email = rawEmail ? normalizeEmail(rawEmail) : null;
 
   // まず findUnique で取得し、差分があるときのみ update / 不在なら create を発行する。
   // upsert を毎リクエスト走らせると、同一ユーザーに対する並列リクエストで

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -6,10 +6,15 @@ import { auth, type AuthVariables } from "../middleware/auth.js";
 // 招待は自分宛 (= user.email と一致) の pending かつ非期限切れのもののみ返す。
 // 期限切れの自動 status 遷移はバッチジョブ前提のため、ここでは status=pending の
 // うち expiresAt > now でフィルタする（DB 側の status は変えない）。
+// email が null のユーザー（Entra で email クレームが返らなかった場合）は
+// 招待照合の前提となるメールが存在しないため、空配列を返す。
 export const meRoute = new Hono<{ Variables: AuthVariables }>()
   .use("*", auth)
   .get("/invitations", async (c) => {
     const user = c.var.user;
+    if (!user.email) {
+      return c.json([]);
+    }
     const invitations = await prisma.organizationInvitation.findMany({
       where: {
         email: user.email,

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -512,6 +512,14 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
       return c.json({ error: "既にこの組織に参加しています" }, 409);
     }
 
+    // email が null のユーザーは招待照合ができないため 404 を返す。
+    // 招待は email 一致で突き合わせる設計であり、email なしでは招待を受け取れない。
+    // user.email を変数に抜き出して async コールバック内で string 型が確定するようにする。
+    const userEmail = user.email;
+    if (!userEmail) {
+      return c.json({ error: "有効な招待が見つかりません" }, 404);
+    }
+
     // 招待検索 → status 更新 → membership 作成を一貫させる。
     // 期限切れ招待は status=pending のまま残るが now と比較してスキップする
     // （expired への自動遷移はバッチジョブ前提）。
@@ -529,7 +537,7 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
         const invitation = await tx.organizationInvitation.findFirst({
           where: {
             organizationId: id,
-            email: user.email,
+            email: userEmail,
             status: "pending",
             expiresAt: { gt: new Date() },
           },

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -52,6 +52,17 @@ const sampleUser = {
   updatedAt: new Date("2026-05-01T00:00:00Z"),
 };
 
+// email なしユーザー（Entra External ID が email クレームを返さない場合）
+const sampleUserNoEmail = {
+  id: "cuid-user-3",
+  externalId: "ext-3",
+  email: null,
+  name: "carol",
+  displayName: "carol",
+  createdAt: new Date("2026-05-01T00:00:00Z"),
+  updatedAt: new Date("2026-05-01T00:00:00Z"),
+};
+
 // auth ミドルウェアを適用したテスト用アプリ
 function buildTestApp() {
   const app = new Hono();
@@ -65,7 +76,10 @@ function buildTestApp() {
 
 describe("auth middleware", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks で未消費の mockResolvedValueOnce キューも含めクリアする。
+    // clearAllMocks だと実装キューが残り、早期 return するテスト（Red フェーズ等）の
+    // 未消費モック値が次のテストに漏れてしまう。
+    vi.resetAllMocks();
   });
 
   it("Authorization ヘッダ無しの場合は 401 を返す", async () => {
@@ -126,16 +140,68 @@ describe("auth middleware", () => {
     expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
-  it("payload.email が無い場合は 401 を返す", async () => {
+  it("payload.email が無くても sub と name があれば 200 を返す", async () => {
     mockJwtVerify.mockResolvedValueOnce(
-      jwtVerifyResult({ sub: "ext-1", name: "alice" }),
+      jwtVerifyResult({ sub: "ext-3", name: "carol" }),
     );
+    mockFindUnique.mockResolvedValueOnce(sampleUserNoEmail);
     const app = buildTestApp();
     const res = await app.request("/whoami", {
       headers: { Authorization: "Bearer t" },
     });
-    expect(res.status).toBe(401);
-    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+
+  it("email なしの新規ユーザーは email: null で create される", async () => {
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-3", name: "carol" }),
+    );
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce(sampleUserNoEmail);
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        externalId: "ext-3",
+        email: null,
+        name: "carol",
+        displayName: "carol",
+      },
+    });
+  });
+
+  it("email なしの既存ユーザー (DB も email: null) は update しない", async () => {
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-3", name: "carol" }),
+    );
+    mockFindUnique.mockResolvedValueOnce(sampleUserNoEmail);
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("DB に email がある既存ユーザーに email なしトークンが来た場合 email: null で update される", async () => {
+    mockJwtVerify.mockResolvedValueOnce(
+      jwtVerifyResult({ sub: "ext-1", name: "alice" }),
+    );
+    mockFindUnique.mockResolvedValueOnce(sampleUser);
+    mockUpdate.mockResolvedValueOnce({ ...sampleUser, email: null });
+    const app = buildTestApp();
+    const res = await app.request("/whoami", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { externalId: "ext-1" },
+      data: { email: null, name: "alice" },
+    });
   });
 
   it("payload.name が無い場合は 401 を返す", async () => {

--- a/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
+++ b/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
@@ -9,7 +9,12 @@ export type PendingInvitation = {
   expiresAt: string;
   createdAt: string;
   expired: boolean;
-  inviter: { id: string; name: string; displayName: string; email: string | null };
+  inviter: {
+    id: string;
+    name: string;
+    displayName: string;
+    email: string | null;
+  };
 };
 
 // 組織の pending 招待一覧を取得するクエリ。

--- a/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
+++ b/apps/web/src/features/organizations/hooks/usePendingInvitations.ts
@@ -9,7 +9,7 @@ export type PendingInvitation = {
   expiresAt: string;
   createdAt: string;
   expired: boolean;
-  inviter: { id: string; name: string; displayName: string; email: string };
+  inviter: { id: string; name: string; displayName: string; email: string | null };
 };
 
 // 組織の pending 招待一覧を取得するクエリ。

--- a/apps/web/src/features/organizations/types.ts
+++ b/apps/web/src/features/organizations/types.ts
@@ -13,7 +13,7 @@ export type Member = {
   userId: string;
   name: string;
   displayName: string;
-  email: string;
+  email: string | null;
   role: OrgRole;
   joinedAt: string;
 };

--- a/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingDetail.ts
+++ b/apps/web/src/features/recurring-meetings/hooks/useRecurringMeetingDetail.ts
@@ -9,7 +9,7 @@ export type RecurringMeetingDetail = RecurringMeeting & {
     userId: string;
     name: string;
     displayName: string;
-    email: string;
+    email: string | null;
     role: "owner" | "member";
     joinedAt: string;
   }>;

--- a/apps/web/src/features/review/types.ts
+++ b/apps/web/src/features/review/types.ts
@@ -20,7 +20,7 @@ export type ReviewAssignee = {
   id: string;
   name: string;
   displayName: string;
-  email: string;
+  email: string | null;
 };
 
 export type AmbiguityResolutionType = "task" | "decision_item" | "discarded";

--- a/apps/web/src/features/review/useReviewItems.ts
+++ b/apps/web/src/features/review/useReviewItems.ts
@@ -212,7 +212,7 @@ export function useReviewItems({
           id: string;
           name: string;
           displayName: string;
-          email: string;
+          email: string | null;
         }[];
         dueDate: string | null;
         version: number;

--- a/apps/web/src/features/tasks/types.ts
+++ b/apps/web/src/features/tasks/types.ts
@@ -85,7 +85,7 @@ export type TaskListItem = TaskEditableFields &
 
 // 詳細 API のレスポンス。assignees に email が含まれる以外は一覧と同形。
 export type Task = Omit<TaskListItem, "assignees"> & {
-  assignees: Array<AssigneeUser & { email: string }>;
+  assignees: Array<AssigneeUser & { email: string | null }>;
 };
 
 // 一覧 API の共通フィルタ。

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -37,7 +37,8 @@ export interface AuthState {
   idToken: string | null;
   user: {
     sub: string;
-    email: string;
+    // Entra External ID は email クレームを返さない設定があるため nullable。
+    email: string | null;
     name: string;
   } | null;
 }
@@ -76,7 +77,7 @@ export function parseToken(token: string): AuthState["user"] {
   try {
     const payload = decodeBase64UrlJson(token.split(".")[1]) as {
       sub: string;
-      email: string;
+      email?: string;
       name: string;
       exp?: number;
     };
@@ -87,7 +88,7 @@ export function parseToken(token: string): AuthState["user"] {
     }
     return {
       sub: payload.sub,
-      email: payload.email,
+      email: payload.email ?? null,
       name: payload.name,
     };
   } catch {

--- a/apps/web/src/test/auth.test.ts
+++ b/apps/web/src/test/auth.test.ts
@@ -45,6 +45,12 @@ describe("parseToken", () => {
     });
   });
 
+  it("email クレームがないトークンは email: null を返す", () => {
+    const token = makeFakeIdToken({ sub: "u3", name: "carol" });
+    const user = parseToken(token);
+    expect(user).toEqual({ sub: "u3", email: null, name: "carol" });
+  });
+
   it("不正な形式のトークンは null を返す", () => {
     expect(parseToken("not-a-jwt")).toBeNull();
   });

--- a/apps/web/src/test/helpers/auth.ts
+++ b/apps/web/src/test/helpers/auth.ts
@@ -3,7 +3,7 @@
 
 export interface FakeIdTokenPayload {
   sub: string;
-  email: string;
+  email?: string;
   name: string;
   // UNIX 秒。未指定時は 1 時間後を期限とする。
   exp?: number;


### PR DESCRIPTION
## 関連Issue
Closes #329

## 概要・目的
Entra External ID（社外ユーザー向け認証基盤）が発行するトークンに `email` クレームが含まれない事象が発生しており、現状は email がないと全ユーザーがログインに失敗する。本人特定は `sub`（externalId）で行っているため email は照合に不要なので、アプリ側の email 必須要件を外し、email なしでもログインを通すようにした。

## 背景
インフラ側で Entra のトークンに email を含める設定を試みているが解消しておらず、リソース再作成を検討する段階にある。一方でアプリ側は認証ミドルウェア（`apps/api/src/middleware/auth.ts`）が `sub`/`email`/`name` の3つを必須にしており、email 欠落で 401 を返す。ログイン照合自体は `sub` で完結しているため、email を必須にし続ける必然性は招待フローのみにある。そのため email を任意化し、招待は「email を持つユーザーのみ受け取れる」と割り切る方針とした。

## 変更内容
* 認証ミドルウェアの必須チェックを `sub`/`name` のみに緩和。email がある場合のみ `normalizeEmail` で正規化し、ない場合は `null` を保存
* `User.email` を `String? @unique` に変更（nullable 化）。PostgreSQL は NULL 同士を unique 制約で許容するため、email なしユーザーが複数共存できる
* マイグレーション追加（`ALTER COLUMN "email" DROP NOT NULL`）
* `GET /me/invitations`: `user.email` が null の場合は招待照合できないため空配列を返す
* `POST /:id/join`: email が null の場合は招待を突き合わせられないため 404 を返す
* フロント `AuthState.user.email` と `parseToken` を `string | null` に変更。User 由来の email を返す型定義（Member・招待・タスク・レビュー等）も `string | null` に統一
* email なしトークンのログイン・create/update 挙動を検証するテストを API/Web 双方に追加

## 動作確認手順
1. ブランチを checkout: `git checkout issue-329-email-nullable-auth`
2. テストを実行: `make test`（web 419 / api 358 / ai 59 が全て pass）
3. lint を実行: `make lint`（エラーなし）
4. マイグレーション適用を確認: DB 起動後 `make migrate-status`

## スクリーンショット
*（API/型の変更のみ。UI 変更なし）*

## 特に見てほしい箇所
* `apps/api/src/middleware/auth.ts`: email を null で保存・update する分岐の妥当性（差分検出 `user.email !== email` が null 同士で正しく動くか）
* `apps/api/src/routes/organizations.ts` の join: email null 時に 404 を返す扱いが招待フローの仕様として妥当か（招待は email 一致が前提のため email なしユーザーは join 不可）
* `User.email @unique` の nullable 化が招待重複チェック（`OrganizationInvitation` 側）に副作用を持たないか