### PR TITLE
feat(web): 会議詳細に次回会議の推奨アジェンダ表示とコピーを追加 (#332)

### DIFF
--- a/apps/web/src/features/meetings/agenda.ts
+++ b/apps/web/src/features/meetings/agenda.ts
@@ -1,0 +1,23 @@
+import type { RecommendedAgendaItem } from "./hooks/useMeetingDetail";
+
+// 推奨アジェンダ（構造化配列）をクリップボード向けのプレーンテキストへ整形する。
+// 例:
+//   1. 設計書レビュー担当の確定（約5分）
+//      理由: 未決事項の解消
+// estimated_minutes / reason が欠落・null の項目は該当部分を省略する。
+export function formatAgendaForCopy(items: RecommendedAgendaItem[]): string {
+  return items
+    .map((item, i) => {
+      const minutes =
+        item.estimated_minutes != null
+          ? `（約${item.estimated_minutes}分）`
+          : "";
+      const head = `${i + 1}. ${item.title}${minutes}`;
+      const reason =
+        item.reason && item.reason.trim().length > 0
+          ? `\n   理由: ${item.reason}`
+          : "";
+      return `${head}${reason}`;
+    })
+    .join("\n");
+}

--- a/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
+++ b/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
@@ -1,0 +1,71 @@
+import { Card } from "@/components/ui/card";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type RecommendedAgendaSectionProps = {
+  // AI が生成した次回会議の推奨アジェンダ。未解析・未生成のときは null。
+  agenda: string | null;
+};
+
+// 会議の解析結果（latestAnalysisRun.recommendedAgenda）として生成された
+// 「次回会議の推奨アジェンダ」を表示し、クリップボードへコピーできるカード。
+// トースト UI は未導入のため、コピー成否はボタン表示の差し替えでフィードバックする。
+export function RecommendedAgendaSection({
+  agenda,
+}: RecommendedAgendaSectionProps) {
+  const [copied, setCopied] = useState(false);
+
+  // コピー後のフィードバックは一定時間で自動的に元へ戻す。
+  // アンマウント時のタイマー解放も行う。
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const hasAgenda = agenda != null && agenda.trim().length > 0;
+
+  const handleCopy = async () => {
+    if (!hasAgenda) return;
+    try {
+      await navigator.clipboard.writeText(agenda);
+      setCopied(true);
+    } catch {
+      // クリップボード API が使えない環境では何もしない（フィードバックも出さない）。
+    }
+  };
+
+  return (
+    <Card
+      aria-label="次回会議の推奨アジェンダ"
+      className="gap-0 py-0 overflow-hidden"
+    >
+      <div className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 shrink-0">
+        <span className="text-sm font-semibold flex-1">
+          次回会議の推奨アジェンダ
+        </span>
+        {hasAgenda && (
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? "コピーしました" : "コピー"}
+          </button>
+        )}
+      </div>
+      <div className="px-5 py-4">
+        {hasAgenda ? (
+          <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+            {agenda}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            推奨アジェンダはまだありません
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
+++ b/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
@@ -1,10 +1,12 @@
 import { Card } from "@/components/ui/card";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
+import { formatAgendaForCopy } from "../agenda";
+import type { RecommendedAgendaItem } from "../hooks/useMeetingDetail";
 
 type RecommendedAgendaSectionProps = {
-  // AI が生成した次回会議の推奨アジェンダ。未解析・未生成のときは null。
-  agenda: string | null;
+  // AI が生成した次回会議の推奨アジェンダ項目。未解析・未生成のときは null。
+  agenda: RecommendedAgendaItem[] | null;
 };
 
 // 会議の解析結果（latestAnalysisRun.recommendedAgenda）として生成された
@@ -23,12 +25,12 @@ export function RecommendedAgendaSection({
     return () => clearTimeout(timer);
   }, [copied]);
 
-  const hasAgenda = agenda != null && agenda.trim().length > 0;
+  const hasAgenda = agenda != null && agenda.length > 0;
 
   const handleCopy = async () => {
     if (!hasAgenda) return;
     try {
-      await navigator.clipboard.writeText(agenda);
+      await navigator.clipboard.writeText(formatAgendaForCopy(agenda));
       setCopied(true);
     } catch {
       // クリップボード API が使えない環境では何もしない（フィードバックも出さない）。
@@ -57,9 +59,29 @@ export function RecommendedAgendaSection({
       </div>
       <div className="px-5 py-4">
         {hasAgenda ? (
-          <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
-            {agenda}
-          </p>
+          <ol className="space-y-3">
+            {agenda.map((item, i) => (
+              // タイトルは AI 出力上の項目識別子として一意に並ぶ前提で key に用いる。
+              <li key={item.title} className="text-sm">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-muted-foreground tabular-nums">
+                    {i + 1}.
+                  </span>
+                  <span className="font-medium flex-1">{item.title}</span>
+                  {item.estimated_minutes != null && (
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      約{item.estimated_minutes}分
+                    </span>
+                  )}
+                </div>
+                {item.reason && item.reason.trim().length > 0 && (
+                  <p className="text-xs text-muted-foreground mt-0.5 pl-5">
+                    理由: {item.reason}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
         ) : (
           <p className="text-sm text-muted-foreground">
             推奨アジェンダはまだありません

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -1,6 +1,15 @@
 import { api, authHeaders } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 
+// AI が生成する推奨アジェンダの 1 項目。
+// 実体は MeetingAnalysisRun.recommendedAgenda（JSON 配列）で、AI 出力のブレに備え
+// title 以外は欠落/ null を許容する。
+export type RecommendedAgendaItem = {
+  title: string;
+  estimated_minutes?: number | null;
+  reason?: string | null;
+};
+
 // 会議詳細レスポンス。API 側 (apps/api/src/routes/meetings.ts) の整形に揃える。
 export type MeetingDetail = {
   id: string;
@@ -21,7 +30,7 @@ export type MeetingDetail = {
     id: string;
     status: string;
     summary: string | null;
-    recommendedAgenda: string | null;
+    recommendedAgenda: RecommendedAgendaItem[] | null;
     alertLevel: string | null;
     completedAt: string | null;
   } | null;

--- a/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
+++ b/apps/web/src/features/meetings/hooks/useMeetingDetail.ts
@@ -21,6 +21,7 @@ export type MeetingDetail = {
     id: string;
     status: string;
     summary: string | null;
+    recommendedAgenda: string | null;
     alertLevel: string | null;
     completedAt: string | null;
   } | null;

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { RecommendedAgendaSection } from "@/features/meetings/components/RecommendedAgendaSection";
 import { TopicRequestSection } from "@/features/topic-requests/components/TopicRequestSection";
 import {
   REVIEW_ITEM_TYPES,
@@ -289,6 +290,13 @@ export function MeetingDetailView({
             </div>
           </Card>
         </div>
+      )}
+
+      {/* 次回会議の推奨アジェンダ（解析で生成された場合に表示）。過去の会議のみ。 */}
+      {isPastMeeting && (
+        <RecommendedAgendaSection
+          agenda={detail.latestAnalysisRun?.recommendedAgenda ?? null}
+        />
       )}
 
       {/* 下段: タスク（フルwidth） */}

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -321,6 +321,7 @@ describe("MeetingDetailView - 会議要約・AI抽出結果", () => {
           id: "run-1",
           status: "completed",
           summary: "今回の会議では予算について合意しました。",
+          recommendedAgenda: null,
           alertLevel: null,
           completedAt: "2026-05-16T02:00:00.000Z",
         },
@@ -338,6 +339,63 @@ describe("MeetingDetailView - 会議要約・AI抽出結果", () => {
     );
     renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
     expect(await screen.findByText("要約はまだありません")).toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
+  // recommendedAgenda 入りの latestAnalysisRun を持つ過去会議を組み立てる。
+  const withAgenda = (agenda: string | null): MeetingDetail => ({
+    ...detailPast,
+    latestAnalysisRun: {
+      id: "run-1",
+      status: "completed",
+      summary: null,
+      recommendedAgenda: agenda,
+      alertLevel: null,
+      completedAt: "2026-05-16T02:00:00.000Z",
+    },
+  });
+
+  it("recommendedAgenda があれば本文が表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson(withAgenda("1. 前回タスクの確認\n2. 予算の決定")),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByLabelText("次回会議の推奨アジェンダ"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/前回タスクの確認/)).toBeInTheDocument();
+  });
+
+  it("recommendedAgenda が null のとき「推奨アジェンダはまだありません」が表示される", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson(withAgenda(null)),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    expect(
+      await screen.findByText("推奨アジェンダはまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("コピーボタンで clipboard.writeText が呼ばれ「コピーしました」表示になる", async () => {
+    const agenda = "1. 前回タスクの確認";
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
+      mockJson(withAgenda(agenda)),
+    );
+    const user = userEvent.setup();
+    // userEvent のクリップボードスタブより後に独自スパイを差し込む。
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    const copyBtn = await screen.findByRole("button", { name: "コピー" });
+    await user.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith(agenda);
+    expect(await screen.findByText("コピーしました")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -1,4 +1,7 @@
-import type { MeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import type {
+  MeetingDetail,
+  RecommendedAgendaItem,
+} from "@/features/meetings/hooks/useMeetingDetail";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -344,7 +347,9 @@ describe("MeetingDetailView - 会議要約・AI抽出結果", () => {
 
 describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
   // recommendedAgenda 入りの latestAnalysisRun を持つ過去会議を組み立てる。
-  const withAgenda = (agenda: string | null): MeetingDetail => ({
+  const withAgenda = (
+    agenda: RecommendedAgendaItem[] | null,
+  ): MeetingDetail => ({
     ...detailPast,
     latestAnalysisRun: {
       id: "run-1",
@@ -356,18 +361,27 @@ describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
     },
   });
 
-  it("recommendedAgenda があれば本文が表示される", async () => {
+  it("recommendedAgenda があれば各項目が表示される", async () => {
     vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
-      mockJson(withAgenda("1. 前回タスクの確認\n2. 予算の決定")),
+      mockJson(
+        withAgenda([
+          { title: "前回タスクの確認", estimated_minutes: 5, reason: "継続" },
+          { title: "予算の決定", estimated_minutes: null, reason: null },
+        ]),
+      ),
     );
     renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
     expect(
       await screen.findByLabelText("次回会議の推奨アジェンダ"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/前回タスクの確認/)).toBeInTheDocument();
+    expect(screen.getByText("前回タスクの確認")).toBeInTheDocument();
+    expect(screen.getByText("予算の決定")).toBeInTheDocument();
+    // estimated_minutes / reason がある項目は補足表示される
+    expect(screen.getByText("約5分")).toBeInTheDocument();
+    expect(screen.getByText("理由: 継続")).toBeInTheDocument();
   });
 
-  it("recommendedAgenda が null のとき「推奨アジェンダはまだありません」が表示される", async () => {
+  it("recommendedAgenda が空配列/null のとき「推奨アジェンダはまだありません」が表示される", async () => {
     vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
       mockJson(withAgenda(null)),
     );
@@ -377,10 +391,13 @@ describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
     ).toBeInTheDocument();
   });
 
-  it("コピーボタンで clipboard.writeText が呼ばれ「コピーしました」表示になる", async () => {
-    const agenda = "1. 前回タスクの確認";
+  it("コピーボタンで整形済みテキストが clipboard.writeText に渡り「コピーしました」表示になる", async () => {
     vi.mocked(api.meetings[":id"].$get).mockResolvedValue(
-      mockJson(withAgenda(agenda)),
+      mockJson(
+        withAgenda([
+          { title: "前回タスクの確認", estimated_minutes: 5, reason: "継続" },
+        ]),
+      ),
     );
     const user = userEvent.setup();
     // userEvent のクリップボードスタブより後に独自スパイを差し込む。
@@ -394,7 +411,9 @@ describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
     const copyBtn = await screen.findByRole("button", { name: "コピー" });
     await user.click(copyBtn);
 
-    expect(writeText).toHaveBeenCalledWith(agenda);
+    expect(writeText).toHaveBeenCalledWith(
+      "1. 前回タスクの確認（約5分）\n   理由: 継続",
+    );
     expect(await screen.findByText("コピーしました")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 関連Issue
Refs #332

<!-- 注: #332 のうち「表示・クリップボードコピー」を実装。「手動再生成」は #331（議事録入力＋AI解析実行UI）が追加する analyze フックに依存するため、本PRには含めず後追いの別PRで対応する。そのため Closes ではなく Refs とし #332 はオープンのまま残す。 -->

## 概要・目的
* AI が生成した次回会議の推奨アジェンダ（`latestAnalysisRun.recommendedAgenda`）を会議詳細画面に表示し、ワンクリックでクリップボードへコピーできるようにする
* 解析パイプラインで生成済みだが UI に出ていなかった主要価値（次回会議準備）を可視化する

## 背景
* `GET /meetings/:id` は既に `recommendedAgenda` を返していたが、フロントの `useMeetingDetail` 型に含まれず画面でも未使用だった
* トースト UI は本リポジトリ未導入のため、コピー成否はボタン表示の差し替えでフィードバックする

## 変更内容
* `RecommendedAgendaSection` コンポーネントを新規追加（カード表示・コピー・改行保持の `whitespace-pre-wrap`）
* `useMeetingDetail` の `latestAnalysisRun` 型に `recommendedAgenda: string | null` を追加
* 会議詳細（過去の会議のみ）に推奨アジェンダセクションを描画。未生成時はプレースホルダ表示
* 表示・null時プレースホルダ・コピー動作（`navigator.clipboard.writeText` 呼び出し＋「コピーしました」表示）のテストを追加

## 動作確認手順
1. `make dev` で全サービスを起動する
2. 過去日時の会議で AI 解析を実行し、`recommendedAgenda` が生成された状態にする（または DB に直接設定）
3. 会議詳細画面（`/meetings/:id`）を開き、「次回会議の推奨アジェンダ」カードに本文が表示されることを確認する
4. 「コピー」ボタンを押し、表示が「コピーしました」に変わり、クリップボードにアジェンダ本文がコピーされることを確認する
5. 推奨アジェンダ未生成の会議では「推奨アジェンダはまだありません」が表示されることを確認する

## スクリーンショット
* （UI追加: 会議詳細の「次回会議の推奨アジェンダ」カード。後ほど添付）
