### PR TITLE
feat: アジェンダ生成履歴の閲覧・コピーを追加 (#333)

### DIFF
--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -225,6 +225,29 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
     });
     return c.json(topicRequests);
   })
+  .get("/:id/agenda-history", async (c) => {
+    const id = c.req.param("id");
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
+
+    // 当該会議で過去に生成された推奨アジェンダの履歴。完了した解析ランのうち
+    // recommendedAgenda を持つものを新しい順に返す（専用テーブルは設けず派生で扱う）。
+    // JSON null のフィルタは取りこぼしを避けるため取得後に JS 側で行う。
+    const runs = await prisma.meetingAnalysisRun.findMany({
+      where: { meetingId: id, status: "completed" },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        recommendedAgenda: true,
+        createdAt: true,
+        completedAt: true,
+      },
+    });
+    const history = runs.filter(
+      (r) => r.recommendedAgenda != null && r.recommendedAgenda !== undefined,
+    );
+    return c.json(history);
+  })
   .post(
     "/:id/topic-requests",
     zValidator("json", topicRequestCreateSchema),

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -21,6 +21,7 @@ vi.mock("../src/lib/prisma.js", () => ({
     },
     meetingAnalysisRun: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -114,6 +115,7 @@ const mockAnalysisRunCreate = vi.mocked(prisma.meetingAnalysisRun.create);
 const mockSendToServiceBus = vi.mocked(sendToServiceBus);
 const mockAnalysisRunUpdate = vi.mocked(prisma.meetingAnalysisRun.update);
 const mockAnalysisRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
+const mockAnalysisRunFindMany = vi.mocked(prisma.meetingAnalysisRun.findMany);
 const mockDecisionItemFindMany = vi.mocked(prisma.decisionItem.findMany);
 const mockAmbiguousInfoFindMany = vi.mocked(prisma.ambiguousInfo.findMany);
 
@@ -231,6 +233,79 @@ describe("GET /meetings/:id/tasks", () => {
     const res = await app.request("/meetings/mtg-1/tasks");
     expect(res.status).toBe(404);
     expect(mockTaskFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /meetings/:id/agenda-history", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const meetingWithRecurring = {
+    id: "mtg-1",
+    title: "第3回",
+    heldAt: new Date("2026-05-17T10:00:00Z"),
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  } satisfies Partial<MeetingWithRecurringOrgId>;
+
+  const grantAccess = () => {
+    mockFindUnique.mockResolvedValue(
+      meetingWithRecurring as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      role: "member",
+      joinedAt: new Date(),
+    });
+  };
+
+  it("completed かつ recommendedAgenda を持つランを新しい順に返す", async () => {
+    grantAccess();
+    // recommendedAgenda が null のランは履歴から除外されることも検証する。
+    mockAnalysisRunFindMany.mockResolvedValue([
+      {
+        id: "run-2",
+        recommendedAgenda: [{ title: "新しい議題" }],
+        createdAt: new Date("2026-05-17T11:00:00Z"),
+        completedAt: new Date("2026-05-17T11:05:00Z"),
+        // biome-ignore lint/suspicious/noExplicitAny: select 部分型のためテストでキャスト
+      } as any,
+      {
+        id: "run-1",
+        recommendedAgenda: null,
+        createdAt: new Date("2026-05-17T09:00:00Z"),
+        completedAt: new Date("2026-05-17T09:05:00Z"),
+        // biome-ignore lint/suspicious/noExplicitAny: select 部分型のためテストでキャスト
+      } as any,
+    ]);
+
+    const res = await app.request("/meetings/mtg-1/agenda-history");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string }>;
+    expect(body.map((x) => x.id)).toEqual(["run-2"]);
+    expect(mockAnalysisRunFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { meetingId: "mtg-1", status: "completed" },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+
+  it("会議不存在は 404", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/agenda-history");
+    expect(res.status).toBe(404);
+    expect(mockAnalysisRunFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockFindUnique.mockResolvedValue(
+      meetingWithRecurring as MeetingWithRecurringOrgId,
+    );
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/agenda-history");
+    expect(res.status).toBe(404);
+    expect(mockAnalysisRunFindMany).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/features/meetings/components/AgendaCopyButton.tsx
+++ b/apps/web/src/features/meetings/components/AgendaCopyButton.tsx
@@ -1,0 +1,41 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { formatAgendaForCopy } from "../agenda";
+import type { RecommendedAgendaItem } from "../hooks/useMeetingDetail";
+
+type AgendaCopyButtonProps = {
+  agenda: RecommendedAgendaItem[];
+};
+
+// 推奨アジェンダを整形してクリップボードへコピーするボタン。
+// トースト UI 未導入のため、コピー成否はラベル差し替えでフィードバックする。
+// 現在のアジェンダ・履歴の各エントリで独立した状態を持てるよう、単体で切り出している。
+export function AgendaCopyButton({ agenda }: AgendaCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(formatAgendaForCopy(agenda));
+      setCopied(true);
+    } catch {
+      // クリップボード API が使えない環境では何もしない。
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      {copied ? <Check size={14} /> : <Copy size={14} />}
+      {copied ? "コピーしました" : "コピー"}
+    </button>
+  );
+}

--- a/apps/web/src/features/meetings/components/AgendaHistorySection.tsx
+++ b/apps/web/src/features/meetings/components/AgendaHistorySection.tsx
@@ -1,0 +1,80 @@
+import { Card } from "@/components/ui/card";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { useAgendaHistory } from "../hooks/useAgendaHistory";
+import { AgendaCopyButton } from "./AgendaCopyButton";
+import { AgendaItemList } from "./AgendaItemList";
+
+type AgendaHistorySectionProps = {
+  meetingId: string;
+  // 過去の会議でのみ取得する（未来の会議では履歴は存在しない）。
+  enabled?: boolean;
+};
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// 過去に生成された推奨アジェンダの履歴を、折りたたみ可能なカードで一覧表示する。
+// 各版は閲覧・コピーできる（MVP では版の切替＝復元は行わない）。
+// 履歴が 1 件以下のときは「現在の推奨アジェンダ」カードと重複するため表示しない。
+export function AgendaHistorySection({
+  meetingId,
+  enabled = true,
+}: AgendaHistorySectionProps) {
+  const [open, setOpen] = useState(false);
+  const { data, isError } = useAgendaHistory(meetingId, enabled);
+
+  const entries = data ?? [];
+  if (!isError && entries.length <= 1) return null;
+
+  return (
+    <Card
+      aria-label="アジェンダ生成履歴"
+      className="gap-0 py-0 overflow-hidden"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 px-5 py-3.5 bg-muted/40 border-b border-border/50 w-full text-left"
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+        <span className="text-sm font-semibold flex-1">アジェンダ生成履歴</span>
+        {!isError && (
+          <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">
+            {entries.length}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="px-5 py-4 space-y-5">
+          {isError ? (
+            <p className="text-sm text-muted-foreground">
+              履歴の取得に失敗しました
+            </p>
+          ) : (
+            entries.map((entry, i) => (
+              <div key={entry.id} className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground flex-1">
+                    {formatTimestamp(entry.completedAt ?? entry.createdAt)}
+                    {i === 0 && "（最新）"}
+                  </span>
+                  <AgendaCopyButton agenda={entry.recommendedAgenda} />
+                </div>
+                <AgendaItemList items={entry.recommendedAgenda} />
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/features/meetings/components/AgendaItemList.tsx
+++ b/apps/web/src/features/meetings/components/AgendaItemList.tsx
@@ -1,0 +1,33 @@
+import type { RecommendedAgendaItem } from "../hooks/useMeetingDetail";
+
+type AgendaItemListProps = {
+  items: RecommendedAgendaItem[];
+};
+
+// 推奨アジェンダ項目を番号付きリストで表示する共通コンポーネント。
+// 現在の推奨アジェンダ（RecommendedAgendaSection）と履歴（AgendaHistorySection）で共用する。
+export function AgendaItemList({ items }: AgendaItemListProps) {
+  return (
+    <ol className="space-y-3">
+      {items.map((item, i) => (
+        // タイトルは AI 出力上の項目識別子として一意に並ぶ前提で key に用いる。
+        <li key={item.title} className="text-sm">
+          <div className="flex items-baseline gap-2">
+            <span className="text-muted-foreground tabular-nums">{i + 1}.</span>
+            <span className="font-medium flex-1">{item.title}</span>
+            {item.estimated_minutes != null && (
+              <span className="text-xs text-muted-foreground shrink-0">
+                約{item.estimated_minutes}分
+              </span>
+            )}
+          </div>
+          {item.reason && item.reason.trim().length > 0 && (
+            <p className="text-xs text-muted-foreground mt-0.5 pl-5">
+              理由: {item.reason}
+            </p>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
+++ b/apps/web/src/features/meetings/components/RecommendedAgendaSection.tsx
@@ -1,8 +1,7 @@
 import { Card } from "@/components/ui/card";
-import { Check, Copy } from "lucide-react";
-import { useEffect, useState } from "react";
-import { formatAgendaForCopy } from "../agenda";
 import type { RecommendedAgendaItem } from "../hooks/useMeetingDetail";
+import { AgendaCopyButton } from "./AgendaCopyButton";
+import { AgendaItemList } from "./AgendaItemList";
 
 type RecommendedAgendaSectionProps = {
   // AI が生成した次回会議の推奨アジェンダ項目。未解析・未生成のときは null。
@@ -11,31 +10,10 @@ type RecommendedAgendaSectionProps = {
 
 // 会議の解析結果（latestAnalysisRun.recommendedAgenda）として生成された
 // 「次回会議の推奨アジェンダ」を表示し、クリップボードへコピーできるカード。
-// トースト UI は未導入のため、コピー成否はボタン表示の差し替えでフィードバックする。
 export function RecommendedAgendaSection({
   agenda,
 }: RecommendedAgendaSectionProps) {
-  const [copied, setCopied] = useState(false);
-
-  // コピー後のフィードバックは一定時間で自動的に元へ戻す。
-  // アンマウント時のタイマー解放も行う。
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
   const hasAgenda = agenda != null && agenda.length > 0;
-
-  const handleCopy = async () => {
-    if (!hasAgenda) return;
-    try {
-      await navigator.clipboard.writeText(formatAgendaForCopy(agenda));
-      setCopied(true);
-    } catch {
-      // クリップボード API が使えない環境では何もしない（フィードバックも出さない）。
-    }
-  };
 
   return (
     <Card
@@ -46,42 +24,11 @@ export function RecommendedAgendaSection({
         <span className="text-sm font-semibold flex-1">
           次回会議の推奨アジェンダ
         </span>
-        {hasAgenda && (
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            {copied ? <Check size={14} /> : <Copy size={14} />}
-            {copied ? "コピーしました" : "コピー"}
-          </button>
-        )}
+        {hasAgenda && <AgendaCopyButton agenda={agenda} />}
       </div>
       <div className="px-5 py-4">
         {hasAgenda ? (
-          <ol className="space-y-3">
-            {agenda.map((item, i) => (
-              // タイトルは AI 出力上の項目識別子として一意に並ぶ前提で key に用いる。
-              <li key={item.title} className="text-sm">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-muted-foreground tabular-nums">
-                    {i + 1}.
-                  </span>
-                  <span className="font-medium flex-1">{item.title}</span>
-                  {item.estimated_minutes != null && (
-                    <span className="text-xs text-muted-foreground shrink-0">
-                      約{item.estimated_minutes}分
-                    </span>
-                  )}
-                </div>
-                {item.reason && item.reason.trim().length > 0 && (
-                  <p className="text-xs text-muted-foreground mt-0.5 pl-5">
-                    理由: {item.reason}
-                  </p>
-                )}
-              </li>
-            ))}
-          </ol>
+          <AgendaItemList items={agenda} />
         ) : (
           <p className="text-sm text-muted-foreground">
             推奨アジェンダはまだありません

--- a/apps/web/src/features/meetings/hooks/useAgendaHistory.ts
+++ b/apps/web/src/features/meetings/hooks/useAgendaHistory.ts
@@ -1,0 +1,29 @@
+import { api, authHeaders } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import type { RecommendedAgendaItem } from "./useMeetingDetail";
+
+// アジェンダ履歴の 1 エントリ。完了した解析ランから派生する。
+export type AgendaHistoryEntry = {
+  id: string;
+  recommendedAgenda: RecommendedAgendaItem[];
+  createdAt: string;
+  completedAt: string | null;
+};
+
+// 指定 meeting の推奨アジェンダ生成履歴を新しい順で取得する。
+export function useAgendaHistory(meetingId: string, enabled = true) {
+  return useQuery<AgendaHistoryEntry[]>({
+    queryKey: ["meetings", meetingId, "agenda-history"],
+    queryFn: async () => {
+      const res = await api.meetings[":id"]["agenda-history"].$get(
+        { param: { id: meetingId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch agenda history: ${res.status}`);
+      }
+      return (await res.json()) as AgendaHistoryEntry[];
+    },
+    enabled: enabled && meetingId !== "",
+  });
+}

--- a/apps/web/src/routes/meetings.$id.tsx
+++ b/apps/web/src/routes/meetings.$id.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useMeetingDetail } from "@/features/meetings/hooks/useMeetingDetail";
+import { AgendaHistorySection } from "@/features/meetings/components/AgendaHistorySection";
 import { RecommendedAgendaSection } from "@/features/meetings/components/RecommendedAgendaSection";
 import { TopicRequestSection } from "@/features/topic-requests/components/TopicRequestSection";
 import {
@@ -297,6 +298,11 @@ export function MeetingDetailView({
         <RecommendedAgendaSection
           agenda={detail.latestAnalysisRun?.recommendedAgenda ?? null}
         />
+      )}
+
+      {/* アジェンダ生成履歴（過去に複数回生成された場合のみ表示）。過去の会議のみ。 */}
+      {isPastMeeting && (
+        <AgendaHistorySection meetingId={id} enabled={isPastMeeting} />
       )}
 
       {/* 下段: タスク（フルwidth） */}

--- a/apps/web/src/test/meetings.$id.test.tsx
+++ b/apps/web/src/test/meetings.$id.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/lib/api", () => ({
         $get: vi.fn(),
         tasks: { $get: vi.fn() },
         "review-items": { $get: vi.fn() },
+        "agenda-history": { $get: vi.fn() },
       },
     },
     organizations: {
@@ -103,6 +104,9 @@ beforeEach(() => {
   vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detail));
   vi.mocked(api.meetings[":id"].tasks.$get).mockResolvedValue(mockJson([]));
   vi.mocked(api.meetings[":id"]["review-items"].$get).mockResolvedValue(
+    mockJson([]),
+  );
+  vi.mocked(api.meetings[":id"]["agenda-history"].$get).mockResolvedValue(
     mockJson([]),
   );
   // AssigneeFilter のメンバー取得はデフォルトで空配列。個別テストで上書きしない想定。
@@ -415,6 +419,56 @@ describe("MeetingDetailView - 次回会議の推奨アジェンダ", () => {
       "1. 前回タスクの確認（約5分）\n   理由: 継続",
     );
     expect(await screen.findByText("コピーしました")).toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView - アジェンダ生成履歴", () => {
+  it("履歴が2件以上あれば履歴カードが表示され、展開すると各版が出る", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detailPast));
+    vi.mocked(api.meetings[":id"]["agenda-history"].$get).mockResolvedValue(
+      mockJson([
+        {
+          id: "run-2",
+          recommendedAgenda: [{ title: "最新版の議題" }],
+          createdAt: "2026-05-16T11:00:00.000Z",
+          completedAt: "2026-05-16T11:05:00.000Z",
+        },
+        {
+          id: "run-1",
+          recommendedAgenda: [{ title: "旧版の議題" }],
+          createdAt: "2026-05-16T09:00:00.000Z",
+          completedAt: "2026-05-16T09:05:00.000Z",
+        },
+      ]),
+    );
+    const user = userEvent.setup();
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+
+    const toggle = await screen.findByRole("button", {
+      name: /アジェンダ生成履歴/,
+    });
+    await user.click(toggle);
+    expect(await screen.findByText("最新版の議題")).toBeInTheDocument();
+    expect(screen.getByText("旧版の議題")).toBeInTheDocument();
+  });
+
+  it("履歴が1件以下のときは履歴カードを表示しない", async () => {
+    vi.mocked(api.meetings[":id"].$get).mockResolvedValue(mockJson(detailPast));
+    vi.mocked(api.meetings[":id"]["agenda-history"].$get).mockResolvedValue(
+      mockJson([
+        {
+          id: "run-1",
+          recommendedAgenda: [{ title: "唯一の議題" }],
+          createdAt: "2026-05-16T09:00:00.000Z",
+          completedAt: "2026-05-16T09:05:00.000Z",
+        },
+      ]),
+    );
+    renderWithQuery(<MeetingDetailView id="mtg-1" now={NOW} />);
+    await screen.findByText("第3回");
+    expect(
+      screen.queryByLabelText("アジェンダ生成履歴"),
+    ).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #333

## 概要・目的
* 会議で過去に生成された推奨アジェンダ（完了した解析ランの `recommendedAgenda`）を履歴として閲覧・コピーできるようにする
* 「いつ・どんなアジェンダが生成されたか」を版ごとに振り返れるようにする

## 背景
* `MeetingAnalysisRun` は解析のたびに `recommendedAgenda` を保存しているが、最新版（`latestAnalysisRun`）しか UI に出ていなかった
* 確定方針（Issue #333）に基づき、専用履歴テーブルは設けず `MeetingAnalysisRun` から派生で扱い、「復元（版の切替）」は MVP では行わず閲覧＋コピーのみとする

## 変更内容
* api: `GET /meetings/:id/agenda-history` を追加。`completed` かつ `recommendedAgenda` を持つランを新しい順に返す（JSON null は取得後に JS 側で除外）
* web: `useAgendaHistory` フックと `AgendaHistorySection`（折りたたみ式・各版にコピーボタン）を追加
* アジェンダ項目の描画とコピーを `AgendaItemList` / `AgendaCopyButton` に共通化し、`RecommendedAgendaSection`（#332）もこれを利用するよう整理
* 履歴が 1 件以下のときは「現在の推奨アジェンダ」カード（#332）と重複するため履歴カードは非表示

## 動作確認手順
1. `make dev` で全サービスを起動する
2. 同一の過去会議に対して AI 解析を 2 回以上実行し、`recommendedAgenda` を持つ解析ランを複数作る
3. 会議詳細（`/meetings/:id`）に「アジェンダ生成履歴」カードが表示されることを確認する
4. カードを展開し、各版が生成日時（最新には「（最新）」）とともに新しい順で並ぶことを確認する
5. 各版の「コピー」ボタンでその版のアジェンダがクリップボードにコピーされることを確認する
6. 解析が 1 回以下の会議では履歴カードが表示されないことを確認する

## スクリーンショット
* （UI追加: 会議詳細の「アジェンダ生成履歴」カード。後ほど添付）
