### PR TITLE
docs: README を現状のアーキテクチャ・認証構成に同期する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ flowchart LR
     AUTH["FakeAuth\nOIDC Provider"]
     DB[(PostgreSQL)]
     SB[Azure Service Bus]
-    WP[Azure Web PubSub]
     OAI[Azure OpenAI]
-    AIS[Azure AI Search]
+    AIS["Azure AI Search\n（RAG・将来連携）"]
 
     FE <-->|REST| API
     FE -->|OIDC| AUTH
@@ -22,17 +21,18 @@ flowchart LR
     API -->|ジョブ投入| SB
     SB -->|Consumer| AI
     AI --> OAI
-    AI --> AIS
-    AI --> DB
-    AI -->|処理完了通知| WP
-    WP -->|WebSocket| FE
+    AI -.->|将来連携| AIS
+    AI -->|解析結果を保存| API
+    FE -->|status をポーリング| API
 ```
+
+> 解析の完了通知はプッシュ（WebSocket / Web PubSub）ではなく、Frontend が `GET /meetings/:id` で `analysisRun.status` をポーリングして検知する方式です。AI Service は解析結果を App Server の内部 API 経由で保存します。Azure AI Search（RAG）は現状インターフェースのみで、実連携は将来対応です。
 
 ## Prerequisites
 
 | ツール | バージョン | インストール |
 |--------|-----------|------------|
-| Node.js | 20+ | https://nodejs.org |
+| Node.js | 22+ | https://nodejs.org |
 | pnpm | 9+ | `npm install -g pnpm` |
 | Python | 3.12+ | https://www.python.org |
 | uv | 最新 | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
@@ -70,7 +70,7 @@ docker compose exec api wget -qO- http://fake-auth:3007/.well-known/jwks.json
 
 > 手順 3 が成功することで、api コンテナの OIDC ミドルウェア（`apps/api/src/middleware/auth.ts`）が token の `iss` クレーム（`http://fake-auth:3007`）と JWKS 取得経路の双方を満たせる構成になっていることを確認できます。
 >
-> 認証ミドルウェアを適用した API エンドポイントによる end-to-end 動作確認は、ミドルウェアを実ルートに適用する別 Issue で対応します（現時点では `apps/api/src/app.ts` のどのルートにも未適用）。
+> 認証ミドルウェアは各 API ルート（meetings / organizations / tasks / decision-items / ambiguous-infos / me / topic-requests / recurring-meetings）に適用済みです。これらのエンドポイントは有効な Bearer トークンが必須です。
 
 ### `make dev-native` で OIDC を使う場合の追加設定
 
@@ -96,7 +96,7 @@ docker compose exec api wget -qO- http://fake-auth:3007/.well-known/jwks.json
 |---------|-----|
 | Frontend (Vite + React) | http://localhost:5173 |
 | Backend (Hono API) | http://localhost:3001 |
-| AI Service (FastAPI + WebSocket) | http://localhost:8001 |
+| AI Service (FastAPI) | http://localhost:8001 |
 | AI Service docs | http://localhost:8001/docs |
 | **FakeAuth (OIDC Provider)** | http://localhost:3007 |
 


### PR DESCRIPTION
## 関連Issue
（なし: ドキュメント同期）

## 概要・目的
* README の記述を現状の main のアーキテクチャ・認証構成に同期する
* #55 でプッシュ通知（WebSocket / Web PubSub）からポーリング方式へ移行した以降、未反映だった箇所を修正する

## 背景
* アーキテクチャ図が存在しない Web PubSub / WebSocket 経路を記載していた（実コードに該当実装なし。AI Service は `/analyze`・`/health` のみ、FE に WS/PubSub クライアントなし）
* 認証ミドルウェアの注記が「どのルートにも未適用」のままだったが、実際は 8 ルートファイルに適用済み

## 変更内容
* アーキテクチャ図: Web PubSub と WebSocket 経路を削除し、Frontend が `analysisRun.status` をポーリングする構成へ修正。AI Service → App Server（内部API保存）の経路を明示。Azure AI Search は将来連携と注記
* 起動サービス表記を「AI Service (FastAPI + WebSocket)」→「AI Service (FastAPI)」に修正
* OIDC セクションの「実ルートに未適用」注記を、各 API ルートに適用済みである旨へ更新
* Prerequisites の Node.js を CI/デプロイ（Node 22 固定）に合わせて `22+` に更新

## 動作確認手順
1. README.md をプレビュー表示し、Mermaid 図に Web PubSub / WebSocket 経路が無く、ポーリング経路になっていることを確認する
2. 「起動されるサービス」表で AI Service が「(FastAPI)」表記であることを確認する
3. OIDC セクションに認証ミドルウェアが各ルートへ適用済みと記載されていることを確認する

## スクリーンショット
* （ドキュメントのみの変更）
