### PR TITLE
feat: 組織メンバーのロール変更（#124）と退会（#125）機能を追加

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -66,6 +66,11 @@ const inviteSchema = z.object({
   expiresInDays: z.number().int().positive().max(365).nullable().optional(),
 });
 
+// メンバーのロール変更（#124）。owner への変更・降格は不可（owner は組織作成者のみ）。
+const memberRoleUpdateSchema = z.object({
+  role: z.enum(["admin", "member"]),
+});
+
 // 認可ガードは `middleware/authz.ts` に集約済み。
 // 旧 requireMembership / requireRole はそちらの requireOrgMembership /
 // requireOrgRole に統合した。
@@ -217,6 +222,86 @@ export const organizationsRoute = new Hono<{ Variables: AuthVariables }>()
           userId: targetUserId,
           organizationId: id,
         },
+      },
+    });
+    return c.body(null, 204);
+  })
+  // メンバーのロール変更（#124）。owner のみ実行可。
+  .patch(
+    "/:id/members/:userId",
+    zValidator("json", memberRoleUpdateSchema),
+    async (c) => {
+      const id = c.req.param("id");
+      const targetUserId = c.req.param("userId");
+      const callerUserId = c.var.user.id;
+      const { role } = c.req.valid("json");
+
+      const guard = await requireOrgRole(
+        c,
+        id,
+        ["owner"],
+        "ロール変更権限がありません",
+      );
+      if (!guard.ok) return guard.res;
+
+      // 自分自身のロール変更は不可（owner が自分を降格するとロックアウトするため）。
+      if (callerUserId === targetUserId) {
+        return c.json({ error: "自分自身のロールは変更できません" }, 400);
+      }
+
+      const target = await prisma.organizationMembership.findUnique({
+        where: {
+          userId_organizationId: { userId: targetUserId, organizationId: id },
+        },
+      });
+      if (!target) {
+        return c.json({ error: "対象メンバーが見つかりません" }, 404);
+      }
+      // owner は組織作成者のみという仕様を維持するため、owner の降格は許可しない。
+      if (target.role === "owner") {
+        return c.json({ error: "owner のロールは変更できません" }, 400);
+      }
+
+      const updated = await prisma.organizationMembership.update({
+        where: {
+          userId_organizationId: { userId: targetUserId, organizationId: id },
+        },
+        data: { role },
+        include: { user: true },
+      });
+      return c.json({
+        userId: updated.userId,
+        name: updated.user.name,
+        displayName: updated.user.displayName,
+        email: updated.user.email,
+        role: updated.role,
+        joinedAt: updated.joinedAt,
+      });
+    },
+  )
+  // 認証ユーザー自身が組織から退会する（#125）。owner は退会不可。
+  .delete("/:id/membership", async (c) => {
+    const id = c.req.param("id");
+    const callerUserId = c.var.user.id;
+
+    const guard = await requireOrgMembership(c, id);
+    if (!guard.ok) return guard.res;
+
+    // owner は退会不可。組織を抜けるには組織削除 or owner 譲渡（別 Issue）が必要。
+    if (guard.membership.role === "owner") {
+      return c.json(
+        {
+          error:
+            "owner は退会できません。組織を削除するか所有権を移譲してください",
+        },
+        403,
+      );
+    }
+
+    // MeetingMember は schema 側で onDelete: Cascade のため連鎖削除される。
+    await prisma.organizationMembership.delete({
+      where: {
+        userId_organizationId: { userId: callerUserId, organizationId: id },
       },
     });
     return c.body(null, 204);

--- a/apps/api/test/organizations.test.ts
+++ b/apps/api/test/organizations.test.ts
@@ -15,6 +15,7 @@ vi.mock("../src/lib/prisma.js", () => ({
       findFirst: vi.fn(),
       findMany: vi.fn(),
       create: vi.fn(),
+      update: vi.fn(),
       delete: vi.fn(),
     },
     organizationInvitation: {
@@ -145,6 +146,7 @@ const mockMembershipFindMany = vi.mocked(
   prisma.organizationMembership.findMany,
 );
 const mockMembershipDelete = vi.mocked(prisma.organizationMembership.delete);
+const mockMembershipUpdate = vi.mocked(prisma.organizationMembership.update);
 const mockInvitationCreate = vi.mocked(prisma.organizationInvitation.create);
 const mockInvitationFindUnique = vi.mocked(
   prisma.organizationInvitation.findUnique,
@@ -652,6 +654,178 @@ describe("DELETE /organizations/:id/members/:userId", () => {
     mockMembershipFindUnique.mockResolvedValueOnce(null);
 
     const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /organizations/:id/members/:userId（ロール変更 #124）", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function membership(
+    role: "owner" | "admin" | "member",
+    userId = "user-1",
+  ): OrganizationMembership {
+    return {
+      userId,
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  it("owner は他メンバーのロールを変更でき 200 を返す", async () => {
+    // requireOrgRole（呼び出し元）→ 対象 findUnique の順
+    mockMembershipFindUnique
+      .mockResolvedValueOnce(membership("owner", "user-1"))
+      .mockResolvedValueOnce(membership("member", "user-2"));
+    // include: { user: true } 付きの戻り値。テスト用に型をキャストする。
+    mockMembershipUpdate.mockResolvedValue({
+      userId: "user-2",
+      organizationId: "org-1",
+      role: "admin",
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+      user: {
+        name: "bob",
+        displayName: "Bob",
+        email: "bob@example.com",
+      },
+    } as unknown as OrganizationMembership);
+
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "admin" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockMembershipUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_organizationId: { userId: "user-2", organizationId: "org-1" },
+        },
+        data: { role: "admin" },
+      }),
+    );
+  });
+
+  it("admin は 403 を返し update は呼ばれない", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(membership("admin"));
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "admin" }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
+  });
+
+  it("自分自身のロール変更は 400 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(
+      membership("owner", "user-1"),
+    );
+    const res = await app.request("/organizations/org-1/members/user-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "admin" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
+  });
+
+  it("対象が owner の場合は 400 を返す", async () => {
+    mockMembershipFindUnique
+      .mockResolvedValueOnce(membership("owner", "user-1"))
+      .mockResolvedValueOnce(membership("owner", "user-2"));
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "member" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
+  });
+
+  it("対象が存在しない場合は 404 を返す", async () => {
+    mockMembershipFindUnique
+      .mockResolvedValueOnce(membership("owner", "user-1"))
+      .mockResolvedValueOnce(null);
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "admin" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
+  });
+
+  it("role に owner を指定すると 400（バリデーション）", async () => {
+    // zValidator がハンドラ前に弾くため findUnique は呼ばれない。
+    // ここで mockResolvedValueOnce を積むと未消費キューが後続テストへ漏れるため積まない。
+    const res = await app.request("/organizations/org-1/members/user-2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "owner" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /organizations/:id/membership（退会 #125）", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function membership(
+    role: "owner" | "admin" | "member",
+  ): OrganizationMembership {
+    return {
+      userId: "user-1",
+      organizationId: "org-1",
+      role,
+      joinedAt: new Date("2026-05-01T00:00:00Z"),
+    };
+  }
+
+  it("member は自身の membership を削除でき 204 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(membership("member"));
+    mockMembershipDelete.mockResolvedValue(membership("member"));
+
+    const res = await app.request("/organizations/org-1/membership", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(mockMembershipDelete).toHaveBeenCalledWith({
+      where: {
+        userId_organizationId: { userId: "user-1", organizationId: "org-1" },
+      },
+    });
+  });
+
+  it("admin も退会でき 204 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(membership("admin"));
+    mockMembershipDelete.mockResolvedValue(membership("admin"));
+
+    const res = await app.request("/organizations/org-1/membership", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("owner は退会できず 403 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(membership("owner"));
+
+    const res = await app.request("/organizations/org-1/membership", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect(mockMembershipDelete).not.toHaveBeenCalled();
+  });
+
+  it("未所属の場合は 404 を返す", async () => {
+    mockMembershipFindUnique.mockResolvedValueOnce(null);
+
+    const res = await app.request("/organizations/org-1/membership", {
       method: "DELETE",
     });
     expect(res.status).toBe(404);

--- a/apps/web/src/features/organizations/components/LeaveOrganizationDialog.tsx
+++ b/apps/web/src/features/organizations/components/LeaveOrganizationDialog.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useLeaveOrganization } from "@/features/organizations/hooks/useLeaveOrganization";
+import { useState } from "react";
+
+// 組織からの退会確認ダイアログ（#125）。
+// 退会成功後は親に通知（一覧へ遷移するのは親の責務。ページ自体が見えなくなる前提）。
+export function LeaveOrganizationDialog({
+  org,
+  onLeft,
+}: {
+  org: { id: string; name: string };
+  onLeft: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const mutation = useLeaveOrganization(org.id, onLeft);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) mutation.reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="destructive">組織を退会</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>組織を退会</DialogTitle>
+          <DialogDescription>
+            「{org.name}」から退会します。再び参加するには新しい招待が必要です。
+          </DialogDescription>
+        </DialogHeader>
+        {mutation.isError && (
+          <p className="text-destructive text-sm">退会に失敗しました</p>
+        )}
+        <DialogFooter>
+          <Button
+            variant="destructive"
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            退会する
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/organizations/components/MemberRoleSelect.tsx
+++ b/apps/web/src/features/organizations/components/MemberRoleSelect.tsx
@@ -1,0 +1,33 @@
+import { useUpdateMemberRole } from "@/features/organizations/hooks/useUpdateMemberRole";
+
+// owner がメンバーの admin / member ロールを切り替える select（#124）。
+// owner 対象・自分自身は呼び出し側で除外し、本コンポーネントは admin/member のみ受け取る。
+export function MemberRoleSelect({
+  orgId,
+  targetUserId,
+  role,
+}: {
+  orgId: string;
+  targetUserId: string;
+  role: "admin" | "member";
+}) {
+  const mutation = useUpdateMemberRole(orgId);
+
+  return (
+    <select
+      aria-label="ロール変更"
+      value={role}
+      disabled={mutation.isPending}
+      onChange={(e) => {
+        const next = e.target.value as "admin" | "member";
+        if (next !== role) {
+          mutation.mutate({ targetUserId, role: next });
+        }
+      }}
+      className="text-xs px-2 py-1 rounded-md border border-border/60 bg-card text-foreground disabled:opacity-50"
+    >
+      <option value="admin">管理者</option>
+      <option value="member">メンバー</option>
+    </select>
+  );
+}

--- a/apps/web/src/features/organizations/hooks/useLeaveOrganization.ts
+++ b/apps/web/src/features/organizations/hooks/useLeaveOrganization.ts
@@ -1,0 +1,20 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation } from "@tanstack/react-query";
+
+// DELETE /organizations/:id/membership の薄いラッパー（#125・退会）。
+// 退会成功後は組織一覧へ遷移する責務を呼び出し側が持つため、ここでは invalidate せず
+// onSuccess に委ねる（組織詳細ページ自体が見えなくなる前提）。
+export function useLeaveOrganization(orgId: string, onSuccess?: () => void) {
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.organizations[":id"].membership.$delete(
+        { param: { id: orgId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to leave organization: ${res.status}`);
+      }
+    },
+    onSuccess,
+  });
+}

--- a/apps/web/src/features/organizations/hooks/useUpdateMemberRole.ts
+++ b/apps/web/src/features/organizations/hooks/useUpdateMemberRole.ts
@@ -1,0 +1,30 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type UpdateMemberRoleInput = {
+  targetUserId: string;
+  role: "admin" | "member";
+};
+
+// PATCH /organizations/:id/members/:userId の薄いラッパー（#124）。
+// 変更後にメンバー一覧を invalidate して最新ロールを反映する。
+export function useUpdateMemberRole(orgId: string, onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ targetUserId, role }: UpdateMemberRoleInput) => {
+      const res = await api.organizations[":id"].members[":userId"].$patch(
+        { param: { id: orgId, userId: targetUserId }, json: { role } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to update member role: ${res.status}`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["organizations", orgId, "members"],
+      });
+      onSuccess?.();
+    },
+  });
+}

--- a/apps/web/src/routes/organizations.$id.tsx
+++ b/apps/web/src/routes/organizations.$id.tsx
@@ -3,6 +3,8 @@ import { DeleteMemberDialog } from "@/features/organizations/components/DeleteMe
 import { DeleteOrganizationDialog } from "@/features/organizations/components/DeleteOrganizationDialog";
 import { EditOrganizationDialog } from "@/features/organizations/components/EditOrganizationDialog";
 import { InviteMemberDialog } from "@/features/organizations/components/InviteMemberDialog";
+import { LeaveOrganizationDialog } from "@/features/organizations/components/LeaveOrganizationDialog";
+import { MemberRoleSelect } from "@/features/organizations/components/MemberRoleSelect";
 import { PendingInvitationsList } from "@/features/organizations/components/PendingInvitationsList";
 import { RoleBadge } from "@/features/organizations/components/RoleBadge";
 import type {
@@ -141,7 +143,19 @@ export function OrganizationDetailView({
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <RoleBadge role={m.role} />
+                  {/* owner は他メンバー（owner 以外・自分以外）のロールを変更できる（#124）。
+                      それ以外はバッジ表示のみ。 */}
+                  {org.role === "owner" &&
+                  m.role !== "owner" &&
+                  m.email !== currentUserEmail ? (
+                    <MemberRoleSelect
+                      orgId={id}
+                      targetUserId={m.userId}
+                      role={m.role}
+                    />
+                  ) : (
+                    <RoleBadge role={m.role} />
+                  )}
                   {org.role === "owner" && m.email !== currentUserEmail && (
                     <DeleteMemberDialog orgId={id} member={m} />
                   )}
@@ -191,21 +205,32 @@ export function OrganizationDetailView({
         )}
       </section>
 
-      {org.role === "owner" && (
-        <section
-          aria-label="危険な操作"
-          className="space-y-3 rounded-md border border-destructive/30 p-4"
-        >
-          <h2 className="text-lg font-semibold text-destructive">危険な操作</h2>
-          <p className="text-sm text-muted-foreground">
-            組織を削除すると、関連する定例とメンバーシップもすべて失われます。
-          </p>
-          <DeleteOrganizationDialog
-            org={org}
-            onDeleted={onOrganizationDeleted}
-          />
-        </section>
-      )}
+      {/* 危険な操作: owner は組織削除、それ以外のメンバーは退会（#125）。 */}
+      <section
+        aria-label="危険な操作"
+        className="space-y-3 rounded-md border border-destructive/30 p-4"
+      >
+        <h2 className="text-lg font-semibold text-destructive">危険な操作</h2>
+        {org.role === "owner" ? (
+          <>
+            <p className="text-sm text-muted-foreground">
+              組織を削除すると、関連する定例とメンバーシップもすべて失われます。
+              owner は退会できないため、組織を抜けるには削除してください。
+            </p>
+            <DeleteOrganizationDialog
+              org={org}
+              onDeleted={onOrganizationDeleted}
+            />
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              この組織から退会します。再び参加するには新しい招待が必要です。
+            </p>
+            <LeaveOrganizationDialog org={org} onLeft={onOrganizationDeleted} />
+          </>
+        )}
+      </section>
     </section>
   );
 }

--- a/apps/web/src/test/organizations.$id.test.tsx
+++ b/apps/web/src/test/organizations.$id.test.tsx
@@ -25,8 +25,9 @@ vi.mock("@/lib/api", () => ({
         invite: { $post: vi.fn() },
         members: {
           $get: vi.fn(),
-          ":userId": { $delete: vi.fn() },
+          ":userId": { $delete: vi.fn(), $patch: vi.fn() },
         },
+        membership: { $delete: vi.fn() },
         meetings: { $post: vi.fn() },
       },
     },
@@ -63,16 +64,18 @@ describe("組織詳細ページ - 基本表示", () => {
     expect(screen.getAllByText("オーナー").length).toBeGreaterThan(0);
   });
 
-  it("メンバー一覧が role バッジ付きで表示される", async () => {
-    renderDetail();
+  it("メンバー一覧が表示され、owner 閲覧時は owner にバッジ・他メンバーにロール変更 select が出る", async () => {
+    renderDetail({ currentUserEmail: "alice@example.com" });
     const memberList = await screen.findByRole("list", {
       name: "メンバー一覧",
     });
     expect(within(memberList).getByText("Alice A.")).toBeInTheDocument();
     expect(within(memberList).getByText("Bob B.")).toBeInTheDocument();
     expect(within(memberList).getByText("Carol C.")).toBeInTheDocument();
-    expect(within(memberList).getByText("管理者")).toBeInTheDocument();
-    expect(within(memberList).getByText("メンバー")).toBeInTheDocument();
+    // owner（alice 自身）はバッジ表示
+    expect(within(memberList).getByText("オーナー")).toBeInTheDocument();
+    // bob(admin) / carol(member) はロール変更 select（owner 閲覧時）
+    expect(within(memberList).getAllByLabelText("ロール変更")).toHaveLength(2);
   });
 
   it("定例一覧がカードで表示され、定例名・scheduleCron・所要時間・作成日を含む", async () => {
@@ -620,5 +623,105 @@ describe("組織詳細ページ - 定例削除ダイアログ", () => {
     expect(
       await within(dialog).findByText("定例の削除に失敗しました"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("組織詳細ページ - メンバーのロール変更（#124）", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson(ownerOrgDetail),
+    );
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("owner 閲覧時は owner 以外・自分以外のメンバーにロール変更 select が出る", async () => {
+    renderDetail({ currentUserEmail: "alice@example.com" });
+    await screen.findByText("Bob B.");
+    // bob(admin) と carol(member) の 2 件。owner の alice 自身には出ない。
+    const selects = screen.getAllByLabelText("ロール変更");
+    expect(selects).toHaveLength(2);
+  });
+
+  it("select 変更で PATCH members/:userId が呼ばれる", async () => {
+    const patch = vi.mocked(api.organizations[":id"].members[":userId"].$patch);
+    patch.mockResolvedValue(mockJson({}));
+    const user = userEvent.setup();
+    renderDetail({ currentUserEmail: "alice@example.com" });
+    await screen.findByText("Bob B.");
+
+    // bob(admin) の select を member に変更
+    const selects = screen.getAllByLabelText("ロール変更");
+    await user.selectOptions(selects[0], "member");
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    const call = patch.mock.calls[0][0] as {
+      param: { id: string; userId: string };
+      json: { role: string };
+    };
+    expect(call.param).toEqual({ id: "org-1", userId: "user-2" });
+    expect(call.json).toEqual({ role: "member" });
+  });
+
+  it("member 閲覧時はロール変更 select が出ない", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "member" }),
+    );
+    renderDetail({ currentUserEmail: "carol@example.com" });
+    await screen.findByText("Bob B.");
+    expect(screen.queryByLabelText("ロール変更")).not.toBeInTheDocument();
+  });
+});
+
+describe("組織詳細ページ - 退会（#125）", () => {
+  beforeEach(() => {
+    vi.mocked(api.organizations[":id"].members.$get).mockResolvedValue(
+      mockJson(sampleMembers),
+    );
+  });
+
+  it("非 owner 閲覧時は「組織を退会」ボタンが出る", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "member" }),
+    );
+    renderDetail({ currentUserEmail: "carol@example.com" });
+    expect(
+      await screen.findByRole("button", { name: "組織を退会" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "組織を削除" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("owner 閲覧時は「組織を削除」が出て「組織を退会」は出ない", async () => {
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson(ownerOrgDetail),
+    );
+    renderDetail({ currentUserEmail: "alice@example.com" });
+    expect(
+      await screen.findByRole("button", { name: "組織を削除" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "組織を退会" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("退会実行で DELETE membership が呼ばれる", async () => {
+    const del = vi.mocked(api.organizations[":id"].membership.$delete);
+    del.mockResolvedValue(mockJson(null, 204));
+    vi.mocked(api.organizations[":id"].$get).mockResolvedValue(
+      mockJson({ ...ownerOrgDetail, role: "member" }),
+    );
+    const user = userEvent.setup();
+    renderDetail({ currentUserEmail: "carol@example.com" });
+
+    await user.click(await screen.findByRole("button", { name: "組織を退会" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "退会する" }));
+
+    await waitFor(() => expect(del).toHaveBeenCalled());
+    const call = del.mock.calls[0][0] as { param: { id: string } };
+    expect(call.param).toEqual({ id: "org-1" });
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #124
Closes #125

## 概要・目的
* 組織メンバーのロールを後から変更する機能（#124）と、メンバー自身が組織を退会する機能（#125）を追加する
* 招待時にロールが固定され変更できない・自分で組織を抜けられない、という運用上のギャップを解消する

## 背景
* メンバー管理（招待・削除）は実装済みだが、ロール変更 API と自己退会 API が無かった
* 認可ガード（requireOrgRole / requireOrgMembership）・組織詳細 UI（メンバー一覧・危険な操作）の土台は既存

## 変更内容
### #124 メンバーのロール変更
* api: `PATCH /organizations/:id/members/:userId`（body: `{ role: "admin" | "member" }`）。owner のみ実行可。自分自身・owner 対象は変更不可（ロックアウト防止 / owner 単独仕様の維持）
* web: 組織詳細のメンバー行に、owner 閲覧時のみ admin/member 切替の select を表示（owner 対象・自分自身は対象外）

### #125 組織からの退会
* api: `DELETE /organizations/:id/membership`（認証ユーザー自身の membership を削除）。owner は退会不可（403）
* web: 危険な操作セクションを再構成し、非 owner には「組織を退会」ボタン + 確認ダイアログ、owner には従来の組織削除を表示。退会後は組織一覧へ遷移

## 動作確認手順
1. `make dev` で全サービスを起動する
2. owner で組織詳細を開き、他メンバー（admin/member）の行にロール変更 select が出ることを確認し、admin↔member を切り替えてバッジ/select が更新されることを確認する
3. 自分自身（owner）・他の owner にはロール変更 select が出ないことを確認する
4. admin または member のユーザーでログインして組織詳細を開き、「組織を退会」→確認ダイアログ→退会で組織一覧へ遷移し、一覧から当該組織が消えることを確認する
5. owner では「組織を退会」が出ず「組織を削除」が出ることを確認する
6. `make test`（api / web）がすべて通ることを確認する

## スクリーンショット
* （UI追加: メンバー行のロール変更 select / 危険な操作の退会ボタン。後ほど添付）
