### PR TITLE
ユーザー事前登録議題を AI の推奨アジェンダ生成に反映する

### DIFF
--- a/services/ai/pipeline/analyze_meeting.py
+++ b/services/ai/pipeline/analyze_meeting.py
@@ -327,6 +327,7 @@ async def analyze_meeting(
             estimation_note=estimation_note,
             suggested_participants=suggested_participants,
             change_summary=change_summary,
+            user_topic_requests=job.user_topic_requests,
         )
         raw6, parsed6 = await run_llm_call(llm_client, "call6", prompt6)
         raw_outputs["call6"] = raw6

--- a/services/ai/pipeline/prompt_builders.py
+++ b/services/ai/pipeline/prompt_builders.py
@@ -2,6 +2,8 @@
 
 from string import Template
 
+from schemas.analysis import UserTopicRequest
+
 
 def render_prompt(template: str, **kwargs: object) -> str:
     """string.Template.safe_substituteを使いプロンプト変数を展開する。
@@ -172,6 +174,22 @@ def fmt_ambiguities_for_call6(ambiguities: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def fmt_topic_requests_for_call6(topic_requests: list[UserTopicRequest]) -> str:
+    """Call 6用：ユーザーが事前登録した議題を箇条書きで整形する。
+
+    priority を [required]/[optional] で示し、required は必ずアジェンダに
+    含めるべき議題であることを LLM に伝える。
+    """
+    lines = []
+    for tr in topic_requests:
+        priority = tr.priority or "optional"
+        body = f"：{tr.body}" if tr.body else ""
+        lines.append(
+            f"- [{priority}] {tr.title}{body}（登録者: {tr.requested_by_name}）"
+        )
+    return "\n".join(lines)
+
+
 # ──────────────────── Callプロンプト構築 ────────────────────
 
 
@@ -247,6 +265,7 @@ def build_call6_prompt(
     estimation_note: str,
     suggested_participants: str,
     change_summary: str | None = None,
+    user_topic_requests: list[UserTopicRequest] | None = None,
 ) -> str:
     """Call 6（サマリー・推奨アジェンダ生成）のプロンプトを構築する。"""
     speakers_text = fmt_speakers(speakers)
@@ -260,6 +279,16 @@ def build_call6_prompt(
     else:
         change_summary_section = ""
 
+    # ユーザー事前登録議題は、あるときだけセクションを出す
+    # （change_summary_section と同じ「あるときだけ出す」パターン）。
+    if user_topic_requests:
+        user_topic_requests_section = render_prompt(
+            prompts["call6_user_topic_requests"]["template"],
+            user_topic_requests=fmt_topic_requests_for_call6(user_topic_requests),
+        )
+    else:
+        user_topic_requests_section = ""
+
     return render_prompt(
         prompts["call6"]["template"],
         speakers=speakers_text,
@@ -270,4 +299,5 @@ def build_call6_prompt(
         estimation_note=estimation_note,
         suggested_participants=suggested_participants,
         change_summary_section=change_summary_section,
+        user_topic_requests_section=user_topic_requests_section,
     )

--- a/services/ai/prompts/meeting_analysis_prompts.toml
+++ b/services/ai/prompts/meeting_analysis_prompts.toml
@@ -262,9 +262,12 @@ $suggested_participants
 
 $change_summary_section
 
+$user_topic_requests_section
+
 ## 出力ルール
 - summaryは今回の会議全体を200字以内で要約する
 - recommended_agendaは次回会議で議論すべき項目を優先度順に並べる
+- ユーザー事前登録議題（上掲の「ユーザーが事前登録した議題」）のうち[required]はrecommended_agendaに必ず含め、タイトルの文言を変えない。[optional]は内容に応じて取り込む。既存の議論項目と重複する場合は1つにまとめる
 - estimation_noteは次回会議の所要時間見積もりを記す
 
 ## 出力フォーマット（JSON）
@@ -285,3 +288,8 @@ JSONのみ返してください（コードブロック不要）。"""
 [continuity_call6_change_summary]
 template = """## 前回からの変化サマリー
 $change_summary"""
+
+[call6_user_topic_requests]
+template = """## ユーザーが事前登録した議題
+次回会議でユーザーが取り上げたいと登録した議題です。[required]は必ず推奨アジェンダに含めてください。
+$user_topic_requests"""

--- a/services/ai/schemas/analysis.py
+++ b/services/ai/schemas/analysis.py
@@ -14,6 +14,17 @@ class SpeakerInfo(BaseModel):
     resolution_status: str
 
 
+class UserTopicRequest(BaseModel):
+    # ユーザーが事前登録した議題。apps/api の GET /internal/analysis-runs/:id/input が
+    # 返す user_topic_requests の各要素と形を合わせる
+    # （apps/api/src/routes/analysis-runs.ts の user_topic_requests）。
+    # priority は TopicRequestPriority?（required / optional / null）を文字列で受ける。
+    title: str
+    body: Optional[str] = None
+    priority: Optional[str] = None
+    requested_by_name: str
+
+
 class AnalysisJobInput(BaseModel):
     # None の場合はドライランモード（apps/api へのステータス更新を行わない）
     analysis_run_id: Optional[str] = None
@@ -27,6 +38,9 @@ class AnalysisJobInput(BaseModel):
     previous_meeting_id: Optional[str] = None
     speakers: list[SpeakerInfo]
     previous_report_json: Optional[dict] = None
+    # ユーザーが事前登録した議題。未指定・0件のときは空リスト。
+    # apps/api が常にキーを送るが、後方互換のためデフォルトを空リストにしておく。
+    user_topic_requests: list[UserTopicRequest] = []
 
 
 class AnalysisRunResult(BaseModel):

--- a/services/ai/tests/test_analyze_pipeline.py
+++ b/services/ai/tests/test_analyze_pipeline.py
@@ -23,7 +23,7 @@ from pipeline.postprocess import (
     remove_emoji,
 )
 from pipeline.validation import validate_outputs
-from schemas.analysis import AnalysisJobInput, SpeakerInfo
+from schemas.analysis import AnalysisJobInput, SpeakerInfo, UserTopicRequest
 
 # ──────────────────────── FakeLLMClient用フィクスチャ ─────────────────────────
 
@@ -196,6 +196,36 @@ async def test_analyze_meeting_completed():
     assert "total_minutes" in report["estimation"]
     assert isinstance(report.get("estimation_note"), str)
     assert "想定所要時間" in report["estimation_note"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_meeting_passes_user_topic_requests_to_call6():
+    """job.user_topic_requests が Call 6（推奨アジェンダ生成）プロンプトに渡る。"""
+    job = _make_job()
+    job.user_topic_requests = [
+        UserTopicRequest(
+            title="予算の再検討",
+            body="前回保留分を詰める",
+            priority="required",
+            requested_by_name="田中",
+        )
+    ]
+
+    captured_prompts: list[str] = []
+
+    class _RecordingClient(FakeLLMClient):
+        async def call(self, prompt: str, temperature: float = 0.1) -> str:
+            captured_prompts.append(prompt)
+            return await super().call(prompt, temperature)
+
+    client = _RecordingClient(_make_fake_responses())
+    result = await analyze_meeting(job, client)
+
+    assert result.status == "completed"
+    # Call 6 のプロンプト（"推奨アジェンダ" を含む）にユーザー議題が注入されている
+    call6_prompts = [p for p in captured_prompts if "推奨アジェンダ" in p]
+    assert call6_prompts, "Call 6 のプロンプトが見つからない"
+    assert "予算の再検討" in call6_prompts[0]
 
 
 @pytest.mark.asyncio

--- a/services/ai/tests/test_user_topic_requests.py
+++ b/services/ai/tests/test_user_topic_requests.py
@@ -4,6 +4,11 @@
 フィールドが無く Pydantic の extra=ignore で破棄されていた。その回帰防止を含む。
 """
 
+from pipeline.analyze_meeting import _load_prompts
+from pipeline.prompt_builders import (
+    build_call6_prompt,
+    fmt_topic_requests_for_call6,
+)
 from schemas.analysis import AnalysisJobInput, UserTopicRequest
 
 
@@ -56,3 +61,64 @@ def test_analysis_job_input_defaults_to_empty_list():
     job = AnalysisJobInput(**data)
 
     assert job.user_topic_requests == []
+
+
+def _topic_requests() -> list[UserTopicRequest]:
+    return [
+        UserTopicRequest(
+            title="予算の再検討",
+            body="前回保留になった増額分を詰める",
+            priority="required",
+            requested_by_name="田中",
+        ),
+        UserTopicRequest(
+            title="次期スケジュール共有",
+            body=None,
+            priority="optional",
+            requested_by_name="佐藤",
+        ),
+    ]
+
+
+def test_fmt_topic_requests_for_call6_includes_priority_body_requester():
+    """整形結果に priority・本文・登録者が含まれる。"""
+    text = fmt_topic_requests_for_call6(_topic_requests())
+
+    assert "[required]" in text
+    assert "[optional]" in text
+    assert "予算の再検討" in text
+    assert "前回保留になった増額分を詰める" in text
+    assert "田中" in text
+
+
+def _build_call6(topics: list[UserTopicRequest] | None) -> str:
+    return build_call6_prompt(
+        _load_prompts(),
+        transcript="本日の議題は...",
+        speakers=[],
+        decisions=[],
+        open_issues=[],
+        tasks=[],
+        ambiguities=[],
+        estimation_note="",
+        suggested_participants="",
+        user_topic_requests=topics,
+    )
+
+
+def test_build_call6_prompt_injects_topic_requests():
+    """議題ありのとき Call 6 プロンプトに議題セクションが入る。"""
+    prompt = _build_call6(_topic_requests())
+
+    assert "次回会議でユーザーが取り上げたいと登録した議題です" in prompt
+    assert "予算の再検討" in prompt
+    assert "[required]" in prompt
+
+
+def test_build_call6_prompt_omits_section_when_empty():
+    """議題が0件のときはセクションを出さず、プレースホルダも残さない。"""
+    prompt = _build_call6([])
+
+    assert "次回会議でユーザーが取り上げたいと登録した議題です" not in prompt
+    assert "予算の再検討" not in prompt
+    assert "$user_topic_requests_section" not in prompt

--- a/services/ai/tests/test_user_topic_requests.py
+++ b/services/ai/tests/test_user_topic_requests.py
@@ -1,0 +1,58 @@
+"""ユーザー事前登録議題（user_topic_requests）の受信・整形・プロンプト注入のテスト。
+
+#347: apps/api は user_topic_requests を送っていたが、AnalysisJobInput に
+フィールドが無く Pydantic の extra=ignore で破棄されていた。その回帰防止を含む。
+"""
+
+from schemas.analysis import AnalysisJobInput, UserTopicRequest
+
+
+def _api_input_dict() -> dict:
+    """apps/api の GET /internal/analysis-runs/:id/input が返す形を模した入力。"""
+    return {
+        "analysis_run_id": "run-1",
+        "meeting_id": "mtg-1",
+        "meeting_type": "recurring_meeting",
+        "transcription_quality": "full",
+        "transcript": "本日の議題は...",
+        "meeting_date": "2026-05-30",
+        "speakers": [],
+        "previous_report_json": None,
+        "user_topic_requests": [
+            {
+                "title": "予算の再検討",
+                "body": "前回保留になった増額分を詰める",
+                "priority": "required",
+                "requested_by_name": "田中",
+            },
+            {
+                "title": "次期スケジュール共有",
+                "body": None,
+                "priority": "optional",
+                "requested_by_name": "佐藤",
+            },
+        ],
+    }
+
+
+def test_analysis_job_input_keeps_user_topic_requests():
+    """API が送る user_topic_requests が破棄されず保持される（#347 回帰防止）。"""
+    job = AnalysisJobInput(**_api_input_dict())
+
+    assert len(job.user_topic_requests) == 2
+    first = job.user_topic_requests[0]
+    assert isinstance(first, UserTopicRequest)
+    assert first.title == "予算の再検討"
+    assert first.body == "前回保留になった増額分を詰める"
+    assert first.priority == "required"
+    assert first.requested_by_name == "田中"
+
+
+def test_analysis_job_input_defaults_to_empty_list():
+    """user_topic_requests 未指定時は空リスト（後方互換）。"""
+    data = _api_input_dict()
+    del data["user_topic_requests"]
+
+    job = AnalysisJobInput(**data)
+
+    assert job.user_topic_requests == []


### PR DESCRIPTION
## 関連Issue
Closes #347

## 概要・目的
ユーザーが「次回会議の議題」UI で事前登録した議題を、AI の推奨アジェンダ生成に反映させる。これまで apps/api は議題（user_topic_requests）を AI Service へ送っていたが、受信側の `AnalysisJobInput` に対応フィールドが無く、Pydantic の `extra=ignore` で黙って破棄されていた。#287 で API 側だけ実装してクローズされた残作業に対応する。

## 背景
会議の詳細ページには「次回会議の議題」（ユーザー登録）と「次回会議の推奨アジェンダ」（AI 生成）が並ぶ。どちらも同じ次回会議を指すが、ユーザー登録議題は AI の生成プロセスに渡っておらず、登録しても推奨アジェンダに現れなかった。DB・API・UI は揃っていたため、欠けていた AI Service 側の受信とプロンプト注入だけを追加する。

## 変更内容
* `AnalysisJobInput` に `UserTopicRequest` モデルと `user_topic_requests` フィールドを追加。デフォルト空リストで後方互換を保つ（`services/ai/schemas/analysis.py`）
* `build_call6_prompt` に議題を注入。議題があるときだけプロンプトにセクションを出す（既存の変化サマリーと同じ「あるときだけ出す」方式）。`fmt_topic_requests_for_call6` で priority・本文・登録者を整形（`services/ai/pipeline/prompt_builders.py`）
* Call 6 の出力ルールに「priority=required の議題は推奨アジェンダに必ず含め、タイトルの文言を変えない」制約を明記（`services/ai/prompts/meeting_analysis_prompts.toml`）
* `analyze_meeting` で `job.user_topic_requests` を `build_call6_prompt` に渡し、API → AI → 推奨アジェンダのデータ経路を貫通（`services/ai/pipeline/analyze_meeting.py`）
* 既存アジェンダ項目との重複排除・優先度調整は LLM に委ね、出力スキーマ `recommended_agenda`（title / estimated_minutes / reason）は変更しない
* テスト6件追加（受信2・整形/プロンプト注入3・パイプライン縦断1）

<img width="681" height="791" alt="image" src="https://github.com/user-attachments/assets/db75e49c-986e-477d-adef-8dc0589f649f" />

<img width="773" height="395" alt="image" src="https://github.com/user-attachments/assets/c91e560e-da3d-4abc-a9d5-89f2c69504b1" />

<img width="776" height="361" alt="image" src="https://github.com/user-attachments/assets/73d4fd58-b311-4242-9402-b63db397aec3" />

## 動作確認手順
1. `git switch feature/issue-347-user-topic-requests-ai`
2. `make test` を実行（内部で `cd services/ai && uv run pytest` が走る）。pytest が 65 passed になることを確認
3. `make lint` を実行し、Ruff（Python）が通ることを確認
4. プロンプト注入のみ確認する場合：`cd services/ai && uv run pytest tests/test_user_topic_requests.py tests/test_analyze_pipeline.py -q`

## スクリーンショット
UI 変更なし（AI Service 内部のプロンプト変更）。議題があるとき Call 6 プロンプトに追加されるセクション例：

```
## ユーザーが事前登録した議題
次回会議でユーザーが取り上げたいと登録した議題です。[required]は必ず推奨アジェンダに含めてください。
- [required] 予算の再検討：前回保留分を詰める（登録者: 田中）
```
