### PR TITLE
会議の意思決定文脈グラフ取得 API を追加

### DIFF
--- a/apps/api/src/lib/decision-graph-serialization.ts
+++ b/apps/api/src/lib/decision-graph-serialization.ts
@@ -1,0 +1,304 @@
+// 1 会議スコープの「意思決定の文脈グラフ（因果チェーン）」を構築する純粋関数群。
+//
+// 会議・決定事項・タスク・未決事項・次回議題を「ノード」、それらの来歴
+// （会議の連なり／決定からの派生／依存／未決の解決先など）を「エッジ」として返す。
+// レスポンスはフロントエンドの React Flow がそのまま扱える形（nodes / edges）に揃える。
+//
+// Prisma の payload 型には直接依存させず、必要なフィールドだけの構造的型を入力に取る。
+// これにより、クエリ側の select / include 変更と疎結合になり、単体テストも書きやすくなる。
+
+export type GraphNodeType =
+  | "meeting"
+  | "decision"
+  | "task"
+  | "ambiguous"
+  | "topic";
+
+export type GraphEdgeType =
+  // 会議の連なり（前回 → 今回 → 次回）
+  | "chain"
+  // 会議が決定/タスクを生んだ
+  | "produces"
+  // 決定から派生したタスク
+  | "derives"
+  // 決定が次回会議へ持ち越された
+  | "carryover"
+  // 前提となる項目への依存
+  | "blocks"
+  // 未決事項の解決先
+  | "resolves"
+  // 次回議題（議題 → 会議）
+  | "agenda";
+
+export type GraphNode = {
+  id: string;
+  type: GraphNodeType;
+  label: string;
+  data: Record<string, unknown>;
+};
+
+export type GraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  type: GraphEdgeType;
+};
+
+export type DecisionGraph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+};
+
+// --- 入力型（純粋関数が必要とする最小フィールドのみ） ---
+
+export type GraphMeetingInput = {
+  id: string;
+  title: string;
+  heldAt: Date;
+  previousMeeting: { id: string; title: string } | null;
+  nextMeetings: { id: string; title: string }[];
+};
+
+export type GraphDecisionInput = {
+  id: string;
+  title: string;
+  status: string;
+  decisionState: string | null;
+  blockingItemId: string | null;
+  plannedMeeting: { id: string; title: string } | null;
+};
+
+export type GraphTaskInput = {
+  id: string;
+  title: string;
+  status: string;
+  decisionItemId: string | null;
+  blockingItemId: string | null;
+};
+
+export type GraphAmbiguousInput = {
+  id: string;
+  body: string;
+  status: string;
+  resolvedToTaskId: string | null;
+  resolvedToDecisionItemId: string | null;
+};
+
+export type GraphTopicInput = {
+  id: string;
+  title: string;
+  priority: string | null;
+};
+
+export type BuildDecisionGraphInput = {
+  meeting: GraphMeetingInput;
+  decisionItems: GraphDecisionInput[];
+  tasks: GraphTaskInput[];
+  ambiguousInfos: GraphAmbiguousInput[];
+  topicRequests: GraphTopicInput[];
+};
+
+const meetingNodeId = (id: string) => `meeting:${id}`;
+const decisionNodeId = (id: string) => `decision:${id}`;
+const taskNodeId = (id: string) => `task:${id}`;
+const ambiguousNodeId = (id: string) => `ambiguous:${id}`;
+const topicNodeId = (id: string) => `topic:${id}`;
+
+/**
+ * 1 会議スコープの意思決定文脈グラフを構築する。
+ * 入力の各リレーションからノード集合とエッジ集合を組み立てて返す。
+ *
+ * 設計方針:
+ * - ノード ID は種別プレフィックス付き（例 "decision:xxx"）で衝突を防ぐ。
+ * - エッジは両端がノード集合に存在する場合のみ張る。会議スコープ外を指す
+ *   blockingItemId / resolvedTo* は端点が無いため自然に除外される。
+ * - 決定由来のタスクは決定からの derives を優先し、会議からの produces は重複させない。
+ */
+export function buildDecisionGraph(
+  input: BuildDecisionGraphInput,
+): DecisionGraph {
+  const { meeting, decisionItems, tasks, ambiguousInfos, topicRequests } =
+    input;
+
+  const nodes = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+  // 生 id → ノード id の逆引き。blockingItemId が決定・タスクのどちらを指すか
+  // 不明（スキーマ上は単なる文字列）なため、登録済みノードから一意に解決する。
+  const rawIdToNodeId = new Map<string, string>();
+
+  // ノードを重複なく登録する。既に同 ID があれば最初の登録を優先する。
+  const addNode = (node: GraphNode, rawId: string) => {
+    if (nodes.has(node.id)) return;
+    nodes.set(node.id, node);
+    rawIdToNodeId.set(rawId, node.id);
+  };
+
+  // エッジを登録する。両端がノード集合に存在する場合のみ張る。
+  const addEdge = (source: string, target: string, type: GraphEdgeType) => {
+    if (!nodes.has(source) || !nodes.has(target)) return;
+    edges.push({ id: `${type}:${source}->${target}`, source, target, type });
+  };
+
+  // --- ノード登録 ---
+  // 当該会議（current=true）。
+  addNode(
+    {
+      id: meetingNodeId(meeting.id),
+      type: "meeting",
+      label: meeting.title,
+      data: { current: true, heldAt: meeting.heldAt },
+    },
+    meeting.id,
+  );
+  if (meeting.previousMeeting) {
+    addNode(
+      {
+        id: meetingNodeId(meeting.previousMeeting.id),
+        type: "meeting",
+        label: meeting.previousMeeting.title,
+        data: { current: false },
+      },
+      meeting.previousMeeting.id,
+    );
+  }
+  for (const next of meeting.nextMeetings) {
+    addNode(
+      {
+        id: meetingNodeId(next.id),
+        type: "meeting",
+        label: next.title,
+        data: { current: false },
+      },
+      next.id,
+    );
+  }
+
+  for (const d of decisionItems) {
+    addNode(
+      {
+        id: decisionNodeId(d.id),
+        type: "decision",
+        label: d.title,
+        data: { status: d.status, decisionState: d.decisionState },
+      },
+      d.id,
+    );
+    // 持ち越し先の会議が会議チェーンに無い場合もノードとして補う。
+    if (d.plannedMeeting) {
+      addNode(
+        {
+          id: meetingNodeId(d.plannedMeeting.id),
+          type: "meeting",
+          label: d.plannedMeeting.title,
+          data: { current: false },
+        },
+        d.plannedMeeting.id,
+      );
+    }
+  }
+
+  for (const t of tasks) {
+    addNode(
+      {
+        id: taskNodeId(t.id),
+        type: "task",
+        label: t.title,
+        data: { status: t.status },
+      },
+      t.id,
+    );
+  }
+
+  for (const a of ambiguousInfos) {
+    addNode(
+      {
+        id: ambiguousNodeId(a.id),
+        type: "ambiguous",
+        label: a.body,
+        data: { status: a.status },
+      },
+      a.id,
+    );
+  }
+
+  for (const tr of topicRequests) {
+    addNode(
+      {
+        id: topicNodeId(tr.id),
+        type: "topic",
+        label: tr.title,
+        data: { priority: tr.priority },
+      },
+      tr.id,
+    );
+  }
+
+  // --- エッジ登録（全ノード登録後に実施し、端点解決を確実にする） ---
+  // 会議の連なり: 前回 → 今回 → 次回。
+  if (meeting.previousMeeting) {
+    addEdge(
+      meetingNodeId(meeting.previousMeeting.id),
+      meetingNodeId(meeting.id),
+      "chain",
+    );
+  }
+  for (const next of meeting.nextMeetings) {
+    addEdge(meetingNodeId(meeting.id), meetingNodeId(next.id), "chain");
+  }
+
+  for (const d of decisionItems) {
+    // 会議が決定を生んだ。
+    addEdge(meetingNodeId(meeting.id), decisionNodeId(d.id), "produces");
+    // 前提となる項目への依存。
+    if (d.blockingItemId) {
+      const blocker = rawIdToNodeId.get(d.blockingItemId);
+      if (blocker) addEdge(blocker, decisionNodeId(d.id), "blocks");
+    }
+    // 次回会議への持ち越し。
+    if (d.plannedMeeting) {
+      addEdge(
+        decisionNodeId(d.id),
+        meetingNodeId(d.plannedMeeting.id),
+        "carryover",
+      );
+    }
+  }
+
+  for (const t of tasks) {
+    // 決定由来なら決定 → タスク、それ以外は会議 → タスク。
+    if (t.decisionItemId && nodes.has(decisionNodeId(t.decisionItemId))) {
+      addEdge(decisionNodeId(t.decisionItemId), taskNodeId(t.id), "derives");
+    } else {
+      addEdge(meetingNodeId(meeting.id), taskNodeId(t.id), "produces");
+    }
+    if (t.blockingItemId) {
+      const blocker = rawIdToNodeId.get(t.blockingItemId);
+      if (blocker) addEdge(blocker, taskNodeId(t.id), "blocks");
+    }
+  }
+
+  for (const a of ambiguousInfos) {
+    // 未決事項の解決先（タスク化 / 決定化）。
+    if (a.resolvedToTaskId) {
+      addEdge(
+        ambiguousNodeId(a.id),
+        taskNodeId(a.resolvedToTaskId),
+        "resolves",
+      );
+    }
+    if (a.resolvedToDecisionItemId) {
+      addEdge(
+        ambiguousNodeId(a.id),
+        decisionNodeId(a.resolvedToDecisionItemId),
+        "resolves",
+      );
+    }
+  }
+
+  for (const tr of topicRequests) {
+    // 次回議題は当該会議に向けたものとして会議へ結ぶ。
+    addEdge(topicNodeId(tr.id), meetingNodeId(meeting.id), "agenda");
+  }
+
+  return { nodes: [...nodes.values()], edges };
+}

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -37,6 +37,7 @@ import {
   taskListInclude,
   taskListOrderBy,
 } from "../lib/task-serialization.js";
+import { buildDecisionGraph } from "../lib/decision-graph-serialization.js";
 import { auth, type AuthVariables } from "../middleware/auth.js";
 import { requireMeetingAccess } from "../middleware/meeting-access.js";
 
@@ -314,6 +315,77 @@ export const meetingsRoute = new Hono<{ Variables: AuthVariables }>()
       return c.json(infos);
     },
   )
+  .get("/:id/decision-graph", async (c) => {
+    const id = c.req.param("id");
+
+    const access = await requireMeetingAccess(c, id);
+    if (!access.ok) return access.response;
+
+    // 当該会議スコープで、来歴をたどるのに必要なノード素材を一括取得する。
+    // 会議は前回/次回のチェーン、決定・タスク・未決・次回議題は当該会議に紐付くもの。
+    const [meeting, decisionItems, tasks, ambiguousInfos, topicRequests] =
+      await Promise.all([
+        prisma.meeting.findUnique({
+          where: { id },
+          select: {
+            id: true,
+            title: true,
+            heldAt: true,
+            previousMeeting: { select: { id: true, title: true } },
+            nextMeetings: { select: { id: true, title: true } },
+          },
+        }),
+        prisma.decisionItem.findMany({
+          where: { meetingId: id },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            decisionState: true,
+            blockingItemId: true,
+            plannedMeeting: { select: { id: true, title: true } },
+          },
+        }),
+        prisma.task.findMany({
+          where: { originMeetingId: id },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            decisionItemId: true,
+            blockingItemId: true,
+          },
+        }),
+        prisma.ambiguousInfo.findMany({
+          where: { meetingId: id },
+          select: {
+            id: true,
+            body: true,
+            status: true,
+            resolvedToTaskId: true,
+            resolvedToDecisionItemId: true,
+          },
+        }),
+        prisma.topicRequest.findMany({
+          where: { meetingId: id },
+          select: { id: true, title: true, priority: true },
+        }),
+      ]);
+
+    // requireMeetingAccess 通過直後なので存在は保証されるが、型ナローイングのため再判定
+    if (!meeting) {
+      return c.json({ error: "会議が見つかりません" }, 404);
+    }
+
+    const graph = buildDecisionGraph({
+      meeting,
+      decisionItems,
+      tasks,
+      ambiguousInfos,
+      topicRequests,
+    });
+    return c.json(graph);
+  })
   // TODO: 動作確認用のため削除する
   .post(
     "/:id/review-items",

--- a/apps/api/test/decision-graph-serialization.test.ts
+++ b/apps/api/test/decision-graph-serialization.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest";
+import {
+  type BuildDecisionGraphInput,
+  buildDecisionGraph,
+} from "../src/lib/decision-graph-serialization.js";
+
+// 各テストが必要な部分だけ上書きできるよう、空の会議スコープを基底とする。
+function baseInput(
+  overrides: Partial<BuildDecisionGraphInput> = {},
+): BuildDecisionGraphInput {
+  return {
+    meeting: {
+      id: "m1",
+      title: "第3回 定例",
+      heldAt: new Date("2026-05-17T10:00:00Z"),
+      previousMeeting: null,
+      nextMeetings: [],
+      ...overrides.meeting,
+    },
+    decisionItems: overrides.decisionItems ?? [],
+    tasks: overrides.tasks ?? [],
+    ambiguousInfos: overrides.ambiguousInfos ?? [],
+    topicRequests: overrides.topicRequests ?? [],
+  };
+}
+
+describe("buildDecisionGraph", () => {
+  it("関連が無くても当該会議ノードのみを返し、エッジは空になる", () => {
+    const graph = buildDecisionGraph(baseInput());
+
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.nodes[0]).toMatchObject({
+      id: "meeting:m1",
+      type: "meeting",
+      label: "第3回 定例",
+    });
+    expect(graph.nodes[0].data).toMatchObject({ current: true });
+    expect(graph.edges).toEqual([]);
+  });
+
+  it("前回・次回会議を会議ノードと chain エッジで連ねる", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        meeting: {
+          id: "m1",
+          title: "第3回",
+          heldAt: new Date("2026-05-17T10:00:00Z"),
+          previousMeeting: { id: "m0", title: "第2回" },
+          nextMeetings: [{ id: "m2", title: "第4回" }],
+        },
+      }),
+    );
+
+    const meetingIds = graph.nodes
+      .filter((n) => n.type === "meeting")
+      .map((n) => n.id)
+      .sort();
+    expect(meetingIds).toEqual(["meeting:m0", "meeting:m1", "meeting:m2"]);
+
+    // 前回 → 今回、今回 → 次回 の 2 本
+    const chains = graph.edges.filter((e) => e.type === "chain");
+    expect(chains).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "meeting:m0", target: "meeting:m1" }),
+        expect.objectContaining({ source: "meeting:m1", target: "meeting:m2" }),
+      ]),
+    );
+    expect(chains).toHaveLength(2);
+
+    // 今回以外の会議ノードは current=false
+    const prev = graph.nodes.find((n) => n.id === "meeting:m0");
+    expect(prev?.data).toMatchObject({ current: false });
+  });
+
+  it("会議が生んだ決定・タスクを produces エッジで結ぶ", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        decisionItems: [
+          {
+            id: "d1",
+            title: "予算を承認する",
+            status: "confirmed",
+            decisionState: "confirmed",
+            blockingItemId: null,
+            plannedMeeting: null,
+          },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "資料を作成する",
+            status: "todo",
+            decisionItemId: null,
+            blockingItemId: null,
+          },
+        ],
+      }),
+    );
+
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "decision:d1", type: "decision" }),
+        expect.objectContaining({ id: "task:t1", type: "task" }),
+      ]),
+    );
+    const produces = graph.edges.filter((e) => e.type === "produces");
+    expect(produces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "meeting:m1",
+          target: "decision:d1",
+        }),
+        expect.objectContaining({ source: "meeting:m1", target: "task:t1" }),
+      ]),
+    );
+  });
+
+  it("決定由来のタスクは derives エッジで結び、会議からの produces は張らない", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        decisionItems: [
+          {
+            id: "d1",
+            title: "方針を決定",
+            status: "confirmed",
+            decisionState: "confirmed",
+            blockingItemId: null,
+            plannedMeeting: null,
+          },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "決定に基づく作業",
+            status: "todo",
+            decisionItemId: "d1",
+            blockingItemId: null,
+          },
+        ],
+      }),
+    );
+
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "decision:d1",
+          target: "task:t1",
+          type: "derives",
+        }),
+      ]),
+    );
+    // 決定由来のタスクは会議 → タスクの produces を重複して張らない
+    expect(
+      graph.edges.some((e) => e.target === "task:t1" && e.type === "produces"),
+    ).toBe(false);
+  });
+
+  it("次回会議へ持ち越された決定を carryover エッジと会議ノードで表す", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        decisionItems: [
+          {
+            id: "d1",
+            title: "次回再検討",
+            status: "open",
+            decisionState: "open",
+            blockingItemId: null,
+            plannedMeeting: { id: "m2", title: "第4回" },
+          },
+        ],
+      }),
+    );
+
+    // planned 先の会議がノードとして追加される
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "meeting:m2", type: "meeting" }),
+      ]),
+    );
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "decision:d1",
+          target: "meeting:m2",
+          type: "carryover",
+        }),
+      ]),
+    );
+  });
+
+  it("blockingItemId が集合内なら blocks エッジを張り、集合外なら張らない", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        decisionItems: [
+          {
+            id: "d1",
+            title: "前提となる決定",
+            status: "confirmed",
+            decisionState: "confirmed",
+            blockingItemId: null,
+            plannedMeeting: null,
+          },
+          {
+            id: "d2",
+            title: "d1 に依存する決定",
+            status: "open",
+            decisionState: "open",
+            blockingItemId: "d1",
+            plannedMeeting: null,
+          },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "外部依存タスク",
+            status: "todo",
+            decisionItemId: null,
+            blockingItemId: "unknown-id",
+          },
+        ],
+      }),
+    );
+
+    const blocks = graph.edges.filter((e) => e.type === "blocks");
+    expect(blocks).toEqual([
+      expect.objectContaining({ source: "decision:d1", target: "decision:d2" }),
+    ]);
+  });
+
+  it("未決事項の解決先を resolves エッジで結ぶ", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        decisionItems: [
+          {
+            id: "d1",
+            title: "解決先の決定",
+            status: "confirmed",
+            decisionState: "confirmed",
+            blockingItemId: null,
+            plannedMeeting: null,
+          },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "解決先のタスク",
+            status: "todo",
+            decisionItemId: null,
+            blockingItemId: null,
+          },
+        ],
+        ambiguousInfos: [
+          {
+            id: "a1",
+            body: "担当者が未定",
+            status: "resolved",
+            resolvedToTaskId: "t1",
+            resolvedToDecisionItemId: null,
+          },
+          {
+            id: "a2",
+            body: "判断保留",
+            status: "resolved",
+            resolvedToTaskId: null,
+            resolvedToDecisionItemId: "d1",
+          },
+        ],
+      }),
+    );
+
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "ambiguous:a1",
+          type: "ambiguous",
+          label: "担当者が未定",
+        }),
+      ]),
+    );
+    const resolves = graph.edges.filter((e) => e.type === "resolves");
+    expect(resolves).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "ambiguous:a1", target: "task:t1" }),
+        expect.objectContaining({
+          source: "ambiguous:a2",
+          target: "decision:d1",
+        }),
+      ]),
+    );
+  });
+
+  it("次回議題を topic ノードと agenda エッジで当該会議に結ぶ", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        topicRequests: [{ id: "tr1", title: "次回の論点", priority: "high" }],
+      }),
+    );
+
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "topic:tr1",
+          type: "topic",
+          label: "次回の論点",
+        }),
+      ]),
+    );
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "topic:tr1",
+          target: "meeting:m1",
+          type: "agenda",
+        }),
+      ]),
+    );
+  });
+
+  it("全ノード ID が一意であり、全エッジの端点がノード集合に含まれる", () => {
+    const graph = buildDecisionGraph(
+      baseInput({
+        meeting: {
+          id: "m1",
+          title: "第3回",
+          heldAt: new Date("2026-05-17T10:00:00Z"),
+          previousMeeting: { id: "m0", title: "第2回" },
+          nextMeetings: [{ id: "m2", title: "第4回" }],
+        },
+        decisionItems: [
+          {
+            id: "d1",
+            title: "決定",
+            status: "confirmed",
+            decisionState: "confirmed",
+            blockingItemId: null,
+            plannedMeeting: { id: "m2", title: "第4回" },
+          },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "タスク",
+            status: "todo",
+            decisionItemId: "d1",
+            blockingItemId: null,
+          },
+        ],
+        topicRequests: [{ id: "tr1", title: "議題", priority: null }],
+      }),
+    );
+
+    const ids = graph.nodes.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const idSet = new Set(ids);
+    for (const edge of graph.edges) {
+      expect(idSet.has(edge.source)).toBe(true);
+      expect(idSet.has(edge.target)).toBe(true);
+    }
+
+    // エッジ ID も一意
+    const edgeIds = graph.edges.map((e) => e.id);
+    expect(new Set(edgeIds).size).toBe(edgeIds.length);
+  });
+});

--- a/apps/api/test/meetings.test.ts
+++ b/apps/api/test/meetings.test.ts
@@ -19,6 +19,9 @@ vi.mock("../src/lib/prisma.js", () => ({
     ambiguousInfo: {
       findMany: vi.fn(),
     },
+    topicRequest: {
+      findMany: vi.fn(),
+    },
     meetingAnalysisRun: {
       findFirst: vi.fn(),
       findMany: vi.fn(),
@@ -104,6 +107,47 @@ type TaskWithReview = Prisma.TaskGetPayload<{
 type AmbiguousInfoWithReview = Prisma.AmbiguousInfoGetPayload<{
   include: typeof ambiguousInfoReviewInclude;
 }>;
+// GET /meetings/:id/decision-graph ハンドラ用: グラフ構築に必要な select 形
+type MeetingForGraph = Prisma.MeetingGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    heldAt: true;
+    previousMeeting: { select: { id: true; title: true } };
+    nextMeetings: { select: { id: true; title: true } };
+  };
+}>;
+type DecisionItemForGraph = Prisma.DecisionItemGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    status: true;
+    decisionState: true;
+    blockingItemId: true;
+    plannedMeeting: { select: { id: true; title: true } };
+  };
+}>;
+type TaskForGraph = Prisma.TaskGetPayload<{
+  select: {
+    id: true;
+    title: true;
+    status: true;
+    decisionItemId: true;
+    blockingItemId: true;
+  };
+}>;
+type AmbiguousInfoForGraph = Prisma.AmbiguousInfoGetPayload<{
+  select: {
+    id: true;
+    body: true;
+    status: true;
+    resolvedToTaskId: true;
+    resolvedToDecisionItemId: true;
+  };
+}>;
+type TopicRequestForGraph = Prisma.TopicRequestGetPayload<{
+  select: { id: true; title: true; priority: true };
+}>;
 
 const mockFindUnique = vi.mocked(prisma.meeting.findUnique);
 const mockMeetingUpdate = vi.mocked(prisma.meeting.update);
@@ -118,6 +162,7 @@ const mockAnalysisRunFindFirst = vi.mocked(prisma.meetingAnalysisRun.findFirst);
 const mockAnalysisRunFindMany = vi.mocked(prisma.meetingAnalysisRun.findMany);
 const mockDecisionItemFindMany = vi.mocked(prisma.decisionItem.findMany);
 const mockAmbiguousInfoFindMany = vi.mocked(prisma.ambiguousInfo.findMany);
+const mockTopicRequestFindMany = vi.mocked(prisma.topicRequest.findMany);
 
 describe("旧 GET / と POST /meetings は撤去済み", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -1209,6 +1254,146 @@ describe("GET /meetings/:id/review-items", () => {
     mockFindUnique.mockResolvedValue(meetingBase);
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/meetings/mtg-1/review-items");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /meetings/:id/decision-graph", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // 認可チェック（requireMeetingAccess）が参照する最小形の会議。
+  const accessMeeting = {
+    id: "mtg-1",
+    recurringMeetingId: "rmtg-1",
+    recurringMeeting: { organizationId: "org-1" },
+  } as MeetingWithRecurringOrgId;
+
+  const membership = {
+    userId: "user-1",
+    organizationId: "org-1",
+    role: "member" as const,
+    joinedAt: new Date("2026-05-01T00:00:00Z"),
+  };
+
+  it("組織メンバーは会議の意思決定グラフを 200 で取得できる", async () => {
+    // findUnique は認可（access 形）→ グラフ用（select 形）の順で 2 回呼ばれる。
+    mockFindUnique.mockResolvedValueOnce(accessMeeting).mockResolvedValueOnce({
+      id: "mtg-1",
+      title: "第3回",
+      heldAt: new Date("2026-05-17T10:00:00Z"),
+      previousMeeting: { id: "mtg-0", title: "第2回" },
+      nextMeetings: [{ id: "mtg-2", title: "第4回" }],
+    } as MeetingForGraph);
+    mockMembershipFindUnique.mockResolvedValue(membership);
+    mockDecisionItemFindMany.mockResolvedValue([
+      {
+        id: "dec-1",
+        title: "予算承認",
+        status: "decided",
+        decisionState: "confirmed",
+        blockingItemId: null,
+        plannedMeeting: null,
+      },
+    ] as DecisionItemForGraph[]);
+    mockTaskFindMany.mockResolvedValue([
+      {
+        id: "task-1",
+        title: "資料作成",
+        status: "todo",
+        decisionItemId: "dec-1",
+        blockingItemId: null,
+      },
+    ] as TaskForGraph[]);
+    mockAmbiguousInfoFindMany.mockResolvedValue([] as AmbiguousInfoForGraph[]);
+    mockTopicRequestFindMany.mockResolvedValue([
+      { id: "tr-1", title: "次回論点", priority: "required" },
+    ] as TopicRequestForGraph[]);
+
+    const res = await app.request("/meetings/mtg-1/decision-graph");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      nodes: Array<{ id: string; type: string }>;
+      edges: Array<{ source: string; target: string; type: string }>;
+    };
+
+    const nodeIds = body.nodes.map((n) => n.id);
+    expect(nodeIds).toEqual(
+      expect.arrayContaining([
+        "meeting:mtg-1",
+        "meeting:mtg-0",
+        "meeting:mtg-2",
+        "decision:dec-1",
+        "task:task-1",
+        "topic:tr-1",
+      ]),
+    );
+    // 決定由来のタスクは derives、次回議題は agenda エッジで結ばれる。
+    expect(body.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "decision:dec-1",
+          target: "task:task-1",
+          type: "derives",
+        }),
+        expect.objectContaining({
+          source: "topic:tr-1",
+          target: "meeting:mtg-1",
+          type: "agenda",
+        }),
+      ]),
+    );
+    // タスクは当該会議を発生源とするものに限定して取得する。
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ originMeetingId: "mtg-1" }),
+      }),
+    );
+  });
+
+  it("関連が無くても会議ノードのみのグラフを 200 で返す", async () => {
+    mockFindUnique.mockResolvedValueOnce(accessMeeting).mockResolvedValueOnce({
+      id: "mtg-1",
+      title: "第1回",
+      heldAt: new Date("2026-05-17T10:00:00Z"),
+      previousMeeting: null,
+      nextMeetings: [],
+    } as MeetingForGraph);
+    mockMembershipFindUnique.mockResolvedValue(membership);
+    mockDecisionItemFindMany.mockResolvedValue([] as DecisionItemForGraph[]);
+    mockTaskFindMany.mockResolvedValue([] as TaskForGraph[]);
+    mockAmbiguousInfoFindMany.mockResolvedValue([] as AmbiguousInfoForGraph[]);
+    mockTopicRequestFindMany.mockResolvedValue([] as TopicRequestForGraph[]);
+
+    const res = await app.request("/meetings/mtg-1/decision-graph");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nodes: unknown[]; edges: unknown[] };
+    expect(body.nodes).toHaveLength(1);
+    expect(body.edges).toEqual([]);
+  });
+
+  it("会議不存在は 404", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/missing/decision-graph");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+
+  it("単発会議（recurringMeetingId=null）は 404", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "mtg-x",
+      recurringMeetingId: null,
+      recurringMeeting: null,
+    } as MeetingWithRecurringOrgId);
+    const res = await app.request("/meetings/mtg-x/decision-graph");
+    expect(res.status).toBe(404);
+    expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
+  });
+
+  it("組織非所属は 404", async () => {
+    mockFindUnique.mockResolvedValue(accessMeeting);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const res = await app.request("/meetings/mtg-1/decision-graph");
     expect(res.status).toBe(404);
     expect(mockDecisionItemFindMany).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## 関連Issue
#350（バックエンド分。フロントエンドの React Flow 表示は別 PR で対応するため `Closes` は付けない）

## 概要・目的
* 会議単位で「決定 → タスク → 次回議題」といった意思決定の来歴をたどれる読み取り専用 API `GET /meetings/:id/decision-graph` を追加した。前回・今回・次回の意思決定の流れを 1 つのグラフ構造で取得できるようにし、後続のフロントエンド可視化（React Flow）の土台とする。

## 背景
* 本プロダクトの核は「前回→今回→次回の意思決定・タスク・未決事項の流れを切らさない」こと。既存スキーマには会議チェーン（`Meeting.previousMeetingId`）や決定→タスクの派生（`Task.decisionItemId`）など来歴を表すリレーションが揃っているが、これらを横断してグラフとして取り出す経路が無かった。Issue #350 ではまず会議スコープの API を先行させ、可視化は別 PR に分割する方針とした。

## 変更内容
* グラフ構築ロジックを純粋関数 `buildDecisionGraph` として `apps/api/src/lib/decision-graph-serialization.ts` に切り出した。会議・決定事項・タスク・未決事項・次回議題を「ノード」、来歴を「エッジ」に変換する。
  * ノード種別: `meeting` / `decision` / `task` / `ambiguous` / `topic`。ノード ID は `decision:xxx` のように種別プレフィックスを付け、テーブル間の ID 衝突を防ぐ。
  * エッジ種別: `chain`(会議の連なり) / `produces`(会議→決定・タスク) / `derives`(決定→派生タスク) / `carryover`(決定→次回会議への持ち越し) / `blocks`(依存) / `resolves`(未決→解決先) / `agenda`(次回議題→会議)。
  * 端点が会議スコープ外を指すエッジ（別会議を指す `blockingItemId` など）は張らず、グラフの整合性を保つ。決定由来のタスクは `derives` を優先し、会議からの `produces` を重複させない。
* `GET /meetings/:id/decision-graph` を `apps/api/src/routes/meetings.ts` に追加。既存の `requireMeetingAccess` で認可（単発会議・組織非所属は 404）したうえで、`Promise.all` で各リレーションを一括取得し純粋関数へ渡す。レスポンス形は後続のフロントエンドがそのまま扱えるよう `{ nodes, edges }` に揃えた。
* テストを追加。純粋関数側は各エッジ種別・空状態・ID 一意性を網羅（9 件）、ルート側は 200（グラフ構造・`originMeetingId` スコープ）・関連ゼロ時の会議ノードのみ・404 三種（不存在/単発/非所属）を検証（5 件）。

## 動作確認手順
1. ブランチを checkout: `git checkout issue-350-decision-context-graph-api`
2. テストを実行: `make test`（Vitest + pytest。本 PR 該当分は `apps/api` の `decision-graph-serialization.test.ts` と `meetings.test.ts`）
3. 必要に応じてローカル起動して確認: `make dev` 後、組織メンバーの会議 ID に対し `GET /api/meetings/<会議ID>/decision-graph` を認証付きで叩き、`nodes` / `edges` が返ることを確認

## スクリーンショット
* API のためレスポンス例を記載（決定由来タスク 1 件・次回議題 1 件を含む会議の例）:

\`\`\`json
{
  "nodes": [
    { "id": "meeting:mtg-1", "type": "meeting", "label": "第3回 定例", "data": { "current": true, "heldAt": "2026-05-17T10:00:00.000Z" } },
    { "id": "decision:dec-1", "type": "decision", "label": "予算承認", "data": { "status": "decided", "decisionState": "confirmed" } },
    { "id": "task:task-1", "type": "task", "label": "資料作成", "data": { "status": "todo" } },
    { "id": "topic:tr-1", "type": "topic", "label": "次回論点", "data": { "priority": "required" } }
  ],
  "edges": [
    { "id": "produces:meeting:mtg-1->decision:dec-1", "source": "meeting:mtg-1", "target": "decision:dec-1", "type": "produces" },
    { "id": "derives:decision:dec-1->task:task-1", "source": "decision:dec-1", "target": "task:task-1", "type": "derives" },
    { "id": "agenda:topic:tr-1->meeting:mtg-1", "source": "topic:tr-1", "target": "meeting:mtg-1", "type": "agenda" }
  ]
}
\`\`\`