### PR TITLE
意思決定グラフのデモシードを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,6 @@ migrate-status: ## マイグレーションの適用状況を確認する
 db-shell: ## psql で decision_loop DB に直接接続する
 	@if [ -f apps/api/.env ]; then set -a; . apps/api/.env; set +a; fi; \
 	  psql "$${DATABASE_URL}"
+
+seed-demo: ## 意思決定グラフ用のデモデータを投入する（Issue #350・冪等）
+	@if [ -f apps/api/.env ]; then set -a; . apps/api/.env; set +a; fi; pnpm --filter api seed:demo

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ make install                # 依存関係のインストール（pnpm install +
 make fake-auth-keys         # fake-authのRSA鍵ペアを生成（初回のみ）
 make dev                    # 全サービスを Docker Compose で起動
 make migrate                # DB マイグレーションを適用（初回起動時）
+make seed-demo              # 意思決定グラフ用のデモデータを投入（任意・何度でも可）
 ```
 
 > アプリサービスをネイティブ起動したい場合は `docker-compose.yml` の web / api / ai をコメントアウトして `make dev-native` を使用してください（overmind が必要）。

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,8 @@
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "seed:demo": "tsx prisma/seed-decision-graph.ts"
   },
   "dependencies": {
     "@azure/service-bus": "^7.9.5",

--- a/apps/api/prisma/seed-decision-graph.ts
+++ b/apps/api/prisma/seed-decision-graph.ts
@@ -1,0 +1,246 @@
+// 意思決定の文脈グラフ（Issue #350）を映えさせるためのデモシード。
+//
+// 1 定例「デモ定例」に 前回 → 今回 → 次回 の 3 会議をチェーンで作り、今回会議に
+// 決定・タスク・未決・次回議題を、グラフの全エッジ種別が出るように張る。
+//
+// すべて固定 ID で upsert するため冪等（何度実行しても重複しない）。
+// 既存ユーザー全員をデモ組織のメンバーに追加するので、ログイン中のユーザーで
+// すぐにグラフを閲覧できる。`make dev-reset` で DB を空にした後でも単独で動く。
+
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/decision_loop";
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString }),
+});
+
+// 固定 ID（冪等のため）。
+const ORG_ID = "demo-decision-graph-org";
+const RM_ID = "demo-decision-graph-rm";
+const M_PREV = "demo-dg-meeting-prev";
+const M_CUR = "demo-dg-meeting-cur";
+const M_NEXT = "demo-dg-meeting-next";
+const D1 = "demo-dg-decision-1"; // 決定済み
+const D2 = "demo-dg-decision-2"; // 未決 → 次回へ持ち越し
+const D3 = "demo-dg-decision-3"; // D1 に依存
+const T1 = "demo-dg-task-1"; // D1 から派生
+const T2 = "demo-dg-task-2"; // 会議から直接発生
+const T3 = "demo-dg-task-3"; // T2 に依存
+const A1 = "demo-dg-ambiguous-1"; // → T1 で解決
+const A2 = "demo-dg-ambiguous-2"; // → D1 で解決
+const TR1 = "demo-dg-topic-1"; // 次回議題
+
+async function main() {
+  // 1. デモ組織
+  await prisma.organization.upsert({
+    where: { id: ORG_ID },
+    update: { name: "デモ組織（意思決定グラフ）" },
+    create: { id: ORG_ID, name: "デモ組織（意思決定グラフ）" },
+  });
+
+  // 2. 既存ユーザー全員をデモ組織のメンバーにする（ログイン中のユーザーで閲覧可能にする）
+  const users = await prisma.user.findMany({ select: { id: true } });
+  if (users.length === 0) {
+    console.warn(
+      "[seed] ユーザーが 0 件です。先に一度ログインしてユーザーを作成してから再実行してください。",
+    );
+  }
+  for (const u of users) {
+    await prisma.organizationMembership.upsert({
+      where: {
+        userId_organizationId: { userId: u.id, organizationId: ORG_ID },
+      },
+      update: {},
+      create: { userId: u.id, organizationId: ORG_ID, role: "member" },
+    });
+  }
+
+  // 3. デモ定例
+  await prisma.recurringMeeting.upsert({
+    where: { id: RM_ID },
+    update: {},
+    create: {
+      id: RM_ID,
+      organizationId: ORG_ID,
+      name: "デモ定例",
+      scheduleCron: "0 10 * * 1", // 毎週月曜 10:00
+    },
+  });
+
+  // 4. 会議チェーン（前回 → 今回 → 次回）
+  await prisma.meeting.upsert({
+    where: { id: M_PREV },
+    update: {},
+    create: {
+      id: M_PREV,
+      title: "デモ: 前回会議（5/22）",
+      heldAt: new Date("2026-05-22T01:00:00Z"),
+      recurringMeetingId: RM_ID,
+      meetingType: "recurring",
+      sequenceNumber: 1,
+    },
+  });
+  await prisma.meeting.upsert({
+    where: { id: M_CUR },
+    update: { previousMeetingId: M_PREV },
+    create: {
+      id: M_CUR,
+      title: "デモ: 今回会議（5/29）",
+      heldAt: new Date("2026-05-29T01:00:00Z"),
+      recurringMeetingId: RM_ID,
+      meetingType: "recurring",
+      sequenceNumber: 2,
+      previousMeetingId: M_PREV,
+    },
+  });
+  await prisma.meeting.upsert({
+    where: { id: M_NEXT },
+    update: { previousMeetingId: M_CUR },
+    create: {
+      id: M_NEXT,
+      title: "デモ: 次回会議（6/5）",
+      heldAt: new Date("2026-06-05T01:00:00Z"),
+      recurringMeetingId: RM_ID,
+      meetingType: "recurring",
+      sequenceNumber: 3,
+      previousMeetingId: M_CUR,
+    },
+  });
+
+  // 5. 決定事項（今回会議）
+  await prisma.decisionItem.upsert({
+    where: { id: D1 },
+    update: {},
+    create: {
+      id: D1,
+      meetingId: M_CUR,
+      title: "新ロゴ案 B を採用する",
+      status: "decided",
+      decisionState: "confirmed",
+      decidedAt: new Date("2026-05-29T02:00:00Z"),
+    },
+  });
+  // D2: 未決 → 次回会議へ持ち越し（carryover）
+  await prisma.decisionItem.upsert({
+    where: { id: D2 },
+    update: { plannedMeetingId: M_NEXT },
+    create: {
+      id: D2,
+      meetingId: M_CUR,
+      title: "広報予算の上限を最終決定する",
+      status: "open",
+      decisionState: "open",
+      reason: "information_lack",
+      plannedMeetingId: M_NEXT,
+    },
+  });
+  // D3: D1 に依存（blocks）
+  await prisma.decisionItem.upsert({
+    where: { id: D3 },
+    update: { blockingItemId: D1 },
+    create: {
+      id: D3,
+      meetingId: M_CUR,
+      title: "ブランドガイドラインを更新する",
+      status: "open",
+      decisionState: "tentative",
+      blockingItemId: D1,
+    },
+  });
+
+  // 6. タスク
+  // T1: D1 から派生（derives）
+  await prisma.task.upsert({
+    where: { id: T1 },
+    update: {},
+    create: {
+      id: T1,
+      organizationId: ORG_ID,
+      originMeetingId: M_CUR,
+      decisionItemId: D1,
+      title: "全媒体のロゴ差し替え",
+      status: "todo",
+    },
+  });
+  // T2: 会議から直接発生（produces）
+  await prisma.task.upsert({
+    where: { id: T2 },
+    update: {},
+    create: {
+      id: T2,
+      organizationId: ORG_ID,
+      originMeetingId: M_CUR,
+      title: "関係部署へ周知",
+      status: "in_progress",
+    },
+  });
+  // T3: T2 に依存（blocks）
+  await prisma.task.upsert({
+    where: { id: T3 },
+    update: { blockingItemId: T2 },
+    create: {
+      id: T3,
+      organizationId: ORG_ID,
+      originMeetingId: M_CUR,
+      title: "公式サイトへ反映",
+      status: "todo",
+      blockingItemId: T2,
+    },
+  });
+
+  // 7. 未決事項
+  // A1: タスク T1 で解決（resolves）
+  await prisma.ambiguousInfo.upsert({
+    where: { id: A1 },
+    update: {},
+    create: {
+      id: A1,
+      meetingId: M_CUR,
+      body: "ロゴ反映の担当者が未確定",
+      status: "resolved",
+      resolutionType: "task",
+      resolvedToTaskId: T1,
+    },
+  });
+  // A2: 決定 D1 で解決（resolves）
+  await prisma.ambiguousInfo.upsert({
+    where: { id: A2 },
+    update: {},
+    create: {
+      id: A2,
+      meetingId: M_CUR,
+      body: "どのロゴ案にするか曖昧だった",
+      status: "resolved",
+      resolutionType: "decision_item",
+      resolvedToDecisionItemId: D1,
+    },
+  });
+
+  // 8. 次回議題（agenda）。requestedBy は必須なので先頭ユーザーを使う。
+  if (users.length > 0) {
+    await prisma.topicRequest.upsert({
+      where: { id: TR1 },
+      update: {},
+      create: {
+        id: TR1,
+        meetingId: M_CUR,
+        requestedBy: users[0].id,
+        title: "次回までに競合ロゴを調査して共有する",
+        priority: "required",
+      },
+    });
+  }
+
+  console.log("[seed] デモ意思決定グラフを投入しました。");
+  console.log(`[seed] 今回会議の URL: /meetings/${M_CUR}/decision-graph`);
+}
+
+main()
+  .catch((e) => {
+    console.error("[seed] 失敗しました:", e);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## 関連Issue
#350（デモシード。Issue #354 の「デモ用シード必達」にも対応）

## 概要・目的
* 意思決定の文脈グラフ（#358 / #361）を実際に映えさせるためのデモデータを投入するシードを追加した。決定・タスク・未決がすべて 0 件だと会議ノードしか出ないため、来歴のつながりが見える状態を作る。
* `make seed-demo` 一発で投入でき、何度実行してもデータが重複しない（冪等）。

## 背景
* Issue #350 に「シードデータがあると映える（リレーションが薄いと見栄えしない）」とあり、デモ用シードは別途必達事項（umbrella #354）とされていた。グラフ機能（#358/#361）単体ではデータが無く、デモで価値が伝わらない。

## 変更内容
* `apps/api/prisma/seed-decision-graph.ts` を追加。1 定例「デモ定例」に **前回 → 今回 → 次回** の 3 会議をチェーンで作り、今回会議に以下を全エッジ種別が出るよう投入:
  * 決定 3 件（決定済み / 次回へ持ち越し / 依存）
  * タスク 3 件（決定由来の派生 / 会議直 / 依存）
  * 未決 2 件（タスクで解決 / 決定で解決）
  * 次回議題 1 件
* 全データを**固定 ID で upsert**するため冪等。**既存ユーザー全員をデモ組織のメンバーに追加**し、ログイン中のユーザーですぐ閲覧できる。`make dev-reset` で DB を空にした後でも単独で動く。
* 実行口を整備: `apps/api/package.json` に `seed:demo`、`Makefile` に `seed-demo` ターゲット、`README.md` に手順を追記。

## 動作確認手順
1. ブランチを checkout: `git checkout feature/decision-graph-demo-seed`
2. DB を起動した状態で投入: `make seed-demo`
3. 投入後、グラフ機能（#358 + #361）のあるブランチで `make dev` を起動し、ログイン後に `/meetings/demo-dg-meeting-cur/decision-graph` を開く → 会議の連なり・決定・タスク・未決・次回議題が全種類の線でつながって表示される
4. 冪等性: `make seed-demo` を再実行しても件数が増えないことを確認

## スクリーンショット
* 投入後に DB で確認した各エッジ種別の素材数（今回会議を起点）:

```
 chain | produces_decision | produces_task | derives | carryover | blocks | resolves | agenda
-------+-------------------+---------------+---------+-----------+--------+----------+--------
     2 |                 3 |             2 |       1 |         1 |      2 |        2 |      1
```
* すべて 1 件以上＝グラフ上で全 7 種類のエッジが描画される。