### PR TITLE
  fix: POST /meetings/:id/analyze の Service Bus 経路を疎通させる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       # service 名で解決する。token の iss クレーム（fake-auth 側 ISSUER）と
       # 完全一致している必要があるため、両者を同一値で揃える。
       OIDC_ISSUER_URL: "http://fake-auth:3007"
+      # ai サービスと同じ値。servicebus は Docker ネットワーク上のサービス名
+      AZURE_SERVICE_BUS_CONNECTION_STRING: "Endpoint=sb://servicebus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
+      AZURE_SERVICE_BUS_QUEUE_NAME: "decision-loop"
     env_file:
       - path: .env.local
         required: false
@@ -94,6 +97,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      servicebus:
+        condition: service_started
 
   ai:
     build:

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -47,6 +47,10 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
     # 取り出し失敗で Consumer が落ちないよう、パース段階で完結させる
     try:
         body = json.loads(_parse_message_body(message).decode("utf-8"))
+        # Node.js SDK が JSON.stringify() した文字列を AMQP がさらにラップするため
+        # json.loads() を 1 回すると文字列が返ってくる場合がある（二重エンコード）
+        if isinstance(body, str):
+            body = json.loads(body)
     except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as error:
         logger.error("メッセージのデコードに失敗 (破棄): %s", error)
         return
@@ -92,8 +96,29 @@ async def _handle_message(message: ServiceBusReceivedMessage) -> None:
         )
 
 
+async def _run_consumer_with_retry(connection_string: str, queue_name: str) -> None:
+    """接続失敗時に指数バックオフでリトライするコンシューマーラッパー"""
+    delay = 5
+    max_delay = 60
+    while True:
+        try:
+            consumer = ServiceBusConsumer(connection_string, queue_name)
+            await consumer.start(_handle_message)
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Service Bus コンシューマーが失敗しました、%d 秒後にリトライします: %s",
+                delay,
+                exc,
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
+
+
 def _on_consumer_done(task: asyncio.Task) -> None:
-    # cancel 以外で終了した場合はエラーをログに残す
+    # cancel 以外で終了した場合はエラーをログに残す（リトライ外のバグ検知用）
     if not task.cancelled() and (exc := task.exception()):
         logger.error("Service Bus コンシューマーが予期せず終了しました: %s", exc)
 
@@ -124,8 +149,9 @@ async def lifespan(app: FastAPI):
         connection_string = os.getenv("AZURE_SERVICE_BUS_CONNECTION_STRING")
         if connection_string:
             queue_name = os.getenv("AZURE_SERVICE_BUS_QUEUE_NAME", _DEFAULT_QUEUE_NAME)
-            consumer = ServiceBusConsumer(connection_string, queue_name)
-            task = asyncio.create_task(consumer.start(_handle_message))
+            task = asyncio.create_task(
+                _run_consumer_with_retry(connection_string, queue_name)
+            )
             task.add_done_callback(_on_consumer_done)
         else:
             logger.warning(

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -93,14 +93,26 @@ async def test_lifespan_cancels_task_on_shutdown():
 
 
 async def test_lifespan_logs_error_on_consumer_failure(caplog):
-    """コンシューマーが予期せず例外で終了した場合に ERROR をログに残す"""
+    """コンシューマーが接続失敗した際に WARNING ログを出し、asyncio.sleep でリトライを待つ"""
     import main
 
+    call_count = 0
+
     async def fake_start(handler):
-        raise RuntimeError("接続失敗")
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("接続失敗")
+        # 2 回目以降はキャンセルされるまでブロック
+        await asyncio.Event().wait()
 
     mock_consumer = MagicMock()
     mock_consumer.start = fake_start
+
+    sleep_called = asyncio.Event()
+
+    async def fast_sleep(delay):
+        sleep_called.set()
 
     env = {
         _SB_CONN_KEY: "fake://conn",
@@ -111,14 +123,14 @@ async def test_lifespan_logs_error_on_consumer_failure(caplog):
     }
     with patch.dict(os.environ, env):
         with patch("main.ServiceBusConsumer", return_value=mock_consumer):
-            with caplog.at_level(logging.ERROR, logger="main"):
-                async with main.lifespan(main.app):
-                    await asyncio.sleep(0)  # タスクを実行させる
-                    # done callback は call_soon で遅延するため 2 ティック必要
-                    await asyncio.sleep(0)
+            with patch("main.asyncio.sleep", new=fast_sleep):
+                with caplog.at_level(logging.WARNING, logger="main"):
+                    async with main.lifespan(main.app):
+                        await asyncio.wait_for(sleep_called.wait(), timeout=1.0)
 
+    assert sleep_called.is_set()
     assert any(
-        r.levelno == logging.ERROR and "予期せず終了" in r.message
+        r.levelno == logging.WARNING and "リトライ" in r.message
         for r in caplog.records
     )
 

--- a/services/ai/tests/test_main_lifespan.py
+++ b/services/ai/tests/test_main_lifespan.py
@@ -93,7 +93,7 @@ async def test_lifespan_cancels_task_on_shutdown():
 
 
 async def test_lifespan_logs_error_on_consumer_failure(caplog):
-    """コンシューマーが接続失敗した際に WARNING ログを出し、asyncio.sleep でリトライを待つ"""
+    """接続失敗時に WARNING ログを出し asyncio.sleep でリトライすることを確認する"""
     import main
 
     call_count = 0


### PR DESCRIPTION
## 関連Issue
  Closes #365

  ## 概要・目的
  `POST /meetings/:id/analyze` を叩くと api サービスに Service Bus 接続文字列が未設定のため常に 500 が返る問題と、ai
  サービスの consumer が起動失敗後にリトライなしで停止したままになる問題を修正する。
  あわせて Node.js SDK の二重エンコード（`JSON.stringify` + AMQP ラップ）により Python
  側のメッセージパースが型エラーで落ちる問題（#362 取り込み）も解消する。

  ## 背景
  * `docker-compose.yml` の `api` サービスに `AZURE_SERVICE_BUS_CONNECTION_STRING` が未設定のため、`POST
  /meetings/:id/analyze` が Service Bus へのエンキューに失敗して 500 を返していた
  * `ai` サービスの Service Bus consumer は起動タイミングによって AMQP
  接続に失敗しても以後リトライせず停止したままになる。`restart: on-failure` はコンテナレベルのため、lifespan
  がエラーを捕捉すると効かない
  * Node.js の Service Bus SDK が `JSON.stringify()` した文字列を AMQP がさらにラップして送信するため、Python 側で
  `json.loads()` を 1 回すると文字列が返り `AnalysisJobInput(**body)` で型エラーになる（#362 より取り込み）

  ## 変更内容
  * `docker-compose.yml` — `api` サービスの `environment` に `AZURE_SERVICE_BUS_CONNECTION_STRING` /
  `AZURE_SERVICE_BUS_QUEUE_NAME` を追加し、`depends_on` に `servicebus: condition: service_started` を追加する
  * `services/ai/main.py` — `_handle_message` で `json.loads()` の結果が文字列の場合にもう 1
  回デコードする（二重エンコード対応）
  * `services/ai/main.py` — `_run_consumer_with_retry()` を追加し、consumer 接続失敗時に指数バックオフ（初期 5 秒・上限
  60 秒）でリトライする。`lifespan` の task 生成をこの関数に切り替える
  * `services/ai/tests/test_main_lifespan.py` — `test_lifespan_logs_error_on_consumer_failure` をリトライ挙動（WARNING
  ログ + `asyncio.sleep` 呼び出し）に合わせて更新する

  ## 動作確認手順
  1. `docker compose up --build` でコンテナを起動する
  2. `POST http://localhost:3007/login` でトークンを取得し、`POST http://localhost:3001/meetings/:id/analyze` を叩く
  3. api コンテナのログに 500 エラーが出ず、ai コンテナのログに `解析完了 analysis_run_id=...` が出ることを確認する