### PR TITLE
feat: 未達・未読・期限超過のリマインド集約をダッシュボードに追加 (#351)

### DIFF
--- a/apps/api/src/lib/read-log.ts
+++ b/apps/api/src/lib/read-log.ts
@@ -1,0 +1,24 @@
+// ユーザーによるリソース既読履歴（ReadLog）の操作ヘルパー。
+// 未読リマインド（Issue #351）でタスクの既読化・未読判定に利用する。
+
+import { prisma } from "./prisma.js";
+
+// ReadLog.resourceType に格納するタスクの識別子。
+// 他リソース（decision_item / ambiguous_info）と区別するための固定値。
+export const READ_LOG_RESOURCE_TASK = "task";
+
+// タスクを既読として ReadLog に追記する。
+// ReadLog は追記専用の不変ログのため、同一タスクを複数回既読化しても
+// 既存行を上書きせず行を追加する（未読判定は最新 readAt で行う）。
+export async function markTaskRead(
+  userId: string,
+  taskId: string,
+): Promise<void> {
+  await prisma.readLog.create({
+    data: {
+      userId,
+      resourceType: READ_LOG_RESOURCE_TASK,
+      resourceId: taskId,
+    },
+  });
+}

--- a/apps/api/src/lib/read-log.ts
+++ b/apps/api/src/lib/read-log.ts
@@ -22,3 +22,39 @@ export async function markTaskRead(
     },
   });
 }
+
+// 指定ユーザーについて、与えたタスク群の未読判定を行い taskId -> unread の Map を返す。
+// 未読 = ReadLog 未記録、または 最新 readAt < task.updatedAt（更新後にまだ見ていない）。
+// ReadLog を taskId 群で 1 クエリ取得し、メモリ上で集計して N+1 を避ける。
+export async function buildTaskUnreadMap(
+  userId: string,
+  tasks: ReadonlyArray<{ id: string; updatedAt: Date }>,
+): Promise<Map<string, boolean>> {
+  const unreadMap = new Map<string, boolean>();
+  if (tasks.length === 0) return unreadMap;
+
+  const taskIds = tasks.map((t) => t.id);
+  const logs = await prisma.readLog.findMany({
+    where: {
+      userId,
+      resourceType: READ_LOG_RESOURCE_TASK,
+      resourceId: { in: taskIds },
+    },
+    select: { resourceId: true, readAt: true },
+  });
+
+  // resourceId ごとに最新の readAt を求める（追記専用ログのため複数行あり得る）。
+  const latestReadAt = new Map<string, Date>();
+  for (const log of logs) {
+    const prev = latestReadAt.get(log.resourceId);
+    if (!prev || log.readAt > prev) {
+      latestReadAt.set(log.resourceId, log.readAt);
+    }
+  }
+
+  for (const task of tasks) {
+    const readAt = latestReadAt.get(task.id);
+    unreadMap.set(task.id, !readAt || readAt < task.updatedAt);
+  }
+  return unreadMap;
+}

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
-import { markTaskRead } from "../lib/read-log.js";
+import { buildTaskUnreadMap, markTaskRead } from "../lib/read-log.js";
 import {
   buildTaskListWhere,
   taskCreateSchema,
@@ -95,7 +95,15 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
       orderBy: taskListOrderBy,
       include: taskListInclude,
     });
-    return c.json(tasks.map(serializeTask));
+
+    // 各タスクの未読判定を 1 クエリで取得し、レスポンスに unread を付与する。
+    const unreadMap = await buildTaskUnreadMap(user.id, tasks);
+    return c.json(
+      tasks.map((task) => ({
+        ...serializeTask(task),
+        unread: unreadMap.get(task.id) ?? true,
+      })),
+    );
   })
   .post("/", zValidator("json", taskCreateSchema), async (c) => {
     const input = c.req.valid("json");

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { prisma } from "../lib/prisma.js";
+import { markTaskRead } from "../lib/read-log.js";
 import {
   buildTaskListWhere,
   taskCreateSchema,
@@ -316,5 +317,14 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     // 配下の TaskAssignee / TaskRecurringMeeting は schema 側で onDelete: Cascade のため
     // delete 一発で連鎖削除される。削除済みボディは返さず 204 で統一。
     await prisma.task.delete({ where: { id } });
+    return c.body(null, 204);
+  })
+  .post("/:id/read", async (c) => {
+    const id = c.req.param("id");
+    // 既読化は組織メンバーのみ許可。不存在・非所属は 404 で統一する。
+    const guard = await requireTaskAccess(c, id);
+    if (!guard.ok) return guard.res;
+
+    await markTaskRead(c.var.user.id, id);
     return c.body(null, 204);
   });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -28,6 +28,10 @@ vi.mock("../src/lib/prisma.js", () => ({
       deleteMany: vi.fn(),
       createMany: vi.fn(),
     },
+    readLog: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -802,5 +806,43 @@ describe("DELETE /tasks/:id", () => {
     mockMembershipFindUnique.mockResolvedValue(null);
     const res = await app.request("/tasks/task-1", { method: "DELETE" });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /tasks/:id/read", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("組織メンバーは 204 で既読化でき ReadLog を追記する", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
+    mockMembershipFindUnique.mockResolvedValue(membership());
+    const mockReadLogCreate = vi.mocked(prisma.readLog.create);
+    mockReadLogCreate.mockResolvedValue({} as never);
+
+    const res = await app.request("/tasks/task-1/read", { method: "POST" });
+    expect(res.status).toBe(204);
+    expect(mockReadLogCreate).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        resourceType: "task",
+        resourceId: "task-1",
+      },
+    });
+  });
+
+  it("タスク不存在は 404 で ReadLog を作らない", async () => {
+    mockTaskFindUnique.mockResolvedValue(null);
+    const mockReadLogCreate = vi.mocked(prisma.readLog.create);
+    const res = await app.request("/tasks/missing/read", { method: "POST" });
+    expect(res.status).toBe(404);
+    expect(mockReadLogCreate).not.toHaveBeenCalled();
+  });
+
+  it("非メンバーは 404 で ReadLog を作らない", async () => {
+    mockTaskFindUnique.mockResolvedValue(sampleTask);
+    mockMembershipFindUnique.mockResolvedValue(null);
+    const mockReadLogCreate = vi.mocked(prisma.readLog.create);
+    const res = await app.request("/tasks/task-1/read", { method: "POST" });
+    expect(res.status).toBe(404);
+    expect(mockReadLogCreate).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -668,7 +668,12 @@ describe("PATCH /tasks/:id", () => {
 });
 
 describe("GET /tasks/me", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 未読判定用の ReadLog 取得は既定で空（＝全件未読）にしておく。
+    // 各ケースで必要に応じて上書きする。
+    vi.mocked(prisma.readLog.findMany).mockResolvedValue([]);
+  });
 
   it("認証ユーザーが assignee のタスクを 200 で返す", async () => {
     const listTask = {
@@ -778,6 +783,61 @@ describe("GET /tasks/me", () => {
     };
     expect(where.dueDate?.lt).toBeInstanceOf(Date);
     expect(where.dueDate?.lte).toEqual(new Date("2026-05-31T00:00:00Z"));
+  });
+
+  // updatedAt を 2026-05-17 に固定し、ReadLog の readAt との前後で未読を判定する。
+  const listTaskForUnread = {
+    ...sampleTask,
+    assignees: [{ user: { id: "user-1", name: "alice", displayName: "alice" } }],
+    recurringMeetings: [],
+  };
+
+  it("ReadLog 未記録のタスクは unread=true", async () => {
+    mockTaskFindMany.mockResolvedValue([listTaskForUnread]);
+    vi.mocked(prisma.readLog.findMany).mockResolvedValue([]);
+    const res = await app.request("/tasks/me");
+    const body = (await res.json()) as Array<{ unread: boolean }>;
+    expect(body[0].unread).toBe(true);
+  });
+
+  it("最新 readAt が updatedAt より前なら unread=true（更新後未読）", async () => {
+    mockTaskFindMany.mockResolvedValue([listTaskForUnread]);
+    vi.mocked(prisma.readLog.findMany).mockResolvedValue([
+      {
+        resourceId: "task-1",
+        readAt: new Date("2026-05-16T00:00:00Z"),
+      },
+    ] as never);
+    const res = await app.request("/tasks/me");
+    const body = (await res.json()) as Array<{ unread: boolean }>;
+    expect(body[0].unread).toBe(true);
+  });
+
+  it("最新 readAt が updatedAt 以降なら unread=false（既読）", async () => {
+    mockTaskFindMany.mockResolvedValue([listTaskForUnread]);
+    vi.mocked(prisma.readLog.findMany).mockResolvedValue([
+      {
+        resourceId: "task-1",
+        readAt: new Date("2026-05-18T00:00:00Z"),
+      },
+    ] as never);
+    const res = await app.request("/tasks/me");
+    const body = (await res.json()) as Array<{ unread: boolean }>;
+    expect(body[0].unread).toBe(false);
+  });
+
+  it("ReadLog 取得は userId と resourceType=task で絞り込む", async () => {
+    mockTaskFindMany.mockResolvedValue([listTaskForUnread]);
+    await app.request("/tasks/me");
+    expect(vi.mocked(prisma.readLog.findMany)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "user-1",
+          resourceType: "task",
+          resourceId: { in: ["task-1"] },
+        }),
+      }),
+    );
   });
 });
 

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -788,7 +788,9 @@ describe("GET /tasks/me", () => {
   // updatedAt を 2026-05-17 に固定し、ReadLog の readAt との前後で未読を判定する。
   const listTaskForUnread = {
     ...sampleTask,
-    assignees: [{ user: { id: "user-1", name: "alice", displayName: "alice" } }],
+    assignees: [
+      { user: { id: "user-1", name: "alice", displayName: "alice" } },
+    ],
     recurringMeetings: [],
   };
 

--- a/apps/web/src/features/tasks/hooks/useMarkTaskRead.ts
+++ b/apps/web/src/features/tasks/hooks/useMarkTaskRead.ts
@@ -1,0 +1,25 @@
+import { api, authHeaders } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "../queryKeys";
+
+// タスクを既読化する mutation（POST /tasks/:id/read）。
+// 未読フラグは /tasks/me が付与するため、成功時に tasks スコープ全体を
+// invalidate して未読表示を最新化する。
+export function useMarkTaskRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (taskId) => {
+      const res = await api.tasks[":id"].read.$post(
+        { param: { id: taskId } },
+        authHeaders(),
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to mark task read: ${res.status}`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/tasks/types.ts
+++ b/apps/web/src/features/tasks/types.ts
@@ -81,6 +81,9 @@ export type TaskListItem = TaskEditableFields &
     } | null;
     assignees: AssigneeUser[];
     recurringMeetings: Array<{ id: string; name: string }>;
+    // 未読フラグ。GET /tasks/me のみが付与する（ReadLog 未記録 or 更新後未読）。
+    // 他経路のレスポンスでは undefined。
+    unread?: boolean;
   };
 
 // 詳細 API のレスポンス。assignees に email が含まれる以外は一覧と同形。

--- a/apps/web/src/features/tasks/urgency.ts
+++ b/apps/web/src/features/tasks/urgency.ts
@@ -1,0 +1,114 @@
+// タスクの緊急度判定とリマインド集計ロジック。
+// ダッシュボードのタスクカード（routes/index.tsx）と集約バナーで共用するため、
+// テスト可能な純関数として features/tasks 配下に切り出している。
+
+import type { TaskListItem } from "./types";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+// 期限超過 / 今週期限 / それ以降 の 3 段階。
+export type TaskUrgency = "overdue" | "this-week" | "later";
+
+// 緊急度ごとの左フレーム色・期限テキスト色。
+export const URGENCY_STYLE: Record<
+  TaskUrgency,
+  { border: string; deadline: string }
+> = {
+  overdue: {
+    border: "border-l-destructive",
+    deadline: "text-destructive font-medium",
+  },
+  "this-week": {
+    border: "border-l-amber-500",
+    deadline: "text-amber-600 font-medium",
+  },
+  later: {
+    border: "border-l-slate-200",
+    deadline: "text-muted-foreground",
+  },
+};
+
+// 当日 0 時を返す。緊急度判定は時刻を切り捨てて「日」単位で比較する。
+function startOfDay(now: Date): Date {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+// 期限日から緊急度を算出する。
+// now を引数化してテストで固定できるようにしつつ、既定値で従来の呼び出しと互換を保つ。
+export function calcUrgency(
+  dueDate: string | null,
+  now: Date = new Date(),
+): TaskUrgency {
+  if (!dueDate) return "later";
+  const today = startOfDay(now);
+  const due = new Date(dueDate);
+  if (due < today) return "overdue";
+  const weekLater = new Date(today);
+  weekLater.setDate(weekLater.getDate() + 7);
+  if (due <= weekLater) return "this-week";
+  return "later";
+}
+
+// 期限の表示用文字列。超過時は「N日超過」、それ以外は「月/日」。
+export function formatDeadline(
+  dueDate: string | null,
+  urgency: TaskUrgency,
+  now: Date = new Date(),
+): string {
+  if (!dueDate) return "未設定";
+  if (urgency === "overdue") {
+    const today = startOfDay(now);
+    const days = Math.ceil(
+      (today.getTime() - new Date(dueDate).getTime()) / DAY_MS,
+    );
+    return `${days}日超過`;
+  }
+  const d = new Date(dueDate);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+// ダッシュボード上部のリマインド集約に表示する件数。
+export type ReminderSummary = {
+  // 期限超過（未完了タスクのうち期限が過ぎたもの）
+  overdue: number;
+  // 今週期限（this-week）
+  dueSoon: number;
+  // 着手予定日超過（開始予定日が過ぎているのに未着手 = status:todo のもの）
+  startOverdue: number;
+  // 未読（API が付与する unread フラグ）
+  unread: number;
+};
+
+// 未完了タスク配列からリマインド件数を集計する。
+// 1 タスクが複数条件に該当する場合は各カテゴリで重複してカウントする
+// （ユーザーへの「見落とし防止」が目的のため、重複は許容する）。
+export function summarizeReminders(
+  tasks: TaskListItem[],
+  now: Date = new Date(),
+): ReminderSummary {
+  const today = startOfDay(now);
+  const summary: ReminderSummary = {
+    overdue: 0,
+    dueSoon: 0,
+    startOverdue: 0,
+    unread: 0,
+  };
+  for (const task of tasks) {
+    const urgency = calcUrgency(task.dueDate, now);
+    if (urgency === "overdue") summary.overdue += 1;
+    else if (urgency === "this-week") summary.dueSoon += 1;
+    // 着手予定日を過ぎてもまだ着手していない（todo のまま）タスクを抽出。
+    // in_progress は着手済みのため対象外。
+    if (
+      task.startDate &&
+      new Date(task.startDate) < today &&
+      task.status === "todo"
+    ) {
+      summary.startOverdue += 1;
+    }
+    if (task.unread) summary.unread += 1;
+  }
+  return summary;
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,6 +8,11 @@ import { partitionMeetings } from "@/features/recurring-meetings/meetingSections
 import { TYPE_LABELS, type ReviewItemType } from "@/features/review/types";
 import { useReviewItems } from "@/features/review/useReviewItems";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
+import {
+  URGENCY_STYLE,
+  calcUrgency,
+  formatDeadline,
+} from "@/features/tasks/urgency";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
@@ -273,50 +278,6 @@ function ReviewPendingCard({ orgId }: { orgId: string }) {
 }
 
 // ===== 未完了タスクカード =====
-
-type TaskUrgency = "overdue" | "this-week" | "later";
-
-const URGENCY_STYLE: Record<TaskUrgency, { border: string; deadline: string }> =
-  {
-    overdue: {
-      border: "border-l-destructive",
-      deadline: "text-destructive font-medium",
-    },
-    "this-week": {
-      border: "border-l-amber-500",
-      deadline: "text-amber-600 font-medium",
-    },
-    later: {
-      border: "border-l-slate-200",
-      deadline: "text-muted-foreground",
-    },
-  };
-
-function calcUrgency(dueDate: string | null): TaskUrgency {
-  if (!dueDate) return "later";
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const due = new Date(dueDate);
-  if (due < today) return "overdue";
-  const weekLater = new Date(today);
-  weekLater.setDate(weekLater.getDate() + 7);
-  if (due <= weekLater) return "this-week";
-  return "later";
-}
-
-function formatDeadline(dueDate: string | null, urgency: TaskUrgency): string {
-  if (!dueDate) return "未設定";
-  if (urgency === "overdue") {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const days = Math.ceil(
-      (today.getTime() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24),
-    );
-    return `${days}日超過`;
-  }
-  const d = new Date(dueDate);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
 
 function IncompleteTasksCard() {
   const {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -7,11 +7,14 @@ import {
 import { partitionMeetings } from "@/features/recurring-meetings/meetingSections";
 import { TYPE_LABELS, type ReviewItemType } from "@/features/review/types";
 import { useReviewItems } from "@/features/review/useReviewItems";
+import { useMarkTaskRead } from "@/features/tasks/hooks/useMarkTaskRead";
 import { useMyTasks } from "@/features/tasks/hooks/useMyTasks";
+import type { TaskListFilters } from "@/features/tasks/types";
 import {
   URGENCY_STYLE,
   calcUrgency,
   formatDeadline,
+  summarizeReminders,
 } from "@/features/tasks/urgency";
 import { currentOrganizationIdAtom } from "@/lib/currentOrganization";
 import { Link, createFileRoute } from "@tanstack/react-router";
@@ -21,7 +24,14 @@ import {
   AvatarStack,
   type AvatarUser,
 } from "@/features/tasks/components/AvatarStack";
-import { ArrowRight, ChevronRight } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bell,
+  CalendarClock,
+  ChevronRight,
+  Clock,
+} from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Dashboard,
@@ -277,17 +287,101 @@ function ReviewPendingCard({ orgId }: { orgId: string }) {
   );
 }
 
+// ===== リマインド集約バナー =====
+
+// 未完了タスクの取得フィルタ。バナーとカードで同一キーを使い fetch を共有する。
+const INCOMPLETE_SEARCH_FILTER: TaskListFilters = {
+  status: ["todo", "in_progress"],
+};
+
+// /tasks 一覧への遷移に使う共通フィルタ（未完了タスクに絞る）。
+const INCOMPLETE_SEARCH = { status: "todo,in_progress" } as const;
+
+// バナーに表示する各カテゴリの定義。
+// 期限超過のみ既存の overdueOnly フィルタへ正確に遷移し、
+// 今週期限・着手予定日超過・未読は専用フィルタUIが無いため未完了一覧へ遷移する。
+const REMINDER_ITEMS = [
+  {
+    key: "overdue" as const,
+    label: "期限超過",
+    Icon: AlertTriangle,
+    className: "text-destructive border-destructive/30 bg-destructive/5",
+    search: { ...INCOMPLETE_SEARCH, overdueOnly: "true" },
+  },
+  {
+    key: "dueSoon" as const,
+    label: "今週期限",
+    Icon: Clock,
+    className: "text-amber-600 border-amber-500/30 bg-amber-500/5",
+    search: INCOMPLETE_SEARCH,
+  },
+  {
+    key: "startOverdue" as const,
+    label: "着手予定日超過",
+    Icon: CalendarClock,
+    className: "text-orange-600 border-orange-500/30 bg-orange-500/5",
+    search: INCOMPLETE_SEARCH,
+  },
+  {
+    key: "unread" as const,
+    label: "未読",
+    Icon: Bell,
+    className: "text-sky-600 border-sky-500/30 bg-sky-500/5",
+    search: INCOMPLETE_SEARCH,
+  },
+];
+
+// 期限超過・今週期限・着手予定日超過・未読を件数付きで集約表示するバナー。
+// 見落とし防止が目的のため、件数 0 のカテゴリは出さず、全て 0 なら非表示にする。
+function RemindersBanner() {
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useMyTasks(INCOMPLETE_SEARCH_FILTER);
+
+  if (isLoading || isError) return null;
+
+  const summary = summarizeReminders(data);
+  const visible = REMINDER_ITEMS.filter((item) => summary[item.key] > 0);
+  if (visible.length === 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-label="リマインド"
+      className="flex flex-wrap items-center gap-2 rounded-xl border border-border/60 bg-card px-4 py-3"
+    >
+      <span className="text-xs font-semibold text-muted-foreground shrink-0">
+        リマインド
+      </span>
+      {visible.map(({ key, label, Icon, className, search }) => (
+        <Link
+          key={key}
+          to="/tasks"
+          search={search}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:brightness-95 ${className}`}
+        >
+          <Icon size={13} />
+          <span>{label}</span>
+          <span className="font-semibold">{summary[key]}</span>
+          <span>件</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 // ===== 未完了タスクカード =====
 
 function IncompleteTasksCard() {
+  const markRead = useMarkTaskRead();
   const {
     data = [],
     isLoading,
     isError,
     refetch,
-  } = useMyTasks({
-    status: ["todo", "in_progress"],
-  });
+  } = useMyTasks(INCOMPLETE_SEARCH_FILTER);
 
   return (
     <Card className="gap-0 py-0 overflow-hidden h-90">
@@ -361,6 +455,19 @@ function IncompleteTasksCard() {
                       </span>
                     )}
                   </div>
+                  {task.unread && (
+                    <button
+                      type="button"
+                      // クリックで既読化する最小導線。pending 中は二重送信を防ぐ。
+                      onClick={() => markRead.mutate(task.id)}
+                      disabled={markRead.isPending}
+                      title="クリックで既読にする"
+                      className="shrink-0 inline-flex items-center gap-1 rounded-full bg-sky-500/10 px-2 py-0.5 text-xs font-medium text-sky-600 transition-colors hover:bg-sky-500/20 disabled:opacity-50"
+                    >
+                      <Bell size={11} />
+                      未読
+                    </button>
+                  )}
                   <span className={`text-xs shrink-0 ${style.deadline}`}>
                     {formatDeadline(task.dueDate, urgency)}
                   </span>
@@ -396,6 +503,9 @@ export function Dashboard() {
         </div>
       ) : (
         <div className="flex flex-col gap-4">
+          {/* 最上段：未達・期限超過・未読のリマインド集約バナー */}
+          <RemindersBanner />
+
           {/* 上段：次回会議（横スクロール） */}
           <NextMeetingsSection orgId={orgId} />
 

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithQuery } from "./test-utils";
 
@@ -17,6 +17,7 @@ vi.mock("@/lib/api", () => ({
     },
     tasks: {
       me: { $get: vi.fn() },
+      ":id": { read: { $post: vi.fn() } },
     },
   },
   authHeaders: () => ({ headers: {} }),
@@ -537,7 +538,8 @@ describe("Dashboard - IncompleteTasksCard", () => {
       mockJson([makeTask({ id: "t1", dueDate: PAST })]),
     );
     renderDashboard();
-    expect(await screen.findByText(/超過/)).toBeInTheDocument();
+    // カードの期限表示「N日超過」を指す。バナーの「期限超過」と区別するため /日超過/ で照合。
+    expect(await screen.findByText(/日超過/)).toBeInTheDocument();
   });
 
   it("期限ありのタスクは「月/日」形式で表示される", async () => {
@@ -583,5 +585,97 @@ describe("Dashboard - IncompleteTasksCard", () => {
     await screen.findByText("タスクA");
     const header = screen.getByText("未完了タスク").closest("div");
     expect(header?.textContent).toContain("2");
+  });
+
+  it("未読タスクには未読バッジ（ボタン）が表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "u1", title: "未読タスク", unread: true })]),
+    );
+    renderDashboard();
+    expect(
+      await screen.findByRole("button", { name: /未読/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("既読タスクには未読バッジが表示されない", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "r1", title: "既読タスク", unread: false })]),
+    );
+    renderDashboard();
+    await screen.findByText("既読タスク");
+    expect(screen.queryByRole("button", { name: /未読/ })).toBeNull();
+  });
+
+  it("未読バッジをクリックすると既読化APIが呼ばれる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "u1", title: "未読タスク", unread: true })]),
+    );
+    const post = vi
+      .mocked(api.tasks[":id"].read.$post)
+      .mockResolvedValue(mockJson(null, 204));
+    renderDashboard();
+    const badge = await screen.findByRole("button", { name: /未読/ });
+    fireEvent.click(badge);
+    await waitFor(() => expect(post).toHaveBeenCalled());
+  });
+});
+
+// ===== RemindersBanner =====
+
+describe("Dashboard - RemindersBanner", () => {
+  beforeEach(() => {
+    vi.mocked(useAtomValue).mockReturnValue("org-1");
+    vi.mocked(api.organizations[":id"].meetings.$get).mockResolvedValue(
+      mockJson([]),
+    );
+    vi.mocked(api.organizations[":id"]["review-items"].$get).mockResolvedValue(
+      mockJson([]),
+    );
+  });
+
+  function renderDashboard() {
+    return renderWithQuery(<Dashboard />);
+  }
+
+  // now を基準にした相対日付。fake timer を避けるため Date.now() から算出する。
+  const threeDaysLater = new Date(
+    Date.now() + 3 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  it("期限超過・今週期限の件数が表示され、該当一覧へ遷移するリンクがある", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([
+        makeTask({ id: "o1", dueDate: PAST }),
+        makeTask({ id: "w1", dueDate: threeDaysLater }),
+      ]),
+    );
+    renderDashboard();
+
+    const overdueLink = await screen.findByRole("link", {
+      name: /期限超過/,
+    });
+    expect(overdueLink.textContent).toContain("1");
+    expect(overdueLink).toHaveAttribute("href", "/tasks");
+
+    const dueSoonLink = screen.getByRole("link", { name: /今週/ });
+    expect(dueSoonLink.textContent).toContain("1");
+    expect(dueSoonLink).toHaveAttribute("href", "/tasks");
+  });
+
+  it("未読件数も集約表示される", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(
+      mockJson([makeTask({ id: "u1", unread: true })]),
+    );
+    renderDashboard();
+    const unreadLink = await screen.findByRole("link", { name: /未読/ });
+    expect(unreadLink.textContent).toContain("1");
+  });
+
+  it("リマインド対象が無いときバナーは表示されない", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderDashboard();
+    // タスク取得完了を待ってからバナー非表示を確認する
+    await screen.findByText("未完了のタスクはありません");
+    expect(screen.queryByRole("link", { name: /期限超過/ })).toBeNull();
   });
 });

--- a/apps/web/src/test/tasks.markRead.test.tsx
+++ b/apps/web/src/test/tasks.markRead.test.tsx
@@ -1,0 +1,65 @@
+import { useMarkTaskRead } from "@/features/tasks/hooks/useMarkTaskRead";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function mockFetchOnce(init: ResponseInit, body: unknown = null) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(body === null ? null : JSON.stringify(body), init),
+  );
+}
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useMarkTaskRead", () => {
+  function makeClient() {
+    return new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+  }
+
+  it("成功時に 204 を受け取り、tasks クエリを invalidate する", async () => {
+    mockFetchOnce({ status: 204 });
+    const client = makeClient();
+    const spy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkTaskRead(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("task-1");
+    });
+
+    // /tasks/me の未読フラグを更新させるため tasks スコープを invalidate する。
+    expect(spy).toHaveBeenCalledWith({ queryKey: taskQueryKeys.all });
+  });
+
+  it("非 2xx のとき reject する", async () => {
+    mockFetchOnce({ status: 500 }, { error: "internal" });
+    const client = makeClient();
+
+    const { result } = renderHook(() => useMarkTaskRead(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await expect(result.current.mutateAsync("task-1")).rejects.toThrow();
+  });
+});

--- a/apps/web/src/test/urgency.test.ts
+++ b/apps/web/src/test/urgency.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { TaskListItem } from "@/features/tasks/types";
+import {
+  calcUrgency,
+  formatDeadline,
+  summarizeReminders,
+} from "@/features/tasks/urgency";
+
+// 基準時刻を固定してタイムゾーン非依存にする（fake timer は使わない）。
+const NOW = new Date("2026-06-15T09:00:00.000Z");
+
+// TZ オフセット（最大±14h）でも日境界が 7 日窓を跨がない余裕を持った日付を使う。
+const OVERDUE = "2026-05-15T12:00:00.000Z"; // 約1ヶ月前
+const THIS_WEEK = "2026-06-17T12:00:00.000Z"; // 2日後
+const LATER = "2026-07-20T12:00:00.000Z"; // 1ヶ月以上先
+
+function makeTask(overrides: Partial<TaskListItem> = {}): TaskListItem {
+  return {
+    id: "task-1",
+    organizationId: "org-1",
+    originMeetingId: null,
+    decisionItemId: null,
+    title: "テストタスク",
+    body: null,
+    sourceQuote: null,
+    sourceContext: null,
+    status: "todo",
+    priority: null,
+    dueDateRaw: null,
+    dueDateEstimated: null,
+    assigneeRaw: null,
+    blockingItemId: null,
+    carriedOverCount: null,
+    ambiguityFlags: null,
+    progressNote: null,
+    dueDate: null,
+    startDate: null,
+    followUpDate: null,
+    version: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    organization: { id: "org-1", name: "ACME" },
+    originMeeting: null,
+    assignees: [],
+    recurringMeetings: [],
+    ...overrides,
+  };
+}
+
+describe("calcUrgency", () => {
+  it("期限なしは later", () => {
+    expect(calcUrgency(null, NOW)).toBe("later");
+  });
+
+  it("過去の期限は overdue", () => {
+    expect(calcUrgency(OVERDUE, NOW)).toBe("overdue");
+  });
+
+  it("今日から7日以内は this-week", () => {
+    expect(calcUrgency(THIS_WEEK, NOW)).toBe("this-week");
+  });
+
+  it("7日より先は later", () => {
+    expect(calcUrgency(LATER, NOW)).toBe("later");
+  });
+});
+
+describe("formatDeadline", () => {
+  it("期限なしは「未設定」", () => {
+    expect(formatDeadline(null, "later", NOW)).toBe("未設定");
+  });
+
+  it("超過は「N日超過」", () => {
+    expect(formatDeadline(OVERDUE, "overdue", NOW)).toMatch(/日超過$/);
+  });
+
+  it("超過以外は「月/日」形式", () => {
+    expect(formatDeadline(THIS_WEEK, "this-week", NOW)).toBe("6/17");
+  });
+});
+
+describe("summarizeReminders", () => {
+  it("空配列は全件 0", () => {
+    expect(summarizeReminders([], NOW)).toEqual({
+      overdue: 0,
+      dueSoon: 0,
+      startOverdue: 0,
+      unread: 0,
+    });
+  });
+
+  it("期限超過・今週・着手超過・未読をそれぞれ集計する", () => {
+    const tasks = [
+      makeTask({ id: "a", dueDate: OVERDUE }),
+      makeTask({ id: "b", dueDate: THIS_WEEK }),
+      makeTask({ id: "c", startDate: OVERDUE, status: "todo" }),
+      makeTask({ id: "d", unread: true }),
+    ];
+    expect(summarizeReminders(tasks, NOW)).toEqual({
+      overdue: 1,
+      dueSoon: 1,
+      startOverdue: 1,
+      unread: 1,
+    });
+  });
+
+  it("着手予定日超過は status=todo のみカウントし、着手済み(in_progress)は除外する", () => {
+    const tasks = [
+      makeTask({ id: "a", startDate: OVERDUE, status: "in_progress" }),
+    ];
+    expect(summarizeReminders(tasks, NOW).startOverdue).toBe(0);
+  });
+
+  it("1件が複数条件に該当する場合は各カテゴリで重複カウントする", () => {
+    const tasks = [makeTask({ id: "a", dueDate: OVERDUE, unread: true })];
+    const summary = summarizeReminders(tasks, NOW);
+    expect(summary.overdue).toBe(1);
+    expect(summary.unread).toBe(1);
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #351

## 概要・目的
* 要件 13.8 / 14.2 の「未達・未読・期限超過のリマインド」を、Azure 不要のアプリ内集約表示として実装する。
* 期限超過・期限間近・着手予定日超過・未読のタスクをダッシュボード上部に件数付きで集約し、見落としを防ぐ。

## 背景
* ダッシュボードには既にタスクの緊急度概念（`calcUrgency`）があったが、リマインドとして集約・強調する導線が無かった。
* `ReadLog`（既読履歴）はスキーマ定義のみで未使用だったため、未読判定の基盤として活用する。
* 定期実行基盤（#336/#337）に依存せず、ログイン時/閲覧時の集約表示で代替する（cron 自動プッシュ・外部通知は本 PR 非対象）。

## 変更内容
* **FE 共通化**: ダッシュボードにインライン定義されていた緊急度判定を `apps/web/src/features/tasks/urgency.ts` へ抽出。着手予定日超過・未読を含む集計関数 `summarizeReminders` を追加（基準時刻 `now` を引数化しテスト可能に）。
* **FE バナー**: ダッシュボード最上段に `RemindersBanner` を追加。期限超過・今週期限・着手予定日超過・未読を件数付きチップで表示し、該当一覧（期限超過は `overdueOnly` フィルタ）へ遷移。件数 0 のカテゴリは非表示、全て 0 ならバナー自体を非表示。
* **BE 既読化 API**: `POST /tasks/:id/read` を追加。組織メンバーのみ許可し、`ReadLog` に追記（追記専用の不変ログ）。
* **BE 未読判定**: `GET /tasks/me` の各タスクに `unread` フラグを付与。判定は「`ReadLog` 未記録」または「最新 `readAt` < `updatedAt`」。`ReadLog` を taskId 群で 1 クエリ取得し N+1 を回避。
* **FE 既読化導線**: 未完了タスクカードに未読バッジを表示し、クリックで `useMarkTaskRead` を呼んで既読化。

## 動作確認手順
1. `make dev` で全サービスを起動する。
2. ダッシュボード（`/`）を開き、担当タスクに期限超過・今週期限・着手予定日超過・未読が含まれる状態で、最上段に「リマインド」バナーが件数付きで表示されることを確認する。
3. バナーの「期限超過」チップをクリックし、`/tasks?status=todo,in_progress&overdueOnly=true` の絞り込み一覧へ遷移することを確認する。
4. 未完了タスクカードで未読タスクに「未読」バッジが表示され、クリックするとバッジが消える（`POST /tasks/:id/read` 後に再取得で既読化される）ことを確認する。
5. リマインド対象が無い場合にバナーが表示されないことを確認する。
6. `make test`（Vitest + pytest）と `make lint` が成功することを確認する。

## スクリーンショット
* UI 変更（ダッシュボードのリマインドバナー・未読バッジ）。レビュー時に動作確認手順 2〜5 を参照。
