### PR TITLE
ci: GitHub Actionsデプロイワークフローを実装（#369）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ concurrency:
 #   AZURE_SUBSCRIPTION_ID - サブスクリプション ID
 #   VITE_FAKE_AUTH_URL   - 【暫定】issue-177（Entra フロント対応）マージ後に VITE_ENTRA_* へ置き換え・削除
 #   DATABASE_URL         - マイグレーション用 PostgreSQL 接続文字列
+#
+# 必要な GitHub Variables（Settings > Variables > Actions）:
+#   INTERNAL_API_BASE_URL - ai → api の内部通信 URL（例: https://decision-loop-api.azurewebsites.net）
 
 jobs:
   ci:
@@ -134,7 +137,7 @@ jobs:
           az webapp config appsettings set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-ai \
-            --settings INTERNAL_API_BASE_URL="https://decision-loop-api.azurewebsites.net"
+            --settings INTERNAL_API_BASE_URL="${{ vars.INTERNAL_API_BASE_URL }}"
           az webapp config container set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-ai \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
   migrate:
     name: DB マイグレーション
     runs-on: ubuntu-latest
-    needs: build-push
+    needs: ci  # build-push と並列実行可能（スキーマさえあれば migrate deploy は実行できる）
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,3 +142,13 @@ jobs:
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-ai \
             --container-image-name decisionloopacr.azurecr.io/ai:${{ github.sha }}
+
+      - name: ヘルスチェック
+        # イメージ pull・コンテナ起動に時間がかかるため --retry-delay 15 × 20回（最大5分）でリトライ
+        run: |
+          curl --fail --silent --retry 20 --retry-delay 15 --retry-all-errors \
+            https://decision-loop-web.azurewebsites.net/
+          curl --fail --silent --retry 20 --retry-delay 15 --retry-all-errors \
+            https://decision-loop-api.azurewebsites.net/health
+          curl --fail --silent --retry 20 --retry-delay 15 --retry-all-errors \
+            https://decision-loop-ai.azurewebsites.net/health

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,72 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# 必要な GitHub Secrets:
+#   AZURE_CLIENT_ID      - OIDC 用 Service Principal の Application ID
+#   AZURE_TENANT_ID      - Azure AD テナント ID
+#   AZURE_SUBSCRIPTION_ID - サブスクリプション ID
+#   VITE_FAKE_AUTH_URL   - 【暫定】issue-177（Entra フロント対応）マージ後に VITE_ENTRA_* へ置き換え・削除
+#   DATABASE_URL         - マイグレーション用 PostgreSQL 接続文字列
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
-  build:
-    name: Build
+  build-push:
+    name: イメージビルド & ACR プッシュ
     runs-on: ubuntu-latest
     needs: ci
+    permissions:
+      id-token: write  # OIDC トークン取得に必要
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Azure ログイン (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR ログイン
+        run: az acr login --name decisionloopacr
+
+      - name: web イメージビルド & プッシュ
+        run: |
+          docker build --target prod \
+            --build-arg "VITE_FAKE_AUTH_URL=${{ secrets.VITE_FAKE_AUTH_URL }}" \
+            -f apps/web/Dockerfile \
+            -t decisionloopacr.azurecr.io/web:${{ github.sha }} \
+            -t decisionloopacr.azurecr.io/web:latest \
+            .
+          docker push decisionloopacr.azurecr.io/web:${{ github.sha }}
+          docker push decisionloopacr.azurecr.io/web:latest
+
+      - name: api イメージビルド & プッシュ
+        run: |
+          docker build --target prod \
+            -f apps/api/Dockerfile \
+            -t decisionloopacr.azurecr.io/api:${{ github.sha }} \
+            -t decisionloopacr.azurecr.io/api:latest \
+            .
+          docker push decisionloopacr.azurecr.io/api:${{ github.sha }}
+          docker push decisionloopacr.azurecr.io/api:latest
+
+      - name: ai イメージビルド & プッシュ
+        run: |
+          docker build --target prod \
+            -f services/ai/Dockerfile \
+            -t decisionloopacr.azurecr.io/ai:${{ github.sha }} \
+            -t decisionloopacr.azurecr.io/ai:latest \
+            .
+          docker push decisionloopacr.azurecr.io/ai:${{ github.sha }}
+          docker push decisionloopacr.azurecr.io/ai:latest
+
+  migrate:
+    name: DB マイグレーション
+    runs-on: ubuntu-latest
+    needs: build-push
     steps:
       - uses: actions/checkout@v6
 
@@ -32,18 +90,52 @@ jobs:
       - name: 依存関係インストール
         run: pnpm install --frozen-lockfile
 
-      - name: Prisma クライアント生成        # issue 230 追加
-        run: pnpm --filter api exec prisma generate
+      - name: Prisma クライアント生成
+        # prisma-dbml-generator は devDependencies のため --generator client で除外
+        run: pnpm --filter api exec prisma generate --generator client
 
-      - name: ビルド
-        run: pnpm turbo run build
+      - name: DB マイグレーション適用
+        run: pnpm --filter api exec prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
-  # TODO: Azure 環境構築後に実装
-  # deploy:
-  #   name: Deploy to Azure Container Apps
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - name: Azure へデプロイ
-  #       run: echo "TODO: azure/container-apps-deploy-action を使用"
+  deploy:
+    name: App Service デプロイ
+    runs-on: ubuntu-latest
+    needs: [build-push, migrate]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Azure ログイン (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: web デプロイ
+        run: |
+          az webapp config container set \
+            --resource-group rg-ms-hackathon-dev \
+            --name decision-loop-web \
+            --container-image-name decisionloopacr.azurecr.io/web:${{ github.sha }}
+
+      - name: api デプロイ
+        run: |
+          az webapp config container set \
+            --resource-group rg-ms-hackathon-dev \
+            --name decision-loop-api \
+            --container-image-name decisionloopacr.azurecr.io/api:${{ github.sha }}
+
+      - name: ai デプロイ
+        run: |
+          # 環境変数を先にセットし、コンテナ起動時に確実に利用可能にする
+          az webapp config appsettings set \
+            --resource-group rg-ms-hackathon-dev \
+            --name decision-loop-ai \
+            --settings INTERNAL_API_BASE_URL="https://decision-loop-api.azurewebsites.net"
+          az webapp config container set \
+            --resource-group rg-ms-hackathon-dev \
+            --name decision-loop-ai \
+            --container-image-name decisionloopacr.azurecr.io/ai:${{ github.sha }}

--- a/services/ai/Dockerfile
+++ b/services/ai/Dockerfile
@@ -20,5 +20,12 @@ RUN uv sync --no-dev
 COPY services/ai/main.py ./
 COPY services/ai/consumers ./consumers
 COPY services/ai/routers ./routers
+COPY services/ai/schemas ./schemas
+COPY services/ai/llm ./llm
+COPY services/ai/integrations ./integrations
+COPY services/ai/pipeline ./pipeline
+COPY services/ai/rag ./rag
+COPY services/ai/prompts ./prompts
+COPY services/ai/agent ./agent
 EXPOSE 8001
 CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
## 関連Issue
Closes #369

## 概要・目的
* `main` マージをトリガーに web/api/ai の本番イメージを ACR にプッシュし、App Service へ自動デプロイするワークフローを実装した
* OIDC（Workload Identity Federation）を採用し、長期資格情報を GitHub Secrets に持たないパスワードレス構成とした
* `prisma migrate deploy` を api デプロイ前ステップとして組み込み、スキーマとアプリのバージョンを揃える経路を確立した

## 背景
* #357 でマルチステージ Dockerfile が整備され、本番イメージのビルド基盤が整った
* 既存の `deploy.yml` に TODO として残されていたデプロイジョブを実装する
* PR #357 レビューで `prisma migrate deploy` の経路が未整備と指摘されていた

## 変更内容
* `.github/workflows/deploy.yml`: `build-push` / `migrate` / `deploy` の3ジョブ構成を実装
  * `ci` ジョブで既存の lint/test を再利用し、通過後にのみデプロイが走る
  * `build-push`: OIDC で Azure ログイン → ACR へ3サービスのイメージをプッシュ（SHA タグ + latest タグ）
  * `migrate`: `prisma migrate deploy` を実行（`DATABASE_URL` は GitHub Secret から注入）
  * `deploy`: `az webapp config container set` で App Service のイメージを更新
* `services/ai/Dockerfile`: prod ステージに不足していた `schemas/` `llm/` `integrations/` `pipeline/` `rag/` `prompts/` `agent/` の COPY を追加

## 動作確認手順
1. GitHub Secrets に `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` / `DATABASE_URL` / `VITE_FAKE_AUTH_URL` を設定する（OIDC セットアップは `tmp/azure-setup-log.md` ⑫ を参照）
2. このブランチを main にマージし、Actions タブで Deploy ワークフローが起動することを確認
3. 各ジョブ（ci → build-push → migrate → deploy）が順に成功することを確認
4. `https://decision-loop-api.azurewebsites.net/health`（またはルート）にアクセスし API が応答することを確認
