### PR TITLE
fix: webのDockerビルドでprisma generateを追加(#371)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,7 +21,11 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/web/package.json ./apps/web/
 COPY apps/api/package.json ./apps/api/
 COPY apps/api/src ./apps/api/src
+COPY apps/api/prisma ./apps/api/prisma
+COPY apps/api/prisma.config.ts ./apps/api/
 RUN pnpm install --frozen-lockfile
+# web が api の型（@prisma/client）を参照するため事前に生成する
+RUN pnpm --filter api exec prisma generate --generator client
 COPY apps/web ./apps/web
 WORKDIR /app/apps/web
 # VITE_* 環境変数はビルド時に静的ファイルへ埋め込まれるため ARG で受け取る


### PR DESCRIPTION
## 関連Issue
Closes #371

## 概要・目的
* web の Docker ビルド（builder ステージ）で `@prisma/client` の型が存在せず tsc が失敗していたため、`prisma generate` を追加する

## 背景
* web は api を devDependency で参照しており、ビルド時に api の型（`@prisma/client`）を解決する
* builder ステージに `prisma/` スキーマと `prisma.config.ts` のコピーが欠けており、`prisma generate` が実行されていなかった

## 変更内容
* `apps/web/Dockerfile`: `apps/api/prisma/` と `prisma.config.ts` をコピーし、`pnpm build` 前に `prisma generate` を実行

## 動作確認手順
1. PR をマージ
2. GitHub Actions の Deploy ワークフローが成功することを確認

## スクリーンショット
* なし