### PR TITLE
fix: MSALのknownAuthoritiesにCIAM GUIDホスト名を追加(#374)

### DIFF
--- a/apps/web/src/lib/msalConfig.ts
+++ b/apps/web/src/lib/msalConfig.ts
@@ -31,13 +31,21 @@ function getEntraConfig(): Configuration {
     );
   }
 
+  const tenantId = import.meta.env.VITE_ENTRA_TENANT_ID as string | undefined;
+
   const resolvedAuthority = (authority ?? "").replace(/\/+$/, "");
 
   // CIAM エンドポイント (*.ciamlogin.com) は MSAL の既定の信頼済みホストではないため、
   // knownAuthorities に明示する必要がある。
-  const knownAuthorities = resolvedAuthority
-    ? [new URL(resolvedAuthority).hostname]
-    : [];
+  // CIAM の OIDC discovery issuer はテナント名ベースではなく GUID ベースのホスト名
+  // （{tenantId}.ciamlogin.com）を返すため、両方を登録しないと endpoints_resolution_error になる。
+  const knownAuthorities: string[] = [];
+  if (resolvedAuthority) {
+    knownAuthorities.push(new URL(resolvedAuthority).hostname);
+  }
+  if (tenantId) {
+    knownAuthorities.push(`${tenantId}.ciamlogin.com`);
+  }
 
   return {
     auth: {


### PR DESCRIPTION
## 関連Issue
Closes #374

## 概要・目的
* CIAM の OIDC discovery issuer が GUID ベースのホスト名（`{tenantId}.ciamlogin.com`）を返すため、MSAL の authority 検証で `endpoints_resolution_error` が発生していた
* `knownAuthorities` に `VITE_ENTRA_TENANT_ID` から生成した GUID ホスト名を追加して解消する

## 背景
* authority: `mshackathon2026.ciamlogin.com`
* discovery issuer: `2627b23c-bb32-4124-99c1-fdbedaa56c85.ciamlogin.com`
* MSAL は両ホスト名が `knownAuthorities` に含まれないと endpoints_resolution_error を投げる

## 変更内容
* `apps/web/src/lib/msalConfig.ts`: `knownAuthorities` に `${VITE_ENTRA_TENANT_ID}.ciamlogin.com` を追加
* GitHub Secrets: `VITE_ENTRA_TENANT_ID` 追加済み（`2627b23c-bb32-4124-99c1-fdbedaa56c85`）

## 動作確認手順
1. PR をマージ
2. Deploy ワークフロー完了後に https://decision-loop-web.azurewebsites.net でEntraログインを試す
3. ログインページへリダイレクトされ、認証が完了することを確認

## スクリーンショット
* なし