### PR TITLE
fix: MSAL authorityMetadataを動的取得してCIAM issuer検証をバイパス(#374)

### DIFF
--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -30,8 +30,7 @@ function UserAvatar() {
     logout();
     if (AUTH_PROVIDER === "entra") {
       try {
-        const msal = getMsalInstance();
-        await msal.initialize();
+        const msal = await getMsalInstance();
         await msal.logoutRedirect({
           postLogoutRedirectUri: window.location.origin + "/login",
         });

--- a/apps/web/src/lib/msalConfig.test.ts
+++ b/apps/web/src/lib/msalConfig.test.ts
@@ -14,7 +14,7 @@ vi.mock("@azure/msal-browser", () => ({
     .fn()
     .mockImplementation((config: CapturedConfig) => {
       capturedConfig.push(config);
-      return {};
+      return { initialize: vi.fn().mockResolvedValue(undefined) };
     }),
 }));
 
@@ -33,14 +33,14 @@ describe("getMsalInstance (MSAL 設定)", () => {
 
   it("複数回呼び出しても同一インスタンスを返す（シングルトン）", async () => {
     const { getMsalInstance } = await import("@/lib/msalConfig");
-    const a = getMsalInstance();
-    const b = getMsalInstance();
+    const a = await getMsalInstance();
+    const b = await getMsalInstance();
     expect(a).toBe(b);
   });
 
   it("knownAuthorities に authority URL のホスト名が設定される", async () => {
     const { getMsalInstance } = await import("@/lib/msalConfig");
-    getMsalInstance();
+    await getMsalInstance();
 
     expect(capturedConfig[0]?.auth?.knownAuthorities).toEqual([
       "test-tenant.ciamlogin.com",
@@ -49,7 +49,7 @@ describe("getMsalInstance (MSAL 設定)", () => {
 
   it("cacheLocation が sessionStorage に設定される", async () => {
     const { getMsalInstance } = await import("@/lib/msalConfig");
-    getMsalInstance();
+    await getMsalInstance();
 
     expect(capturedConfig[0]?.cache?.cacheLocation).toBe("sessionStorage");
   });
@@ -58,7 +58,7 @@ describe("getMsalInstance (MSAL 設定)", () => {
     import.meta.env.VITE_ENTRA_AUTHORITY =
       "https://test-tenant.ciamlogin.com/test-tenant-id/";
     const { getMsalInstance } = await import("@/lib/msalConfig");
-    getMsalInstance();
+    await getMsalInstance();
 
     expect(capturedConfig[0]?.auth?.authority).toBe(
       "https://test-tenant.ciamlogin.com/test-tenant-id",

--- a/apps/web/src/lib/msalConfig.ts
+++ b/apps/web/src/lib/msalConfig.ts
@@ -8,7 +8,7 @@ import {
   PublicClientApplication,
 } from "@azure/msal-browser";
 
-function getEntraConfig(): Configuration {
+function getEntraConfig(authorityMetadata?: string): Configuration {
   const clientId = import.meta.env.VITE_ENTRA_CLIENT_ID as string | undefined;
   const authority = import.meta.env.VITE_ENTRA_AUTHORITY as string | undefined;
   const redirectUri = import.meta.env.VITE_ENTRA_REDIRECT_URI as
@@ -37,8 +37,6 @@ function getEntraConfig(): Configuration {
 
   // CIAM エンドポイント (*.ciamlogin.com) は MSAL の既定の信頼済みホストではないため、
   // knownAuthorities に明示する必要がある。
-  // CIAM の OIDC discovery issuer はテナント名ベースではなく GUID ベースのホスト名
-  // （{tenantId}.ciamlogin.com）を返すため、両方を登録しないと endpoints_resolution_error になる。
   const knownAuthorities: string[] = [];
   if (resolvedAuthority) {
     knownAuthorities.push(new URL(resolvedAuthority).hostname);
@@ -53,6 +51,7 @@ function getEntraConfig(): Configuration {
       authority: resolvedAuthority,
       redirectUri: redirectUri ?? `${window.location.origin}/login`,
       knownAuthorities,
+      ...(authorityMetadata ? { authorityMetadata } : {}),
     },
     cache: {
       // sessionStorage は localStorage より安全（タブを閉じると消える）
@@ -63,12 +62,35 @@ function getEntraConfig(): Configuration {
 
 let _msalInstance: PublicClientApplication | undefined;
 
-// MSAL インスタンスを取得する（初回呼び出し時に生成）。
-// loginRedirect / handleRedirectPromise の前に initialize() を呼ぶこと。
-export function getMsalInstance(): PublicClientApplication {
-  if (!_msalInstance) {
-    _msalInstance = new PublicClientApplication(getEntraConfig());
+// CIAM の OIDC discovery issuer（GUID ベース）が MSAL の期待するテナント名ベースの
+// パターンと一致せず validateIssuer で失敗するため、authorityMetadata を事前に
+// 取得して渡すことでネットワーク経由の validateIssuer をバイパスする。
+async function fetchAuthorityMetadata(
+  authority: string,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `${authority}/v2.0/.well-known/openid-configuration`,
+    );
+    return res.ok ? await res.text() : undefined;
+  } catch {
+    return undefined;
   }
+}
+
+// MSAL インスタンスを取得する（初回呼び出し時に生成・初期化）。
+// initialize() も内部で完了させるため、呼び出し側での追加呼び出しは不要。
+export async function getMsalInstance(): Promise<PublicClientApplication> {
+  if (_msalInstance) return _msalInstance;
+  const authority = (
+    import.meta.env.VITE_ENTRA_AUTHORITY as string ?? ""
+  ).replace(/\/+$/, "");
+  const authorityMetadata = await fetchAuthorityMetadata(authority);
+  const instance = new PublicClientApplication(
+    getEntraConfig(authorityMetadata),
+  );
+  await instance.initialize();
+  _msalInstance = instance;
   return _msalInstance;
 }
 

--- a/apps/web/src/routes/login.entra.test.tsx
+++ b/apps/web/src/routes/login.entra.test.tsx
@@ -24,7 +24,7 @@ const mockMsal = {
 
 // @/lib/msalConfig を常にモックとして差し替える（vi.mock は巻き上げられる）
 vi.mock("@/lib/msalConfig", () => ({
-  getMsalInstance: () => mockMsal,
+  getMsalInstance: async () => mockMsal,
   ENTRA_SCOPES: ["openid", "profile", "email"],
   fetchUserInfoEmail: vi.fn().mockResolvedValue(null),
 }));

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -56,9 +56,7 @@ function Login() {
 
     async function handleEntraLogin() {
       try {
-        const msal = getMsalInstance();
-        // MSAL は initialize() 完了後でないと他の API を呼べない
-        await msal.initialize();
+        const msal = await getMsalInstance();
 
         // リダイレクト後のコールバック処理。result が null の場合は認証前。
         // navigateToLoginRequestUrl: false でリダイレクト完了後に元 URL へ戻る動作を抑制する。


### PR DESCRIPTION
## 関連Issue
Closes #374

## 概要・目的
* MSAL v5 が OIDC discovery の issuer を検証する際、CIAM の GUID ベース issuer (`2627b23c.ciamlogin.com`) がテナント名ベースの期待パターン (`mshackathon2026.ciamlogin.com`) と一致せず `endpoints_resolution_error` が発生していた
* `authorityMetadata` に実際の OIDC 設定を動的取得して渡すことで、ネットワーク経由の `validateIssuer` をバイパスする

## 変更内容
* `msalConfig.ts`: `getMsalInstance()` を async 化し、OIDC メタデータを取得して `authorityMetadata` に渡す。`initialize()` も内部で完了させる
* `login.tsx` / `Topbar.tsx`: `await getMsalInstance()` に変更、`msal.initialize()` の重複呼び出しを削除
* テスト: `getMsalInstance()` の async 化に合わせてモック・呼び出し方を更新

## 動作確認手順
1. PR をマージ
2. Deploy 完了後に https://decision-loop-web.azurewebsites.net でEntraログインを試す
3. Entraのログイン画面にリダイレクトされ、認証が完了することを確認

## スクリーンショット
* なし