### PR TITLE
feat(web): Topbar の表示名を displayName に対応しアバターと設定ボタンを統合

### DIFF
--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useAtomValue, useSetAtom } from "jotai";
-import { Mail, Settings } from "lucide-react";
+import { Mail } from "lucide-react";
 import { useState } from "react";
 import {
   DropdownMenu,
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SettingsDialog } from "@/features/settings/components/SettingsDialog";
+import { useMe } from "@/features/settings/hooks/useMe";
 import { authAtom, logoutAtom } from "@/lib/auth";
 import { getMsalInstance } from "@/lib/msalConfig";
 
@@ -27,6 +28,10 @@ function UserAvatar() {
   const logout = useSetAtom(logoutAtom);
   const navigate = useNavigate();
   const { user } = useAtomValue(authAtom);
+  const { data: profile } = useMe();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  // displayName を優先し、未取得中は JWT の name にフォールバックする。
+  const displayName = profile?.displayName ?? user?.name;
 
   const handleLogout = async () => {
     logout();
@@ -46,41 +51,48 @@ function UserAvatar() {
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label="ユーザーメニュー"
-          className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-semibold select-none hover:opacity-80 transition-opacity"
-        >
-          {initial(user?.name)}
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuLabel className="font-normal">
-          <p className="font-medium">{user?.name ?? "—"}</p>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            {user?.email ?? "—"}
-          </p>
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onSelect={handleLogout}
-          className="cursor-pointer text-destructive focus:text-destructive"
-        >
-          ログアウト
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="ユーザーメニュー"
+            className="w-7 h-7 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-semibold select-none hover:opacity-80 transition-opacity"
+          >
+            {initial(displayName)}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuLabel className="font-normal">
+            <p className="font-medium">{displayName ?? "—"}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {user?.email ?? "—"}
+            </p>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => setSettingsOpen(true)}
+            className="cursor-pointer"
+          >
+            表示名の変更
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={handleLogout}
+            className="cursor-pointer text-destructive focus:text-destructive"
+          >
+            ログアウト
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+    </>
   );
 }
 
 export function Topbar() {
-  const [settingsOpen, setSettingsOpen] = useState(false);
-
   return (
     <header className="h-12 border-b border-border/50 flex items-center px-5 bg-background shadow-sm shrink-0 z-10">
-      {/* アプリ名: index.tsx の h1 と重複するため "Decision Loop" は使わない */}
       <span className="font-semibold text-base tracking-tight">
         Decision Loop
       </span>
@@ -97,18 +109,8 @@ export function Topbar() {
         >
           <Mail size={18} />
         </Link>
-        {/* 設定ボタン。表示名などを編集する設定ダイアログを開く。 */}
-        <button
-          type="button"
-          aria-label="設定"
-          onClick={() => setSettingsOpen(true)}
-          className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-        >
-          <Settings size={18} />
-        </button>
         <UserAvatar />
       </div>
-      <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
     </header>
   );
 }

--- a/apps/web/src/features/settings/hooks/useMe.ts
+++ b/apps/web/src/features/settings/hooks/useMe.ts
@@ -14,7 +14,7 @@ export function useMe() {
   return useQuery({
     queryKey: ["me", "profile"],
     queryFn: async () => {
-      const res = await api.me.$get(authHeaders());
+      const res = await api.me.$get(undefined, authHeaders());
       if (!res.ok) {
         throw new Error(`Failed to fetch profile: ${res.status}`);
       }

--- a/apps/web/src/test/topbar.test.tsx
+++ b/apps/web/src/test/topbar.test.tsx
@@ -47,11 +47,12 @@ function renderTopbar(name = "田中太郎", email = "tanaka@example.com") {
 }
 
 describe("Topbar", () => {
-  it("アバターに名前の頭文字が表示される", () => {
+  it("アバターに displayName の頭文字が表示される", () => {
+    // useMe が返す displayName（"現在の名前"）の頭文字 "現" が使われる。
     renderTopbar("田中太郎");
     expect(
       screen.getByRole("button", { name: "ユーザーメニュー" }),
-    ).toHaveTextContent("田");
+    ).toHaveTextContent("現");
   });
 
   it("招待一覧へのリンクが /invitations を指して表示される", () => {
@@ -71,17 +72,17 @@ describe("Topbar", () => {
     });
   });
 
-  it("設定ボタンが表示される", () => {
-    renderTopbar();
-    expect(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
+  it("アバターのドロップダウンに「表示名の変更」が表示される", async () => {
+    const { user } = renderTopbar();
+    await user.click(screen.getByRole("button", { name: "ユーザーメニュー" }));
+    expect(screen.getByText("表示名の変更")).toBeInTheDocument();
   });
 
-  it("設定ボタンを押すと設定ダイアログが開く", async () => {
+  it("「表示名の変更」をクリックすると設定ダイアログが開く", async () => {
     const { user } = renderTopbar();
-    // 初期状態ではダイアログは閉じている。
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "設定" }));
-    // 開くと表示名の入力欄を持つダイアログが現れる。
+    await user.click(screen.getByRole("button", { name: "ユーザーメニュー" }));
+    await user.click(screen.getByText("表示名の変更"));
     const dialog = await screen.findByRole("dialog", { name: "設定" });
     expect(dialog).toBeInTheDocument();
     expect(screen.getByLabelText("表示名")).toBeInTheDocument();


### PR DESCRIPTION
## 関連Issue
Closes #381 

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
* 設定ダイアログで変更した表示名（displayName）が Topbar に即座に反映されない問題を修正した
* 歯車の設定ボタンをユーザーアバターのドロップダウンに統合し、Topbar をシンプルにした

## 背景
  * Topbar は JWT の `name`（ログイン時に固定）を表示しており、設定ダイアログで `displayName`
  を変更しても反映されなかった
  * 設定ボタン（歯車アイコン）とユーザーアバターが別々のボタンとして存在しており UX として冗長だった

## 変更内容
  * `Topbar.tsx`
    * `useMe()` を導入し、取得した `displayName`
  をアバターの頭文字・ドロップダウンの表示名に使用（未取得中は JWT の `name` にフォールバック）
    * 独立していた歯車の設定ボタンを削除
    * `SettingsDialog` の開閉状態を `UserAvatar`
  内に移動し、ドロップダウンの「表示名の変更」から開くように変更
  * `useMe.ts`
    * `api.me.$get(authHeaders())` → `api.me.$get(undefined, authHeaders())` に修正（Authorization
  ヘッダーが送信されていなかったバグを修正）
  * `topbar.test.tsx`
    * アバター頭文字テストを `displayName` 基準に更新
    * 削除した設定ボタンのテストを「表示名の変更」ドロップダウン項目のテストに置き換え

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. `make dev` でローカル起動後、`http://localhost:5173` にアクセスしてログイン
  2. 右上のユーザーアバター（丸いボタン）をクリックし、「表示名の変更」が表示されることを確認
  3. 「表示名の変更」をクリックして設定ダイアログが開くことを確認
  4. 表示名を変更して「保存」を押し、ダイアログが閉じた後にアバターの頭文字とドロップダウンのラベルが即座に
  更新されることを確認


## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
<img width="1470" height="735" alt="スクリーンショット 2026-06-01 15 22 58" src="https://github.com/user-attachments/assets/630f33cb-3c82-44a1-8d8a-3fdf150e99ca" />

