### PR TITLE
fix(deploy): decision-loop-api に OIDC 環境変数を追加し 401 を修正する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,8 +150,13 @@ jobs:
             --name decision-loop-web \
             --container-image-name decisionloopacr.azurecr.io/web:${{ github.sha }}
 
-      - name: api 環境変数設定
+      - name: api デプロイ
         run: |
+          test -n "${{ secrets.OIDC_ISSUER_URL }}" || \
+            (echo "::error::OIDC_ISSUER_URL が GitHub Secrets に設定されていません" && exit 1)
+          test -n "${{ secrets.OIDC_AUDIENCE }}" || \
+            (echo "::error::OIDC_AUDIENCE が GitHub Secrets に設定されていません" && exit 1)
+          # シークレット未設定時にデプロイへ進まないようガードし、関連処理を同一ステップに集約する
           az webapp config appsettings set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-api \
@@ -160,9 +165,6 @@ jobs:
               OIDC_AUDIENCE="${{ secrets.OIDC_AUDIENCE }}" \
               NODE_ENV="production" \
             --output none
-
-      - name: api デプロイ
-        run: |
           az webapp config container set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-api \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ concurrency:
 #   VITE_ENTRA_AUTHORITY   - Entra External ID の Authority URL
 #   VITE_ENTRA_REDIRECT_URI - Entra External ID のリダイレクト URI
 #   VITE_ENTRA_TENANT_ID   - Entra External ID テナントの GUID（MSAL knownAuthorities 用）
+#   OIDC_ISSUER_URL        - Entra External ID の issuer URL（APIトークン検証用）
+#   OIDC_AUDIENCE          - Entra External ID のクライアント ID（APIトークン検証用）
 #
 # 必要な GitHub Variables（Settings > Variables > Actions）:
 #   INTERNAL_API_BASE_URL - ai → api の内部通信 URL（例: https://decision-loop-api.azurewebsites.net）
@@ -147,6 +149,17 @@ jobs:
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-web \
             --container-image-name decisionloopacr.azurecr.io/web:${{ github.sha }}
+
+      - name: api 環境変数設定
+        run: |
+          az webapp config appsettings set \
+            --resource-group rg-ms-hackathon-dev \
+            --name decision-loop-api \
+            --settings \
+              OIDC_ISSUER_URL="${{ secrets.OIDC_ISSUER_URL }}" \
+              OIDC_AUDIENCE="${{ secrets.OIDC_AUDIENCE }}" \
+              NODE_ENV="production" \
+            --output none
 
       - name: api デプロイ
         run: |


### PR DESCRIPTION
## 関連Issue
Closes #383

## 概要・目的
- 本番環境の `decision-loop-api` に `OIDC_ISSUER_URL` / `OIDC_AUDIENCE` が未設定のため、Entra External ID のトークン検証で 401 が発生していた
- `deploy.yml` に `appsettings set` ステップを追加し、デプロイ時に OIDC 関連の環境変数を App Service へ自動設定する

## 背景
- API がフォールバック値（fake-auth 向け）で issuer・audience を検証しており、Entra External ID が発行するトークンと不一致になっていた
- `OIDC_ISSUER_URL` / `OIDC_AUDIENCE` を GitHub Secrets から注入することで本番環境での検証を正しく行えるようにする

## 変更内容
- `.github/workflows/deploy.yml` に `api 環境変数設定` ステップを追加（`az webapp config container set` の前に実行）
  - `OIDC_ISSUER_URL`・`OIDC_AUDIENCE`・`NODE_ENV=production` をセット
  - `--output none` を付与し、設定値が Actions ログに露出しないよう対処
- 必要な GitHub Secrets のコメント一覧に `OIDC_ISSUER_URL` / `OIDC_AUDIENCE` を追記

## 動作確認手順
1. GitHub Settings > Secrets > Actions に `OIDC_ISSUER_URL` / `OIDC_AUDIENCE` が登録されていることを確認
2. このブランチを main にマージしてデプロイワークフローを実行
3. Azure Portal で `decision-loop-api` の「構成 > アプリケーション設定」に値がセットされていることを確認
4. 本番環境で認証済みリクエストを送り、401 が解消されていることを確認

## スクリーンショット
- 該当なし（CI/CD 設定変更のみ）
