### PR TITLE
fix(deploy): api・ai に Service Bus 接続文字列を Key Vault 参照で追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ concurrency:
 #   VITE_ENTRA_AUTHORITY   - Entra External ID の Authority URL
 #   VITE_ENTRA_REDIRECT_URI - Entra External ID のリダイレクト URI
 #   VITE_ENTRA_TENANT_ID   - Entra External ID テナントの GUID（MSAL knownAuthorities 用）
+#   （Service Bus 接続文字列は Key Vault 参照で直接 appsettings に設定するため GitHub Secrets 不要）
 #   OIDC_ISSUER_URL        - Entra External ID の issuer URL（APIトークン検証用）
 #   OIDC_AUDIENCE          - Entra External ID のクライアント ID（APIトークン検証用）
 #
@@ -164,6 +165,7 @@ jobs:
               OIDC_ISSUER_URL="${{ secrets.OIDC_ISSUER_URL }}" \
               OIDC_AUDIENCE="${{ secrets.OIDC_AUDIENCE }}" \
               NODE_ENV="production" \
+              AZURE_SERVICE_BUS_CONNECTION_STRING="@Microsoft.KeyVault(VaultName=kv-ms-hackathon-dev;SecretName=service-bus-connection-string)" \
             --output none
           az webapp config container set \
             --resource-group rg-ms-hackathon-dev \
@@ -176,7 +178,9 @@ jobs:
           az webapp config appsettings set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-ai \
-            --settings INTERNAL_API_BASE_URL="${{ vars.INTERNAL_API_BASE_URL }}"
+            --settings \
+              INTERNAL_API_BASE_URL="${{ vars.INTERNAL_API_BASE_URL }}" \
+              AZURE_SERVICE_BUS_CONNECTION_STRING="@Microsoft.KeyVault(VaultName=kv-ms-hackathon-dev;SecretName=service-bus-connection-string)"
           az webapp config container set \
             --resource-group rg-ms-hackathon-dev \
             --name decision-loop-ai \


### PR DESCRIPTION
## 関連Issue
Closes #

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
  * deploy.yml の appsettings set に AZURE_SERVICE_BUS_CONNECTION_STRING が含まれておらず、本番で analyze エンドポイントが 500 を返していた
  * Key Vault 参照で api・ai 両方に追加した

## 背景
* 

## 変更内容
  * api・ai の appsettings set に `AZURE_SERVICE_BUS_CONNECTION_STRING` を Key Vault 参照で追加

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
1. 
2. 
3. 

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
* 
