### PR TITLE
fix: ダッシュボードの未完了タスクを現在の組織に絞り込む

### DIFF
--- a/apps/api/src/lib/schemas/task.ts
+++ b/apps/api/src/lib/schemas/task.ts
@@ -104,6 +104,7 @@ const taskStatusValuesSchema = z
 
 export const taskListQuerySchema = z.object({
   status: taskStatusValuesSchema.optional(),
+  organizationId: z.string().min(1).optional(),
   // assigneeId は通常 userId（任意の非空文字列）だが、特殊値 "none" を許容する。
   // "none" は「未アサインのタスクだけ」を意味するセンチネルで、where 構築時に
   // `assignees: { none: {} }` に展開される。

--- a/apps/api/src/routes/recurring-meetings.ts
+++ b/apps/api/src/routes/recurring-meetings.ts
@@ -317,7 +317,7 @@ export const recurringMeetingsRoute = new Hono<{ Variables: AuthVariables }>()
         },
       },
     });
-    if (!member || member.role !== "owner") {
+    if (member?.role !== "owner") {
       return c.json({ error: "定例の削除権限がありません" }, 403);
     }
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -86,13 +86,12 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     const filters = c.req.valid("query");
 
     // 自分が assignee のタスクを返す。organizationId が指定された場合はその組織に絞る。
+    // Prisma は where 値が undefined のフィールドを無視するため条件分岐不要。
     const tasks = await prisma.task.findMany({
       where: {
         ...buildTaskListWhere(filters),
         assignees: { some: { userId: user.id } },
-        ...(filters.organizationId
-          ? { organizationId: filters.organizationId }
-          : {}),
+        organizationId: filters.organizationId,
       },
       orderBy: taskListOrderBy,
       include: taskListInclude,

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -85,12 +85,14 @@ export const tasksRoute = new Hono<{ Variables: AuthVariables }>()
     const user = c.var.user;
     const filters = c.req.valid("query");
 
-    // 自分が assignee の全組織横断タスクを返す。組織所属確認は不要
-    // （assignees 経由のスコープでユーザー自身に閉じている）。
+    // 自分が assignee のタスクを返す。organizationId が指定された場合はその組織に絞る。
     const tasks = await prisma.task.findMany({
       where: {
         ...buildTaskListWhere(filters),
         assignees: { some: { userId: user.id } },
+        ...(filters.organizationId
+          ? { organizationId: filters.organizationId }
+          : {}),
       },
       orderBy: taskListOrderBy,
       include: taskListInclude,

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -737,6 +737,23 @@ describe("GET /tasks/me", () => {
     );
   });
 
+  it("organizationId フィルタが where に反映される", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request("/tasks/me?organizationId=org-1");
+    expect(mockTaskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ organizationId: "org-1" }),
+      }),
+    );
+  });
+
+  it("organizationId 未指定のとき where に organizationId が含まれない", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    await app.request("/tasks/me");
+    const where = mockTaskFindMany.mock.calls[0][0].where as Record<string, unknown>;
+    expect(where.organizationId).toBeUndefined();
+  });
+
   it("不正な status は 400", async () => {
     const res = await app.request("/tasks/me?status=invalid_status");
     expect(res.status).toBe(400);

--- a/apps/api/test/tasks.test.ts
+++ b/apps/api/test/tasks.test.ts
@@ -750,7 +750,10 @@ describe("GET /tasks/me", () => {
   it("organizationId 未指定のとき where に organizationId が含まれない", async () => {
     mockTaskFindMany.mockResolvedValue([]);
     await app.request("/tasks/me");
-    const where = mockTaskFindMany.mock.calls[0][0].where as Record<string, unknown>;
+    const where = mockTaskFindMany.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
     expect(where.organizationId).toBeUndefined();
   });
 

--- a/apps/web/src/features/recurring-meetings/components/DeleteRecurringMeetingDialog.tsx
+++ b/apps/web/src/features/recurring-meetings/components/DeleteRecurringMeetingDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import type { RecurringMeeting } from "@/features/organizations/types";
+import { taskQueryKeys } from "@/features/tasks/queryKeys";
 import { api, authHeaders } from "@/lib/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -47,6 +48,8 @@ export function DeleteRecurringMeetingDialog({
       queryClient.invalidateQueries({
         queryKey: ["organizations", meeting.organizationId, "meetings"],
       });
+      // 削除した定例に紐づくタスクがダッシュボードに残らないよう全タスクキャッシュを破棄する。
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
       setOpen(false);
     },
   });

--- a/apps/web/src/features/tasks/hooks/useTasksQuery.ts
+++ b/apps/web/src/features/tasks/hooks/useTasksQuery.ts
@@ -10,6 +10,7 @@ export function toTaskListQueryParams(
   if (filters.status && filters.status.length > 0) {
     params.status = filters.status.join(",");
   }
+  if (filters.organizationId) params.organizationId = filters.organizationId;
   if (filters.assigneeId) params.assigneeId = filters.assigneeId;
   if (filters.dueBefore) params.dueBefore = filters.dueBefore;
   if (filters.dueAfter) params.dueAfter = filters.dueAfter;

--- a/apps/web/src/features/tasks/types.ts
+++ b/apps/web/src/features/tasks/types.ts
@@ -94,6 +94,7 @@ export type Task = Omit<TaskListItem, "assignees"> & {
 // 一覧 API の共通フィルタ。
 export type TaskListFilters = {
   status?: TaskStatus[];
+  organizationId?: string;
   assigneeId?: string;
   dueBefore?: string;
   dueAfter?: string;

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -289,7 +289,7 @@ function ReviewPendingCard({ orgId }: { orgId: string }) {
 
 // ===== リマインド集約バナー =====
 
-// 未完了タスクの取得フィルタ。バナーとカードで同一キーを使い fetch を共有する。
+// 未完了タスクの基本フィルタ。organizationId はコンポーネント側で付与する。
 const INCOMPLETE_SEARCH_FILTER: TaskListFilters = {
   status: ["todo", "in_progress"],
 };

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -333,12 +333,12 @@ const REMINDER_ITEMS = [
 
 // 期限超過・今週期限・着手予定日超過・未読を件数付きで集約表示するバナー。
 // 見落とし防止が目的のため、件数 0 のカテゴリは出さず、全て 0 なら非表示にする。
-function RemindersBanner() {
+function RemindersBanner({ orgId }: { orgId: string }) {
   const {
     data = [],
     isLoading,
     isError,
-  } = useMyTasks(INCOMPLETE_SEARCH_FILTER);
+  } = useMyTasks({ ...INCOMPLETE_SEARCH_FILTER, organizationId: orgId });
 
   if (isLoading || isError) return null;
 
@@ -374,14 +374,14 @@ function RemindersBanner() {
 
 // ===== 未完了タスクカード =====
 
-function IncompleteTasksCard() {
+function IncompleteTasksCard({ orgId }: { orgId: string }) {
   const markRead = useMarkTaskRead();
   const {
     data = [],
     isLoading,
     isError,
     refetch,
-  } = useMyTasks(INCOMPLETE_SEARCH_FILTER);
+  } = useMyTasks({ ...INCOMPLETE_SEARCH_FILTER, organizationId: orgId });
 
   return (
     <Card className="gap-0 py-0 overflow-hidden h-90">
@@ -504,7 +504,7 @@ export function Dashboard() {
       ) : (
         <div className="flex flex-col gap-4">
           {/* 最上段：未達・期限超過・未読のリマインド集約バナー */}
-          <RemindersBanner />
+          <RemindersBanner orgId={orgId} />
 
           {/* 上段：次回会議（横スクロール） */}
           <NextMeetingsSection orgId={orgId} />
@@ -512,7 +512,7 @@ export function Dashboard() {
           {/* 下段：レビュー待ち（左）・未完了タスク（右） */}
           <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-4">
             <ReviewPendingCard orgId={orgId} />
-            <IncompleteTasksCard />
+            <IncompleteTasksCard orgId={orgId} />
           </div>
         </div>
       )}

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -654,6 +654,19 @@ describe("Dashboard - RemindersBanner", () => {
     Date.now() + 3 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
+  it("選択中の organizationId がクエリに含まれる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderDashboard();
+    // バナーが非表示でも fetch は実行されるため、クエリパラメータを検証する。
+    await screen.findByText("未完了のタスクはありません");
+    expect(api.tasks.me.$get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ organizationId: "org-1" }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("期限超過・今週期限の件数が表示され、該当一覧へ遷移するリンクがある", async () => {
     vi.mocked(api.tasks.me.$get).mockResolvedValue(
       mockJson([

--- a/apps/web/src/test/index.test.tsx
+++ b/apps/web/src/test/index.test.tsx
@@ -509,6 +509,18 @@ describe("Dashboard - IncompleteTasksCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("選択中の organizationId がクエリに含まれる", async () => {
+    vi.mocked(api.tasks.me.$get).mockResolvedValue(mockJson([]));
+    renderDashboard();
+    await screen.findByText("未完了のタスクはありません");
+    expect(api.tasks.me.$get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ organizationId: "org-1" }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("取得失敗時に「タスクの取得に失敗しました」が表示される", async () => {
     vi.mocked(api.tasks.me.$get).mockRejectedValue(new Error("network"));
     renderDashboard();

--- a/apps/web/src/test/tasks.queryParams.test.ts
+++ b/apps/web/src/test/tasks.queryParams.test.ts
@@ -23,6 +23,12 @@ describe("toTaskListQueryParams", () => {
     expect(toTaskListQueryParams({ status: [] })).toEqual({});
   });
 
+  it("organizationId を含める", () => {
+    expect(toTaskListQueryParams({ organizationId: "org-1" })).toEqual({
+      organizationId: "org-1",
+    });
+  });
+
   it("assigneeId / dueBefore / dueAfter を含める", () => {
     expect(
       toTaskListQueryParams({


### PR DESCRIPTION
## 関連Issue
Closes #

## 概要・目的
<!-- 何を・なぜ変更したのか2-3文で記載 -->
  * ダッシュボードの未完了タスク・リマインドバナーが全組織横断で表示されていた
  * `GET /tasks/me` に `organizationId` フィルタを追加し、選択中の組織のタスクのみ表示するよう修正

## 背景
* 

## 変更内容
  * API: `taskListQuerySchema` に `organizationId` を追加し、`/tasks/me` の where 句に反映
  * フロント: ダッシュボードの `IncompleteTasksCard` / `RemindersBanner` に現在の `orgId` を渡す
  * 定例削除時にタスクキャッシュを invalidate し、削除後のダッシュボードに古いタスクが残らないよう修正

## 動作確認手順
<!-- レビュアーが実際に動作確認する手順を具体的に記載 -->
  1. 複数の組織に所属したユーザーでログイン
  2. 組織 A のタスクがダッシュボードに表示されることを確認
  3. サイドバーで組織 B に切り替え、組織 A のタスクが表示されないことを確認

## スクリーンショット
<!-- UI変更の場合は必須。APIの場合はレスポンス例を記載 -->
* 
